### PR TITLE
Fix mavlogfile class for generic log files that have no timestamps.

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1060,6 +1060,7 @@ class mavlogfile(mavfile):
         self.stop_on_EOF = True
         self._last_message = None
         self._last_timestamp = None
+        self._link = 0
 
     def close(self):
         self.f.close()


### PR DESCRIPTION
I am updating MatrixPilot to use the latest mavlink generator for C and Python files. (it's been a while).

Before the enclosed commit, If I run mavlogdump.py on a generic matrixpilot raw log file I get the following errors message with previous MatrixPilot mavlink log files:-

```
Peters-iMac:tools phollands$ ./mavlogdump.py --dialect matrixpilot --no-timestamps /tmp/log.raw 
ERROR LOADING MAVNATIVE - falling back to python implementation
Traceback (most recent call last):
  File "./mavlogdump.py", line 113, in <module>
    m = mlog.recv_match(blocking=args.follow)
  File "/Users/phollands/MatrixPilot/Tools/MAVLink/mavlink/pymavlink/mavutil.py", line 344, in recv_match
    m = self.recv_msg()
  File "/Users/phollands/MatrixPilot/Tools/MAVLink/mavlink/pymavlink/mavutil.py", line 323, in recv_msg
    self.post_message(msg)
  File "/Users/phollands/MatrixPilot/Tools/MAVLink/mavlink/pymavlink/mavutil.py", line 1125, in post_message
    msg._link = self._link
AttributeError: 'mavlogfile' object has no attribute '_link'
```
And after initialising self._link as shown in the attached commit, I have no error, and I can process MatrixPilot log files again.

I think that function post_message will [initialise self._link  to 0 for the planner_format,](https://github.com/ArduPilot/pymavlink/blob/master/mavutil.py#L1103) but not for MatrixPilot :-).  So here I initialise the _link to be 0, and anything that happens later on, can override that value of 0.

I'm looking forward to any comments that you might have. 

Best wishes, Pete