### PR TITLE
Fixed c# compilation status: detects compile failure & raises exception.

### DIFF
--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -341,7 +341,7 @@ using System.Reflection;
     #print("Cmd:" + compileCommand)
     res = os.system (compileCommand)
     
-    if res == '0':
-        print("Generated %s OK" % filename)
+    if res == 0:
+        print("Generated %s OK" % outputLibraryPath)
     else:
-        print("Error")
+        raise SystemError("Compilation failed. (" + str(res) + ")")


### PR DESCRIPTION
This patch addresses an issue where when C# compiles fails the developer is unaware of the failure.