### PR TITLE
Restore null pointer detection in parser.

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -819,14 +819,18 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		status->packet_rx_success_count++;
 	}
 
-	r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
-	r_mavlink_status->parse_state = status->parse_state;
-	r_mavlink_status->packet_idx = status->packet_idx;
-	r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
-	r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
-	r_mavlink_status->packet_rx_drop_count = status->parse_error;
-	r_mavlink_status->flags = status->flags;
-	status->parse_error = 0;
+	if (NULL != r_message) {
+            r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+        }
+        if (NULL != r_mavlink_status) {	
+            r_mavlink_status->parse_state = status->parse_state;
+	    r_mavlink_status->packet_idx = status->packet_idx;
+	    r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+	    r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+	    r_mavlink_status->packet_rx_drop_count = status->parse_error;
+	    r_mavlink_status->flags = status->flags;
+	}
+        status->parse_error = 0;
 
 	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
 		/*
@@ -836,7 +840,9 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		  mavlink_msg_to_send_buffer() won't overwrite the
 		  checksum
 		 */
+            if (NULL != r_message)
 		r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+            }
 	}
 
 	return status->msg_received;

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -819,18 +819,18 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		status->packet_rx_success_count++;
 	}
 
-        if (NULL != r_message) {
-            r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
-        }
-        if (NULL != r_mavlink_status) {	
-            r_mavlink_status->parse_state = status->parse_state;
-            r_mavlink_status->packet_idx = status->packet_idx;
-            r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
-            r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
-            r_mavlink_status->packet_rx_drop_count = status->parse_error;
-            r_mavlink_status->flags = status->flags;
-        }
-        status->parse_error = 0;
+       if (NULL != r_message) {
+           r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+       }
+       if (NULL != r_mavlink_status) {	
+           r_mavlink_status->parse_state = status->parse_state;
+           r_mavlink_status->packet_idx = status->packet_idx;
+           r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+           r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+           r_mavlink_status->packet_rx_drop_count = status->parse_error;
+           r_mavlink_status->flags = status->flags;
+       }
+       status->parse_error = 0;
 
 	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
 		/*

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -819,17 +819,17 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		status->packet_rx_success_count++;
 	}
 
-	if (NULL != r_message) {
+        if (NULL != r_message) {
             r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
         }
         if (NULL != r_mavlink_status) {	
             r_mavlink_status->parse_state = status->parse_state;
-	    r_mavlink_status->packet_idx = status->packet_idx;
-	    r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
-	    r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
-	    r_mavlink_status->packet_rx_drop_count = status->parse_error;
-	    r_mavlink_status->flags = status->flags;
-	}
+            r_mavlink_status->packet_idx = status->packet_idx;
+            r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+            r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+            r_mavlink_status->packet_rx_drop_count = status->parse_error;
+            r_mavlink_status->flags = status->flags;
+        }
         status->parse_error = 0;
 
 	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
@@ -841,7 +841,7 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		  checksum
 		 */
             if (NULL != r_message)
-		r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+                r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
             }
 	}
 


### PR DESCRIPTION
Removal of null pointer detection in v2.0 suppressed conveniency invocation to parser like:

`mavlink_parse_char(MAVLINK_BACKHAUL, *tp, NULL, NULL);`

Better to restore.