### PR TITLE
str -> bytes for Python 3 support

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -834,9 +834,7 @@ class mavserial(mavfile):
 
     def write(self, buf):
         try:
-            if not isinstance(buf, str):
-                buf = str(buf)
-            return self.port.write(buf)
+            return self.port.write(bytes(buf))
         except Exception:
             if not self.portdead:
                 print("Device %s is dead" % self.device)


### PR DESCRIPTION
When running pymavlink in DroneKit on Python 3, pymavlink reports:

    Device /dev/ttyS0 is dead

The reason is that the `write()` function on line 835 in mavutil.py throws an exception because it is trying to encode `buf` (containing bytes) into a `str` (which in Python 3 is an Unicode string).

We can use a smarter approach: in Python 2.6 and later, [the `bytes` type is aliased to `str`](https://docs.python.org/3/whatsnew/2.6.html#pep-3112-byte-literals) (i.e., bytes), and in Python 3 it still represents bytes.
So we can cast `buf` to `bytes` both in Python 2 and 3 and obtain the correct behavior.