### PR TITLE
Add #include <stdbool.h>

### DIFF
--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -5,6 +5,7 @@
 #error "The C-MAVLink implementation requires Visual Studio 2010 or greater"
 #endif
 
+#include <stdbool.h>
 #include <stdint.h>
 
 // Macro to define packed structures


### PR DESCRIPTION
This header is used by C99 source files, which do not
necessarily include &lt;stdbool.h&gt; before including this
header. stdbool.h is needed to define the type 'bool'
that is used in this header. See
https://en.wikibooks.org/wiki/C_Programming/C_Reference/stdbool.h

I need this to be added for the PX4/Firmware project which
doesn't compile anymore after reordering headers (aka, not
having a #include &lt;stdbool.h&gt; anymore before including
this header).