### PR TITLE
Tools: Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -8,6 +8,7 @@ Copyright Andrew Tridgell 2011
 Copyright Vladimir Ermakov 2016
 Released under GNU GPL version 3 or later
 '''
+from __future__ import print_function
 
 import sys, textwrap, os, time
 from . import mavparse, mavtemplate

--- a/tools/magfit_elliptical.py
+++ b/tools/magfit_elliptical.py
@@ -3,6 +3,7 @@
 '''
 fit best estimate of magnetometer offsets
 '''
+from __future__ import print_function
 
 import sys, time, os, math
 
@@ -42,7 +43,7 @@ def select_data(data):
             counts[key] = 1
         if counts[key] < 3:
             ret.append(d)
-    print(len(data), len(ret))
+    print((len(data), len(ret)))
     return ret
 
 def constrain(v, min, max):

--- a/tools/mavfft_int.py
+++ b/tools/mavfft_int.py
@@ -10,6 +10,11 @@ import pylab
 import matplotlib
 import matplotlib.pyplot as pyplot
 
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
+
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
 parser.add_argument("--condition", default=None, help="select packets by condition")

--- a/tools/sertotcp.py
+++ b/tools/sertotcp.py
@@ -4,6 +4,7 @@
 map a serial port to an outgoing TCP connection
 Released under GNU GPLv3 or later
 """
+from __future__ import print_function
 
 from argparse import ArgumentParser
 import errno


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3. There would _definitely_ be much more work required to complete the port to Python 3 but this is a minimal, safe first step.

Run: `futurize --stage1 -w **/*.py`

See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes

$ `pip install future`
$ `git checkout -b modernize-python2-code`
$ `futurize --stage1 -w **/*.py` # done in zsh for ** globbing
$ `git commit --all -m "Modernize Python 2 code to get ready for Python 3"`
$ `git push --set-upstream origin modernize-python2-code`
