### PR TITLE
Python 3.3 end of life

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.3"
-  - "3.5"
+  - "3.4"
+  - "3.6"
 
 install:
   - pip install -r requirements.txt
@@ -10,7 +10,7 @@ install:
 
 before_script:
   # --exit-zero means that flake8 will only warn and not stop the build
-  flake8 . --exit-zero
+  flake8 . --exit-zero 
 
 script:
   # NOTE: we must do all testing on the installed python package, not 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 
 before_script:
   # --exit-zero means that flake8 will only warn and not stop the build
-  flake8 . --exit-zero 
+  flake8 . --exit-zero
 
 script:
   # NOTE: we must do all testing on the installed python package, not 


### PR DESCRIPTION
Python 3.3 goes [EOL](https://docs.python.org/devguide/index.html#branchstatus) next month so let's shift up one.