### PR TITLE
Java: Fix up some performance related bugs found by findbugs

### DIFF
--- a/generator/java/lib/Messages/MAVLinkStats.java
+++ b/generator/java/lib/Messages/MAVLinkStats.java
@@ -70,7 +70,7 @@ public class MAVLinkStats /* implements Serializable */{
     }
 
     // stat structure for every system id
-    private class SystemStat {
+    public static class SystemStat {
         public int lostPacketCount; // the lost count for this source
         public int receivedPacketCount;
 
@@ -101,7 +101,7 @@ public class MAVLinkStats /* implements Serializable */{
     }
 
     // stat structure for every system id
-    private class ComponentStat {
+    public static class ComponentStat {
         public int lastPacketSeq;
         public int lostPacketCount; // the lost count for this source
         public int receivedPacketCount;

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -544,14 +544,14 @@ def generate_one(basename, xml):
     * Gets the message, formated as a string
     */
     public String get%s() {
-        String result = "";
+        StringBuffer buf = new StringBuffer();
         for (int i = 0; i < %d; i++) {
             if (%s[i] != 0)
-                result = result + (char) %s[i];
+                buf.append((char) %s[i]);
             else
                 break;
         }
-        return result;
+        return buf.toString();
 
     }
                         ''' % (f.name.title(),f.array_length,f.name,f.array_length,f.name,f.name.title(),f.array_length,f.name,f.name)


### PR DESCRIPTION
The get%s() one was nasty as it created a new string object on the stack per character operation.