### PR TITLE
message.hpp: added missing include

### DIFF
--- a/generator/CPP11/include_v2.0/message.hpp
+++ b/generator/CPP11/include_v2.0/message.hpp
@@ -3,9 +3,10 @@
 
 #include <array>
 #include <cassert>
+#include <cstring>
+#include <sstream>
 #include <string>
 #include <iostream>
-#include <cstring>
 
 #ifndef MAVLINK_HELPER
 #define MAVLINK_HELPER static inline


### PR DESCRIPTION
In message.hpp:106 a `std::stringstream` is created, but `<sstream>` was never included.