### PR TITLE
Make Java package names lowercase

### DIFF
--- a/generator/java/lib/Parser.java
+++ b/generator/java/lib/Parser.java
@@ -4,10 +4,10 @@
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink;
+package com.mavlink;
 
-import com.MAVLink.MAVLinkPacket;
-import com.MAVLink.Messages.MAVLinkStats;
+import com.mavlink.MAVLinkPacket;
+import com.mavlink.messages.MAVLinkStats;
 
 public class Parser {
 

--- a/generator/java/lib/messages/MAVLinkMessage.java
+++ b/generator/java/lib/messages/MAVLinkMessage.java
@@ -4,11 +4,11 @@
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink.Messages;
+package com.mavlink.messages;
 
 import java.io.Serializable;
 
-import com.MAVLink.MAVLinkPacket;
+import com.mavlink.MAVLinkPacket;
 
 public abstract class MAVLinkMessage implements Serializable {
     private static final long serialVersionUID = -7754622750478538539L;

--- a/generator/java/lib/messages/MAVLinkPayload.java
+++ b/generator/java/lib/messages/MAVLinkPayload.java
@@ -4,7 +4,7 @@
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink.Messages;
+package com.mavlink.messages;
 
 import java.nio.ByteBuffer;
 

--- a/generator/java/lib/messages/MAVLinkStats.java
+++ b/generator/java/lib/messages/MAVLinkStats.java
@@ -4,10 +4,10 @@
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink.Messages;
+package com.mavlink.messages;
 
-import com.MAVLink.MAVLinkPacket;
-import com.MAVLink.common.msg_radio_status;
+import com.mavlink.MAVLinkPacket;
+import com.mavlink.common.msg_radio_status;
 
 /**
  * Storage for MAVLink Packet and Error statistics

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -28,7 +28,7 @@ def generate_enums(basename, xml):
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink.enums;
+package com.mavlink.enums;
 
 /** 
 * ${description}
@@ -58,7 +58,7 @@ def generate_CRC(directory, xml):
  * java mavlink generator tool. It should not be modified by hand.
  */
 
-package com.MAVLink.${basename};
+package com.mavlink.${basename};
 
 /**
 * X.25 CRC calculation for MAVlink messages. The checksum must be initialized,
@@ -137,10 +137,10 @@ def generate_message_h(directory, m):
  */
 
 // MESSAGE ${name} PACKING
-package com.MAVLink.%s;
-import com.MAVLink.MAVLinkPacket;
-import com.MAVLink.Messages.MAVLinkMessage;
-import com.MAVLink.Messages.MAVLinkPayload;
+package com.mavlink.%s;
+import com.mavlink.MAVLinkPacket;
+import com.mavlink.messages.MAVLinkMessage;
+import com.mavlink.messages.MAVLinkPayload;
         
 /**
 * ${description}
@@ -223,7 +223,7 @@ def generate_MAVLinkMessage(directory, xml_list):
     imports = []
 
     for xml in xml_list:
-        importString = "import com.MAVLink.{}.*;".format(xml.basename)
+        importString = "import com.mavlink.{}.*;".format(xml.basename)
         imports.append(importString)
 
     xml_list[0].importString = os.linesep.join(imports)
@@ -235,12 +235,12 @@ def generate_MAVLinkMessage(directory, xml_list):
  * java mavlink generator tool. It should not be modified by hand.
  */
         
-package com.MAVLink;
+package com.mavlink;
 
 import java.io.Serializable;
-import com.MAVLink.Messages.MAVLinkPayload;
-import com.MAVLink.Messages.MAVLinkMessage;
-import com.MAVLink.${basename}.CRC;
+import com.mavlink.messages.MAVLinkPayload;
+import com.mavlink.messages.MAVLinkMessage;
+import com.mavlink.${basename}.CRC;
 
 ${importString}
 
@@ -405,7 +405,7 @@ public class MAVLinkPacket implements Serializable {
 def copy_fixed_headers(directory, xml):
     '''copy the fixed protocol headers to the target directory'''
     import shutil
-    hlist = [ 'Parser.java', 'Messages/MAVLinkMessage.java', 'Messages/MAVLinkPayload.java', 'Messages/MAVLinkStats.java' ]
+    hlist = [ 'Parser.java', 'messages/MAVLinkMessage.java', 'messages/MAVLinkPayload.java', 'messages/MAVLinkStats.java' ]
     basepath = os.path.dirname(os.path.realpath(__file__))
     srcpath = os.path.join(basepath, 'java/lib')
     print("Copying fixed headers")
@@ -414,7 +414,7 @@ def copy_fixed_headers(directory, xml):
         dest = os.path.realpath(os.path.join(directory, h))
         if src == dest:
             continue
-        destdir = os.path.realpath(os.path.join(directory, 'Messages'))
+        destdir = os.path.realpath(os.path.join(directory, 'messages'))
         try:
             os.makedirs(destdir)
         except:


### PR DESCRIPTION
Per the [Java docs](https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html), package names should be all lowercase.