### PR TITLE
Fix Java package name generation on Windows

### DIFF
--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -128,7 +128,9 @@ def generate_message_h(directory, m):
     '''generate per-message header for a XML file'''
     f = open(os.path.join(directory, 'msg_%s.java' % m.name_lower), mode='w')
 
-    path=directory.split('/')
+    (path_head, path_tail) = os.path.split(directory)
+    if path_tail == "":
+        (path_head, path_tail) = os.path.split(path_head)
     t.write(f, '''
 /* AUTO-GENERATED FILE.  DO NOT MODIFY.
  *
@@ -213,7 +215,7 @@ public class msg_${name_lower} extends MAVLinkMessage{
         return "MAVLINK_MSG_ID_${name} - sysid:"+sysid+" compid:"+compid+${{ordered_fields:" ${name}:"+${name}+}}"";
     }
 }
-        ''' % path[len(path)-1], m)
+        ''' % path_tail, m)
     f.close()
 
 


### PR DESCRIPTION
I believe the changes pretty much speak for themselves. The `directory` string is generated elsewhere with `os.path.join`, which uses backslashes as a path separator on Windows.

On a semi-related note, this file has *a lot* of trailing white space that my editor automatically removed, which I had to filter out to make a clean diff.