### PR TITLE
Enforces description for messages

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -212,7 +212,7 @@
                     <xs:element ref="deprecated"/>
                     <xs:element ref="wip"/>
                 </xs:choice>
-                <xs:element ref="description" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="description" minOccurs="1" maxOccurs="1"/>
                 <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
             </xs:sequence>
             <!-- MavLink 2.0 extensions are optional hence minOccurs="0" -->


### PR DESCRIPTION
Every message should IMO have a description (as suggested by @amilcarlucas here: https://github.com/mavlink/mavlink-devguide/pull/96#discussion_r207462353).

While we're here, are there any other types that really must have a description? I think all enums, enum values, params should have descriptions too. BUT, adding those will break the current common.xml as both enums and enum values are missing descriptions: https://mavlink.io/en/messages/common.html
So if we agree that I'll need to make sure the XML is updated first.