### PR TITLE
Mark WIP messages using XML markup

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -150,6 +150,14 @@
     </xs:complexType>
 </xs:element>
 
+<xs:element name="wip">
+    <xs:complexType mixed="true">
+        <xs:sequence>
+            <xs:element ref="description" minOccurs="0"/>
+        </xs:sequence>
+    </xs:complexType>
+</xs:element>
+
 <xs:element name="field">
     <xs:complexType mixed="true">
         <xs:sequence>
@@ -171,7 +179,10 @@
 <xs:element name="entry">
     <xs:complexType>
         <xs:sequence>
-            <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element ref="deprecated"/>
+                <xs:element ref="wip"/>
+            </xs:choice>
             <xs:element ref="description" minOccurs="0"/>
             <xs:element ref="param" minOccurs="0" maxOccurs="unbounded" />
         </xs:sequence>
@@ -195,7 +206,10 @@
     <xs:complexType>
         <xs:sequence>
             <xs:sequence minOccurs="1" maxOccurs="1">
-                <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
+                <xs:choice minOccurs="0" maxOccurs="1">
+                    <xs:element ref="deprecated"/>
+                    <xs:element ref="wip"/>
+                </xs:choice>
                 <xs:element ref="description" minOccurs="0" maxOccurs="1"/>
                 <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -194,19 +194,16 @@
 <xs:element name="message">
     <xs:complexType>
         <xs:sequence>
-            <xs:choice minOccurs="0" maxOccurs="2">
-                    <xs:sequence>
-                        <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
-                        <xs:element ref="description" minOccurs="0"/>
-                        <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
-                    <xs:element ref="extensions" minOccurs="0" maxOccurs="1"/>
-
-            </xs:choice>
-                    <xs:sequence>
-                        <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
-                        <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:sequence>
+            <xs:sequence minOccurs="1" maxOccurs="1">
+                <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="description" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <!-- MavLink 2.0 extensions are optional hence minOccurs="0" -->
+            <xs:sequence minOccurs="0" maxOccurs="1">
+                <xs:element ref="extensions" minOccurs="1" maxOccurs="1"/>
+                <xs:element ref="field" minOccurs="1" maxOccurs="unbounded"/>
+            </xs:sequence>
         </xs:sequence>
         <xs:attribute ref="id" use="required"/>
         <xs:attribute ref="name" use="required"/>


### PR DESCRIPTION
Mark WIP messages using proper XML markup instead of having that information in some comments
As a side effect it improves the validation of Mavlink 2.0 message extensions