### PR TITLE
mavlogdump: Make headers use csv_sep when outputting csv

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -105,7 +105,7 @@ if istlog and args.format == 'csv': # we know our fields from the get-go
 
     # The first line output are names for all columns
     csv_out = ["" for x in fields]
-    print(','.join(fields))
+    print(args.csv_sep.join(fields))
 
 if isbin and args.format == 'csv': # need to accumulate columns from message
     if types is None or len(types) != 1:
@@ -129,7 +129,7 @@ while True:
         if m.Name == types[0]:
             fields += m.Columns.split(',')
             csv_out = ["" for x in fields]
-            print(','.join(fields))
+            print(args.csv_sep.join(fields))
 
     if output is not None:
         if (isbin or islog) and m.get_type() == "FMT":


### PR DESCRIPTION
When using "--csv_sep ;" the header was still using "," as separator.

Signed-off-by: Willian Galvani <williangalvani@gmail.com>