### PR TITLE
Raise bad_crc flag when return

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -977,7 +977,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 		    rxmsg->len = 0;
 		    mavlink_start_checksum(rxmsg);
 	    }
-	    return 0;
+	    return MAVLINK_FRAMING_BAD_CRC;
     }
     return msg_received;
 }


### PR DESCRIPTION
Better to raise a BAD_CRC flag to distinguish from INCOMPLETE packet, so that app can tell the difference and handle it more precisely.

More return code are actually preferred here, however that will rely on the definition of new codes to be done first.