### PR TITLE
generator/mavparse.py 'from .mavgen_python import MAVError'

### DIFF
--- a/generator/maverrors.py
+++ b/generator/maverrors.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+'''
+Define MAVError and MAVParseError
+Copyright Andrew Tridgell 2011
+Released under GNU GPL version 3 or later
+'''
+
+
+class MAVError(Exception):
+        '''MAVLink error class'''
+        def __init__(self, msg):
+            Exception.__init__(self, msg)
+            self.message = msg
+
+
+class MAVParseError(Exception):
+    def __init__(self, message, inner_exception=None):
+        self.message = message
+        self.inner_exception = inner_exception
+        self.exception_info = sys.exc_info()
+    def __str__(self):
+        return self.message

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -12,6 +12,7 @@ from builtins import range
 import os
 import textwrap
 from . import mavtemplate
+from .maverrors import MAVError
 
 t = mavtemplate.MAVTemplate()
 
@@ -374,11 +375,6 @@ def generate_mavlink_class(outf, msgs, xml):
     outf.write("}\n\n")
 
     t.write(outf, """
-class MAVError(Exception):
-        '''MAVLink error class'''
-        def __init__(self, msg):
-            Exception.__init__(self, msg)
-            self.message = msg
 
 class MAVString(str):
         '''NUL terminated string'''

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -16,7 +16,7 @@ import sys
 import time
 import xml.parsers.expat
 
-from .maverrors import MAVError
+from .maverrors import MAVError, MAVParseError
 
 PROTOCOL_0_9 = "0.9"
 PROTOCOL_1_0 = "1.0"

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -16,6 +16,8 @@ import sys
 import time
 import xml.parsers.expat
 
+from .mavgen_python import MAVError
+
 PROTOCOL_0_9 = "0.9"
 PROTOCOL_1_0 = "1.0"
 PROTOCOL_2_0 = "2.0"

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -16,7 +16,7 @@ import sys
 import time
 import xml.parsers.expat
 
-from .mavgen_python import MAVError
+from .maverrors import MAVError
 
 PROTOCOL_0_9 = "0.9"
 PROTOCOL_1_0 = "1.0"
@@ -25,14 +25,6 @@ PROTOCOL_2_0 = "2.0"
 # message flags
 FLAG_HAVE_TARGET_SYSTEM    = 1
 FLAG_HAVE_TARGET_COMPONENT = 2
-
-class MAVParseError(Exception):
-    def __init__(self, message, inner_exception=None):
-        self.message = message
-        self.inner_exception = inner_exception
-        self.exception_info = sys.exc_info()
-    def __str__(self):
-        return self.message
 
 class MAVField(object):
     def __init__(self, name, type, print_format, xml, description='', enum='', bitmask='', units=''):

--- a/generator/mavtemplate.py
+++ b/generator/mavtemplate.py
@@ -8,7 +8,7 @@ Released under GNU GPL version 3 or later
 
 from builtins import object
 
-from .mavparse import MAVParseError
+from .maverrors import MAVParseError
 
 class MAVTemplate(object):
     '''simple templating system'''


### PR DESCRIPTION
Fixes #116,#117

Resolve the circular imports between mavgen_python.py, mavparse.py, and mavtemplate.py by putting `MAVError`and `MAVParseError`into their own `maverrors.py` file.