### PR TITLE
Update to new link for MAVlink resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -103,7 +103,7 @@ setup (name = 'pymavlink',
                            'creation of simple scripts to analyse telemetry logs from autopilots such as ArduPilot which use '
                            'the MAVLink protocol. See the scripts that come with the package for examples of small, useful '
                            'scripts that use pymavlink. For more information about the MAVLink protocol see '
-                           'http://qgroundcontrol.org/mavlink/'),
+                           'https://mavlink.io/en/'),
        url = 'https://github.com/ArduPilot/pymavlink/',
        classifiers=['Development Status :: 4 - Beta',
                     'Environment :: Console',


### PR DESCRIPTION
The qgroundcontrol.org link still exists, but all content is migrated or migrating to https://mavlink.io/en/
