### PR TITLE
tools/mavfft_int.py from builtins import input for Python 3

### DIFF
--- a/tools/mavfft_int.py
+++ b/tools/mavfft_int.py
@@ -4,6 +4,7 @@
 interactively select accel and gyro data for FFT analysis
 '''
 from __future__ import print_function
+from builtins import input
 
 import numpy
 import pylab
@@ -208,7 +209,7 @@ def fft(logfile):
             fftwin.savefig(msg + '_fft.png')
         
         try:
-            selection = raw_input('q to proceed to next file, anything else to select a new range: ')
+            selection = input('q to proceed to next file, anything else to select a new range: ')
             print(selection)
         except:
             continue


### PR DESCRIPTION
__raw_input()__ was removed in Python 3 in favor of __input()__.  http://python-future.org/compatible_idioms.html#raw-input explains the recommended fix that this PR employs to get text from the user in a way that works in both Python 2 and Python 3.