### PR TITLE
Add parser check for duplicate message names

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -471,7 +471,7 @@ def check_duplicates(xml):
                     m.name,
                     m.id,
                     x.filename, m.linenumber,
-                    msg_name_map[name]))
+                    msg_name_map[m.name]))
                 return True
             msg_name_map[m.name] = '%s (%s:%u)' % (m.id, x.filename, m.linenumber)
         for enum in x.enum:

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -444,6 +444,7 @@ def check_duplicates(xml):
     merge_enums(xml)
 
     msgmap = {}
+    msg_name_map = {}
     enummap = {}
     for x in xml:
         for m in x.message:
@@ -464,6 +465,16 @@ def check_duplicates(xml):
                     return True
                 fieldset.add(f.name)
             msgmap[key] = '%s (%s:%u)' % (m.name, x.filename, m.linenumber)
+            # Check for duplicate message names
+            name = m.name
+            if name in msg_name_map:
+                print("ERROR: Duplicate message name %s for id:%u (%s:%u) also used by %s" % (
+                    m.name,
+                    m.id,
+                    x.filename, m.linenumber,
+                    msg_name_map[name]))
+                return True
+            msg_name_map[name] = '%s (%s:%u)' % (m.id, x.filename, m.linenumber)
         for enum in x.enum:
             for entry in enum.entry:
                 if entry.autovalue is True and "common.xml" not in entry.origin_file:

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -466,15 +466,14 @@ def check_duplicates(xml):
                 fieldset.add(f.name)
             msgmap[key] = '%s (%s:%u)' % (m.name, x.filename, m.linenumber)
             # Check for duplicate message names
-            name = m.name
-            if name in msg_name_map:
+            if m.name in msg_name_map:
                 print("ERROR: Duplicate message name %s for id:%u (%s:%u) also used by %s" % (
                     m.name,
                     m.id,
                     x.filename, m.linenumber,
                     msg_name_map[name]))
                 return True
-            msg_name_map[name] = '%s (%s:%u)' % (m.id, x.filename, m.linenumber)
+            msg_name_map[m.name] = '%s (%s:%u)' % (m.id, x.filename, m.linenumber)
         for enum in x.enum:
             for entry in enum.entry:
                 if entry.autovalue is True and "common.xml" not in entry.origin_file:


### PR DESCRIPTION
The existing generator parser (only) tests for duplicate message ids, enum names, and enum value names within a particular enum.

It does not check for:
1. duplicate message _names_:
   - duplicates break Python because it does not support function overloading - any duplicate will not be "findable"
   - duplicates break C/C++ because each message name creates a single file per message, and any duplicate will overwrite the previous message.
2. duplicate enum values within different enums.
   - this is fine for C which scopes the enum values, but the Python implementation creates a "bottom level" constant for every enum value for pymavlink enum values must be unique in a dialect.
3. duplicate enum and enum value names
   - As for "2" the enum and enum values names are all represented by constants in Pymavlink. 
4. Duplicate ids on params. 
   - Do we need to check this? (IMO yes and somewhat important). Will break code.
5. Duplicate names on params. 
   - Do we need to check this? (IMO "should" but not important). Will not break code but may make GCS confusing

This PR fixes the duplicate message id problem (1).

@peterbarker Regarding 2 and 3,  it is easy enough to ensure that all enum values and enums are unique. It seems to me we should check this even though it is a problem that is related to our pymavlink implementation rather than the nature of enums. 
Thoughts/Open to suggestions (or additions) for fixing.