### PR TITLE
Fixed an issue with the way that the Java Import statements were generated.

### DIFF
--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -219,6 +219,15 @@ public class msg_${name_lower} extends MAVLinkMessage{
 
 def generate_MAVLinkMessage(directory, xml_list):
     f = open(os.path.join(directory, "MAVLinkPacket.java"), mode='w')
+
+    imports = []
+
+    for xml in xml_list:
+        importString = "import com.MAVLink.{}.*;".format(xml.basename)
+        imports.append(importString)
+
+    xml_list[0].importString = os.linesep.join(imports)
+
     t.write(f, '''
 /* AUTO-GENERATED FILE.  DO NOT MODIFY.
  *
@@ -232,8 +241,8 @@ import java.io.Serializable;
 import com.MAVLink.Messages.MAVLinkPayload;
 import com.MAVLink.Messages.MAVLinkMessage;
 import com.MAVLink.${basename}.CRC;
-import com.MAVLink.common.*;
-import com.MAVLink.${basename}.*;
+
+${importString}
 
 /**
 * Common interface for all MAVLink Messages


### PR DESCRIPTION
The "MAVLinkPacket" class in the Java implementation always imported the "common" messages and the name of the message definition XML file you generated from.

This was incorrect for two reasons:
- The "common" package may not exist if the message definition XML file does not include the "common.xml"
- If the message definition XML file includes additional message sets they will not be included properly.

This commit fixes both issues.