### PR TITLE
Add a file attribute to the XML schema

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -146,6 +146,7 @@
             <xs:element ref="enums" minOccurs="0"/>
             <xs:element ref="messages"/>
         </xs:sequence>
+        <xs:attribute ref="file" />
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
A file attribute would allow easy tracking of the include hierachy when parsing
from any form that doesn't come with the correct file name.
(InputStreams for example, where you can't track what the original name was)