### PR TITLE
Java: Enhance the debug prints to include sysid/compid

### DIFF
--- a/generator/java/lib/Messages/MAVLinkMessage.java
+++ b/generator/java/lib/Messages/MAVLinkMessage.java
@@ -19,10 +19,9 @@ public abstract class MAVLinkMessage implements Serializable {
      *  Simply a common interface for all MAVLink Messages
      */
     
-    public  int sysid;
+    public int sysid;
     public int compid;
     public int msgid;
     public abstract MAVLinkPacket pack();
     public abstract void unpack(MAVLinkPayload payload);
 }
-    

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -210,7 +210,7 @@ public class msg_${name_lower} extends MAVLinkMessage{
     * Returns a string with the MSG name and data
     */
     public String toString(){
-        return "MAVLINK_MSG_ID_${name} -"+${{ordered_fields:" ${name}:"+${name}+}}"";
+        return "MAVLINK_MSG_ID_${name} - sysid:"+sysid+" compid:"+compid+${{ordered_fields:" ${name}:"+${name}+}}"";
     }
 }
         ''' % path[len(path)-1], m)


### PR DESCRIPTION
Sysid and compid are worth having printed out in toString for debug purposes.

(Not sure what the deal is with the newline at the end of MAVLinkMessage.java, according to git no mater what I did I was either adding or deleting a new line...)