### PR TITLE
fix macros for compiling in MDK5 with armcc

### DIFF
--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -15,6 +15,10 @@ namespace mavlink {
 // Macro to define packed structures
 #ifdef __GNUC__
   #define MAVPACKED( __Declaration__ ) __Declaration__ __attribute__((packed))
+#elif defined __arm__
+  #pragma anon_unions
+  #pragma pack(push, 1)
+  #define MAVPACKED( __Declaration__ ) __Declaration__	
 #else
   #define MAVPACKED( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
 #endif


### PR DESCRIPTION
Inspired by https://github.com/oceanstack/MAVLink_MDK_STM32, adjust some macro defines for armcc compiler in Kail uVision5 embed-system develpment environment.