### PR TITLE
DFReader.py: add hack to avoid struct.error exception

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -578,7 +578,9 @@ class DFReader_binary(DFReader):
                            "Type,Length,Name,Format,Columns")
         }
         self._zero_time_base = zero_time_base
+        self.prev_type = None
         self.init_clock()
+        self.prev_type = None
         self._rewind()
 
     def _rewind(self):
@@ -589,38 +591,45 @@ class DFReader_binary(DFReader):
 
     def _parse_next(self):
         '''read one message, returning it as an object'''
-        if self.data_len - self.offset < 3:
-            return None
 
-        hdr = self.data[self.offset:self.offset+3]
-        skip_bytes = 0
         skip_type = None
-        # skip over bad messages
-        while (u_ord(hdr[0]) != self.HEAD1 or u_ord(hdr[1]) != self.HEAD2 or
-	       u_ord(hdr[2]) not in self.formats):
+        # skip over bad messages; after this loop has run msg_type
+        # indicates the message which starts at self.offset (including
+        # signature bytes and msg_type itself)
+        while True:
+            if self.remaining < 3:
+                return None
+            hdr = self.data[self.offset:self.offset+3]
+            if u_ord(hdr[0]) == self.HEAD1 and u_ord(hdr[1]) == self.HEAD2:
+                # signature found
+                if skip_type is not None:
+                    # emit message about skipped bytes
+                    if self.remaining >= 528:
+                        # APM logs often contain garbage at end
+                        skip_bytes = self.offset - skip_start
+                        print("Skipped %u bad bytes in log at offset %u, type=%s (prev=%s)" %
+                              (skip_bytes, skip_start, skip_type, self.prev_type),
+                          file=sys.stderr)
+                    skip_type = None
+                # check we recognise this message type:
+                msg_type = u_ord(hdr[2])
+                if msg_type in self.formats:
+                    # recognised message found
+                    self.prev_type = msg_type
+                    break;
+                # message was not recognised; fall through so these
+                # bytes are considered "skipped".  The signature bytes
+                # are easily recognisable in the "Skipped bytes"
+                # message.
             if skip_type is None:
                 skip_type = (u_ord(hdr[0]), u_ord(hdr[1]), u_ord(hdr[2]))
                 skip_start = self.offset
-            skip_bytes += 1
             self.offset += 1
-            if self.data_len - self.offset < 3:
-                return None
-            hdr = self.data[self.offset:self.offset+3]
-        msg_type = u_ord(hdr[2])
-        if skip_bytes != 0:
-            if self.remaining < 528:
-                return None
-            print("Skipped %u bad bytes in log at offset %u, type=%s" %
-                  (skip_bytes, skip_start, skip_type), file=sys.stderr)
-            self.remaining -= skip_bytes
+            self.remaining -= 1
 
         self.offset += 3
         self.remaining -= 3
 
-        if msg_type not in self.formats:
-            if self.verbose:
-                print("unknown message type %02x" % msg_type, file=sys.stderr)
-            raise Exception("Unknown message type %02x" % msg_type)
         fmt = self.formats[msg_type]
         if self.remaining < fmt.len-3:
             # out of data - can often happen half way through a message

--- a/DFReader.py
+++ b/DFReader.py
@@ -173,6 +173,9 @@ class DFMessage(object):
             v = self.__getattr__(name)
             if mul is not None:
                 v /= mul
+            if type(v) == unicode:
+                # temporary(?) hack
+                v = bytes(v)
             values.append(v)
         return (struct.pack("BBB", 0xA3, 0x95, self.fmt.type) +
                 struct.pack(self.fmt.msg_struct, *values))

--- a/mavutil.py
+++ b/mavutil.py
@@ -266,7 +266,7 @@ class mavfile(object):
             if seq != seq2 and last_seq != -1:
                 diff = (seq2 - seq) % 256
                 self.mav_loss += diff
-                #print("lost %u seq=%u seq2=%u last_seq=%u src_system=%u %s" % (diff, seq, seq2, last_seq, src_system, msg.get_type()))
+#                print("lost %u seq=%u seq2=%u last_seq=%u src_tupe=%s %s" % (diff, seq, seq2, last_seq, str(src_tuple), msg.get_type()))
             self.last_seq[src_tuple] = seq2
             self.mav_count += 1
         


### PR DESCRIPTION
pbarker@bluebottle:/tmp$ mavlogdump.py skyviper-streaming-replay-655.bin
-o /dev/null
Traceback (most recent call last):
  File "/home/pbarker/.local/bin/mavlogdump.py", line 4, in <module>
    __import__('pkg_resources').run_script('pymavlink==2.2.8',
'mavlogdump.py')
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py",
line 742, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py",
line 1503, in run_script
    exec(code, namespace, namespace)
  File
"/home/pbarker/.local/lib/python2.7/site-packages/pymavlink-2.2.8-py2.7-linux-x86_64.egg/EGG-INFO/scripts/mavlogdump.py",
line 136, in <module>
    output.write(m.get_msgbuf())
  File
"/home/pbarker/.local/lib/python2.7/site-packages/pymavlink-2.2.8-py2.7-linux-x86_64.egg/pymavlink/DFReader.py",
line 178, in get_msgbuf
    struct.pack(self.fmt.msg_struct, *values))
struct.error: argument for 's' must be a string