### PR TITLE
Add future to setup_requires in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,6 +158,9 @@ setup (name = 'pymavlink',
             'future',
             'lxml',
        ],
+       setup_requires=[
+           'future'  # future is required by mavgen, included by this file
+       ],
        cmdclass={'build_py': custom_build_py},
        ext_modules = extensions
        )


### PR DESCRIPTION
The package `future` needs to be added to the `setup_requires` list (i.e., *a string or list of strings specifying what other distributions need to be present in order for the setup script to run*, [source](http://setuptools.readthedocs.io/en/latest/setuptools.html#id8)) in `setup.py`.

The reason is that `future` is needed in pymavlink's installation phase, in `setup.py` itself: `future` is imported by [`mavgen.py`](https://github.com/ArduPilot/pymavlink/blob/master/generator/mavgen.py#L12), which is imported by [`setup.py`](https://github.com/ArduPilot/pymavlink/blob/master/setup.py#L21).

In the past, this has caused some problem with pymavlink installation, e.g. [this issue](https://github.com/ArduPilot/pymavlink/issues/25) and failed builds [like this](https://circleci.com/gh/dronekit/dronekit-python/1343).

Example traceback:

```pip install . -UI
Unpacking /home/ubuntu/dronekit-python
  Running setup.py egg_info for package from file:///home/ubuntu/dronekit-python
    
Downloading/unpacking pymavlink>=2.2.3 (from dronekit==2.9.1)
  Downloading pymavlink-2.2.8.tar.gz (3.0MB): 3.0MB downloaded
  Running setup.py egg_info for package pymavlink
    
Downloading/unpacking monotonic==1.2 (from dronekit==2.9.1)
  Downloading monotonic-1.2.tar.gz
  Running setup.py egg_info for package monotonic
    
Downloading/unpacking future==0.15.2 (from dronekit==2.9.1)
  Downloading future-0.15.2.tar.gz (1.6MB): 1.6MB downloaded
  Running setup.py egg_info for package future
    
    warning: no files found matching '*.au' under directory 'tests'
    warning: no files found matching '*.gif' under directory 'tests'
    warning: no files found matching '*.txt' under directory 'tests'
Downloading/unpacking lxml (from pymavlink>=2.2.3->dronekit==2.9.1)
  Downloading lxml-4.2.1.tar.gz (4.3MB): 4.3MB downloaded
  Running setup.py egg_info for package lxml
    Building lxml version 4.2.1.
    Building without Cython.
    Using build configuration of libxslt 1.1.26
    Building against libxml2/libxslt in the following directory: /usr/lib/x86_64-linux-gnu
    
    warning: no previously-included files found matching '*.py'
Installing collected packages: pymavlink, monotonic, future, dronekit, lxml
  Running setup.py install for pymavlink
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/home/ubuntu/virtualenvs/venv-system/build/pymavlink/setup.py", line 160, in <module>
        ext_modules = extensions
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/core.py", line 151, in setup
        dist.run_commands()
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/dist.py", line 953, in run_commands
        self.run_command(cmd)
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/setuptools/command/install.py", line 53, in run
        return _install.run(self)
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/command/install.py", line 563, in run
        self.run_command('build')
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/cmd.py", line 326, in run_command
        self.distribution.run_command(command)
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/command/build.py", line 127, in run
        self.run_command(cmd_name)
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/cmd.py", line 326, in run_command
        self.distribution.run_command(command)
      File "/home/ubuntu/.pyenv/versions/2.7.10/lib/python2.7/distutils/dist.py", line 972, in run_command
        cmd_obj.run()
      File "/home/ubuntu/virtualenvs/venv-system/build/pymavlink/setup.py", line 93, in run
        generate_content()
      File "/home/ubuntu/virtualenvs/venv-system/build/pymavlink/setup.py", line 21, in generate_content
        from generator import mavgen, mavparse
      File "generator/mavgen.py", line 12, in <module>
        from future import standard_library
    ImportError: No module named future
```