### PR TITLE
mavgen_javascript: pass file in MAVLink creator

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -255,8 +255,9 @@ mavlink.messages.bad_data = function(data, reason) {
 }
 
 /* MAVLink protocol handling class */
-MAVLink = function(logger, srcSystem, srcComponent) {
+MAVLink = function(file, logger, srcSystem, srcComponent) {
 
+    this.file = file;
     this.logger = logger;
 
     this.seq = 0;
@@ -532,6 +533,8 @@ MAVLink.prototype.decode = function(msgbuf) {
 
 def generate_footer(outf):
     t.write(outf, """
+
+mavlink.MAVLink = MAVLink;
 
 // Expose this code as a module
 module.exports = mavlink;


### PR DESCRIPTION
1. Pass file in MAVLink creator function, so that it can be used in send.
2. MAVLink can be used as 'mavlink.MAVLink'
