### PR TITLE
mavlogdump: add --show-available-types option

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -39,6 +39,7 @@ parser.add_argument("--zero-time-base", action='store_true', help="use Z time ba
 parser.add_argument("--no-bad-data", action='store_true', help="Don't output corrupted messages")
 parser.add_argument("--show-source", action='store_true', help="Show source system ID and component ID")
 parser.add_argument("--show-seq", action='store_true', help="Show sequence numbers")
+parser.add_argument("--show-types", action='store_true', help="Shows all message types available on opened log")
 parser.add_argument("--source-system", type=int, default=None, help="filter by source system ID")
 parser.add_argument("--source-component", type=int, default=None, help="filter by source component ID")
 parser.add_argument("--link", type=int, default=None, help="filter by comms link ID")
@@ -114,12 +115,16 @@ if isbin and args.format == 'csv': # need to accumulate columns from message
 # Track the last timestamp value. Used for compressing data for the CSV output format.
 last_timestamp = None
 
+# Track types found
+available_types = set()
+
 # Keep track of data from the current timestep. If the following timestep has the same data, it's stored in here as well. Output should therefore have entirely unique timesteps.
 while True:
     m = mlog.recv_match(blocking=args.follow)
     if m is None:
         # FIXME: Make sure to output the last CSV message before dropping out of this loop
         break
+    available_types.add(m.get_type())
     if isbin and m.get_type() == "FMT" and args.format == 'csv':
         if m.Name == types[0]:
             fields += m.Columns.split(',')
@@ -231,8 +236,12 @@ while True:
             s += " srcSystem=%u srcComponent=%u" % (m.get_srcSystem(), m.get_srcComponent())
         if args.show_seq:
             s += " seq=%u" % m.get_seq()
-        print(s)
+        if not args.show_types:
+            print(s)
 
     # Update our last timestamp value.
     last_timestamp = timestamp
 
+if args.show_types:
+    for msgType in available_types:
+        print(msgType)


### PR DESCRIPTION
Adds --show-available -types option.
The types need to be specified to generate a csv file, this PR adds an option that lists them like this:
```
Found message types:

MISSION_COUNT
ATTITUDE
RC_CHANNELS
BATTERY_STATUS
HEARTBEAT
MISSION_CURRENT
RAW_IMU
SCALED_PRESSURE2
MOUNT_STATUS
GPS_RAW_INT
SCALED_IMU2
NAV_CONTROLLER_OUTPUT
VFR_HUD
MEMINFO
HWSTATUS
VIBRATION
STATUSTEXT
AHRS
SENSOR_OFFSETS
COMMAND_ACK
NAMED_VALUE_FLOAT
SCALED_PRESSURE
GLOBAL_POSITION_INT
SYS_STATUS
POWER_STATUS
PARAM_VALUE
SYSTEM_TIME
EKF_STATUS_REPORT
AHRS3
AUTOPILOT_VERSION
SERVO_OUTPUT_RAW
AHRS2
RC_CHANNELS_RAW
```
Signed-off-by: Willian Galvani <williangalvani@gmail.com>