### PR TITLE
mavutil: fix autoreconnect on serial port

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -839,8 +839,15 @@ class mavserial(mavfile):
             waiting = self.port.inWaiting()
             if waiting < n:
                 n = waiting
-        ret = self.port.read(n)
-        return ret
+        try:
+            return self.port.read(n)
+        except Exception:
+            if not self.portdead:
+                print("Device %s is dead" % self.device)
+            self.portdead = True
+            if self.autoreconnect:
+                self.reset()
+            return bytes()
 
     def write(self, buf):
         try:


### PR DESCRIPTION
If the device got removed while reading, it would crash MAVProxy. Code is basically copied from `write`.