### PR TITLE
Fix bug in mavgen_wlua.py (#102)

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -6,7 +6,7 @@ Copyright Holger Steinhaus 2012
 Released under GNU GPL version 3 or later
 
 Instructions for use: 
-1. python -m pymavlink.generator.mavgen --lang=wlua mymavlink.xml -o ~/.wireshark/plugins/mymavlink.lua
+1. python -m pymavlink.tools.mavgen --lang=WLua mymavlink.xml -o ~/.wireshark/plugins/mymavlink.lua
 2. convert binary stream int .pcap file format (see ../examples/mav2pcap.py)
 3. open the pcap file in Wireshark
 '''
@@ -75,6 +75,7 @@ def generate_preamble(outf):
 """
 -- Wireshark dissector for the MAVLink protocol (please see http://qgroundcontrol.org/mavlink/start for details) 
 
+unknownFrameBeginOffset = 0
 mavlink_proto = Proto("mavlink_proto", "MAVLink protocol")
 f = mavlink_proto.fields
 


### PR DESCRIPTION
This PR fixes the issue #102.
Without `unknownFrameBeginOffset = 0` being set, Wireshark isn't able to decode any MAVLink message.

I also updated the documentation because the `mavgen` script was moved.