### PR TITLE
Add F821 `undefined name` detection to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ install:
   - pip install -r requirements.txt
   - pip install flake8
 before_script:
-  # fail the build if there are Python syntax errors
-  - flake8 . --count --select=E901,E999,F822,F823 --show-source --statistics
+  # fail the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   # exit-zero treats all errors as warnings. The GitHub web ui editor is 127 chars wide
   - SELECT=C,E10,E11,E401,E502,E703,E8,E9,F,W191,W292,W391
   - flake8 . --count --exit-zero --select=${SELECT} --max-complexity=10 --max-line-length=127 --statistics


### PR DESCRIPTION
Undefined names can cause `NameError` exceptions to be raised at runtime.  Detecting them is also helpful for spotting Python 3 incompatibilities (raw_input(), unicode(), xrange(), etc.).  Adding this test to our critical error search will increase runtime stability and help us to achieve Python 3 compatibility.   ~#115 and~ #116 should be fixed __before__ this PR is merged.

While it does not block this PR, #114 will also be required for the Python 3 flake8 tests to pass .