### PR TITLE
mavutil.py: mavudp: stop resolving target hostname for every sendto()

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -923,6 +923,7 @@ class mavudp(mavfile):
         set_close_on_exec(self.port.fileno())
         self.port.setblocking(0)
         self.last_address = None
+        self.resolved_destination_addr = None
         mavfile.__init__(self, self.port.fileno(), device, source_system=source_system, source_component=source_component, input=input, use_native=use_native)
 
     def close(self):
@@ -949,6 +950,11 @@ class mavudp(mavfile):
                     self.destination_addr = self.last_address
                     self.broadcast = False
                     self.port.connect(self.destination_addr)
+                # turn a (possible) hostname into an IP address to
+                # avoid resolving the hostname for every packet sent:
+                if self.destination_addr[0] != self.resolved_destination_addr:
+                    self.resolved_destination_addr = self.destination_addr[0]
+                    self.destination_addr = (socket.gethostbyname(self.destination_addr[0]), self.destination_addr[1])
                 self.port.sendto(buf, self.destination_addr)
         except socket.error:
             pass


### PR DESCRIPTION
Before:

[pid 13322] getpid()                    = 13302
[pid 13322] wait4(13306, 0x7f7f4ac4b624, WNOHANG, NULL) = 0
[pid 13322] stat("/etc/resolv.conf", {st_mode=S_IFREG|0644, st_size=337, ...}) = 0
[pid 13322] openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 25
[pid 13322] fstat(25, {st_mode=S_IFREG|0644, st_size=658, ...}) = 0
[pid 13322] read(25, "127.0.0.1\tlocalhost\n127.0.1.1\tbl"..., 4096) = 658
[pid 13322] read(25, "", 4096)          = 0
[pid 13322] close(25)                   = 0
[pid 13322] sendto(8, "\375\16\0\0\203\1\1\35\0\0P=\26\0~]nD\0\0\0\0\36\20\313\316", 26, 0, {sa_family=AF_INET, sin_port=htons(9866), sin_addr=inet_addr("127.0.0.1")}, 16) = 26
[pid 13322] getpid()                    = 13302
[pid 13322] wait4(13306, 0x7f7f4ac4b624, WNOHANG, NULL) = 0
[pid 13322] stat("/etc/resolv.conf", {st_mode=S_IFREG|0644, st_size=337, ...}) = 0
[pid 13322] openat(AT_FDCWD, "/etc/hosts", O_RDONLY|O_CLOEXEC) = 25
[pid 13322] fstat(25, {st_mode=S_IFREG|0644, st_size=658, ...}) = 0
[pid 13322] read(25, "127.0.0.1\tlocalhost\n127.0.1.1\tbl"..., 4096) = 658
[pid 13322] read(25, "", 4096)          = 0
[pid 13322] close(25)                   = 0
[pid 13322] sendto(8, "\375\37\0\0\204\1\1\1\0\0\17\374`\3\17\34`\0\17\374`\1B\1\0\0\377\377\0\0\0\0"..., 43, 0, {sa_family=AF_INET, sin_port=htons(9866), sin_addr=inet_addr("127.0.0.1")}, 16) = 43

After:
[pid 14422] getpid()                    = 14405
[pid 14422] wait4(14409, 0x7ff346e93624, WNOHANG, NULL) = 0
[pid 14422] sendto(8, "\375\2\0\0\204\1\1\245\0\0\325\23\340\242", 14, 0, {sa_family=AF_INET, sin_port=htons(9866), sin_addr=inet_addr("127.0.0.1")}, 16) = 14
[pid 14422] getpid()                    = 14405
[pid 14422] wait4(14409, 0x7ff346e93624, WNOHANG, NULL) = 0
[pid 14422] getpid()                    = 14405
[pid 14422] wait4(14409, 0x7ff346e93444, WNOHANG, NULL) = 0
[pid 14422] write(13, "\0\0\0\204\200\2(cMAVProxy.modules.lib.wxc"..., 136) = 136
[pid 14422] sendto(8, "\375\v\0\0\205\1\1\2\0\0\0\0\0\0\0\0\0\0\364T)\202\370", 23, 0, {sa_family=AF_INET, sin_port=htons(9866), sin_addr=inet_addr("127.0.0.1")}, 16) = 23
[pid 14422] getpid()                    = 14405
[pid 14422] wait4(14409, 0x7ff346e93624, WNOHANG, NULL) = 0
[pid 14422] sendto(8, "\375\26\0\0\206\1\1\301\0\0\0\0\0\0Hqa;\331\373*<\2J\342:\0\0\0\0\245\1"..., 34, 0, {sa_family=AF_INET, sin_port=htons(9866), sin_addr=inet_addr("127.0.0.1")}, 16) = 34