### PR TITLE
gitignore: ignore *.pyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ pymavlink.egg-info/
 include/
 .tags*
 include/mavlink/v1.0
-
+*.pyc


### PR DESCRIPTION
This avoids submodule warnings about untracked content on projects using
pymavlink repository as a submodule.