### PR TITLE
Fix mavschema.xsd

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -146,7 +146,7 @@
             <xs:element ref="enums" minOccurs="0"/>
             <xs:element ref="messages"/>
         </xs:sequence>
-        <xs:attribute ref="file" />
+        <xs:attribute name="file" type="xs:anyURI"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
As I wrote in https://github.com/ArduPilot/pymavlink/pull/59#issuecomment-296444133, that change broke the XML validation. It added an attribute referencing a type named file, but none existed. This changes it to the intended line.