### PR TITLE
mavutil.py: OFFBOARD mode interpretation fix

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1594,7 +1594,7 @@ def interpret_px4_mode(base_mode, custom_mode):
                 return "LAND"
             elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_RTGS:
                 return "RTGS"
-            elif custom_sub_mode == PX4_CUSTOM_MAIN_MODE_OFFBOARD:
+            elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_OFFBOARD:
                 return "OFFBOARD"
     return "UNKNOWN"
 


### PR DESCRIPTION
OFFBOARD mode is interpreted as UNKNOWN.
Changing custom_sub_mode to custom_main_mode in line 1597 solves this issue.