### PR TITLE
Python 3 fix: correct parsing of strings in parameter names

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -406,9 +406,9 @@ class mavfile(object):
         '''initiate fetch of one parameter'''
         try:
             idx = int(name)
-            self.mav.param_request_read_send(self.target_system, self.target_component, "", idx)
+            self.mav.param_request_read_send(self.target_system, self.target_component, b'', idx)
         except Exception:
-            self.mav.param_request_read_send(self.target_system, self.target_component, name, -1)
+            self.mav.param_request_read_send(self.target_system, self.target_component, name.encode('utf8'), -1)
 
     def time_since(self, mtype):
         '''return the time since the last message of type mtype was received'''

--- a/mavutil.py
+++ b/mavutil.py
@@ -406,9 +406,9 @@ class mavfile(object):
         '''initiate fetch of one parameter'''
         try:
             idx = int(name)
-            self.mav.param_request_read_send(self.target_system, self.target_component, b'', idx)
+            self.mav.param_request_read_send(self.target_system, self.target_component, '', idx)
         except Exception:
-            self.mav.param_request_read_send(self.target_system, self.target_component, name.encode('utf8'), -1)
+            self.mav.param_request_read_send(self.target_system, self.target_component, name, -1)
 
     def time_since(self, mtype):
         '''return the time since the last message of type mtype was received'''
@@ -422,10 +422,10 @@ class mavfile(object):
             if parm_type == None:
                 parm_type = mavlink.MAVLINK_TYPE_FLOAT
             self.mav.param_set_send(self.target_system, self.target_component,
-                                    parm_name.encode('utf8'), parm_value, parm_type)
+                                    parm_name, parm_value, parm_type)
         else:
             self.mav.param_set_send(self.target_system, self.target_component,
-                                    parm_name.encode('utf8'), parm_value)
+                                    parm_name, parm_value)
 
     def waypoint_request_list_send(self):
         '''wrapper for waypoint_request_list_send'''


### PR DESCRIPTION
In the process of rewriting a cleaner patch for [DroneKit PR #784](https://github.com/dronekit/dronekit-python/pull/784), I figured out that the byte-encoding of parameter names should be done on the pymavlink's side, not DroneKit's.