### PR TITLE
Simplify comparisons with None, True, False

### DIFF
--- a/examples/bwtest.py
+++ b/examples/bwtest.py
@@ -44,7 +44,7 @@ while True:
         #and return a new message if available
         m = master.recv_msg()
 
-        if m == None: break  #No new message
+        if m is None: break  #No new message
         
         if m.get_type() not in counts:
         #if no messages of this type received, add this type to the counts dict

--- a/examples/mav2pcap.py
+++ b/examples/mav2pcap.py
@@ -159,7 +159,7 @@ def convert_file(mavlink_file, pcap_file):
         if next_sof > 0:
             print("skipped " + str(next_sof) + " bytes")
             if write_junk:
-                if skipped_char != None:
+                if skipped_char is not None:
                     junk = skipped_char + data[:next_sof]
                     skipped_char = None
                 write_packet(i, junk, 0x03, len(junk))

--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -316,7 +316,7 @@ using System.Reflection;
         winpath=os.environ['WinDir']
         cscCommand = winpath + "\\Microsoft.NET\\Framework\\v4.0.30319\\csc.exe"
         
-        if (os.path.exists(cscCommand)==False):
+        if not os.path.exists(cscCommand):
             print("\nError: CS compiler not found. .Net Assembly generation skipped")
             return   
     else:

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -163,7 +163,7 @@ class MAVLink_message(object):
         return not self.__eq__(other)
 
     def __eq__(self, other):
-        if other == None:
+        if other is None:
             return False
 
         if self.get_type() != other.get_type():
@@ -555,7 +555,7 @@ class MAVLink(object):
             else:
                 m = self.__parse_char_legacy()
 
-            if m != None:
+            if m is not None:
                 self.total_packets_received += 1
                 self.__callbacks(m)
             else:

--- a/mavextra.py
+++ b/mavextra.py
@@ -505,7 +505,7 @@ def distance_home(GPS_RAW):
        (hasattr(GPS_RAW, 'Status')   and GPS_RAW.Status   < 2):
         return 0
 
-    if first_fix == None:
+    if first_fix is None:
         first_fix = GPS_RAW
         return 0
     return distance_two(GPS_RAW, first_fix)

--- a/mavparm.py
+++ b/mavparm.py
@@ -25,7 +25,7 @@ class MAVParmDict(dict):
             tstart = time.time()
             while time.time() - tstart < 1:
                 ack = mav.recv_match(type='PARAM_VALUE', blocking=False)
-                if ack == None:
+                if ack is None:
                     time.sleep(0.1)
                     continue
                 if str(name).upper() == str(ack.param_id).upper():

--- a/mavutil.py
+++ b/mavutil.py
@@ -424,7 +424,7 @@ class mavfile(object):
     def param_set_send(self, parm_name, parm_value, parm_type=None):
         '''wrapper for parameter set'''
         if self.mavlink10():
-            if parm_type == None:
+            if parm_type is None:
                 parm_type = mavlink.MAVLINK_TYPE_FLOAT
             self.mav.param_set_send(self.target_system, self.target_component,
                                     parm_name.encode('utf8'), parm_value, parm_type)
@@ -484,9 +484,9 @@ class mavfile(object):
         '''
         if self.mavlink10():
             mode = self.base_mode
-            if (enable == True):
+            if enable:
                 mode = mode | flag
-            elif (enable == False):
+            elif not enable:
                 mode = mode & ~flag
             self.mav.command_long_send(self.target_system, self.target_component,
                                            mavlink.MAV_CMD_DO_SET_MODE, 0,

--- a/mavwp.py
+++ b/mavwp.py
@@ -495,7 +495,7 @@ class MAVRallyLoader(object):
             print("Inavlid rally point number %u" % i)
             return
         self.rally_points[i-1].alt = int(alt)
-        if (break_alt != None):
+        if break_alt is not None:
             self.rally_points[i-1].break_alt = break_alt
         if change_time:
             self.last_change = time.time()

--- a/rotmat.py
+++ b/rotmat.py
@@ -31,15 +31,15 @@ from math import sin, cos, sqrt, asin, atan2, pi, radians, acos, degrees
 class Vector3(object):
     '''a vector'''
     def __init__(self, x=None, y=None, z=None):
-        if x != None and y != None and z != None:
+        if x is not None and y is not None and z is not None:
             self.x = float(x)
             self.y = float(y)
             self.z = float(z)
-        elif x != None and len(x) == 3:
+        elif x is not None and len(x) == 3:
             self.x = float(x[0])
             self.y = float(x[1])
             self.z = float(x[2])
-        elif x != None:
+        elif x is not None:
             raise ValueError('bad initialiser')
         else:
             self.x = float(0)

--- a/tests/test_fgFDM.py
+++ b/tests/test_fgFDM.py
@@ -60,7 +60,7 @@ class fgFDMVariableListTest(unittest.TestCase):
         assert mapping.vars['longitude'].index == 0
         assert mapping.vars['longitude'].units == 'radians'
         assert mapping.vars['rpm'].index == 2
-        assert mapping.vars['rpm'].units == None
+        assert mapping.vars['rpm'].units is None
 
 
 class fgFDMTest(unittest.TestCase):

--- a/tests/test_mavexpression.py
+++ b/tests/test_mavexpression.py
@@ -28,14 +28,14 @@ class ExpressionTest(unittest.TestCase):
     def test_novars(self):
         """Test the evaluate_expression functionality"""
         assert mavexpression.evaluate_expression('1+2', {}) == 3
-        assert mavexpression.evaluate_expression('4/0', {}) == None
-        assert mavexpression.evaluate_expression('A+4', {}) == None
+        assert mavexpression.evaluate_expression('4/0', {}) is None
+        assert mavexpression.evaluate_expression('A+4', {}) is None
 
     def test_vars(self):
         """Test the evaluate_expression functionality with local vars"""
         assert mavexpression.evaluate_expression('lat+10', self.varsDict) == 15.67
         assert mavexpression.evaluate_expression('4.0/speed', self.varsDict) == 0.5
-        assert mavexpression.evaluate_expression('speed+lat+wrong', self.varsDict) == None
+        assert mavexpression.evaluate_expression('speed+lat+wrong', self.varsDict) is None
         
     def test_mavextra(self):
         """Test evaluate_expression using the functions in mavextra.py"""

--- a/tools/magfit_delta.py
+++ b/tools/magfit_delta.py
@@ -116,7 +116,7 @@ def magfit(logfile):
         if m.get_type() == "SENSOR_OFFSETS":
             # update offsets that were used during this flight
             offsets = Vector3(m.mag_ofs_x, m.mag_ofs_y, m.mag_ofs_z)
-        if m.get_type() == "RAW_IMU" and offsets != None:
+        if m.get_type() == "RAW_IMU" and offsets is not None:
             # extract one mag vector, removing the offsets that were
             # used during that flight to get the raw sensor values
             mag = Vector3(m.xmag, m.ymag, m.zmag) - offsets

--- a/tools/mavgraph.py
+++ b/tools/mavgraph.py
@@ -100,7 +100,7 @@ def plotit(x, y, fields, colors=[]):
             color = 'red'
         (tz, tzdst) = time.tzname
         if axes[i] == 2:
-            if ax2 == None:
+            if ax2 is None:
                 ax2 = ax1.twinx()
             ax = ax2
             if not args.xaxis:

--- a/tools/mavsummarize.py
+++ b/tools/mavsummarize.py
@@ -107,12 +107,12 @@ def PrintSummary(logfile):
             if m.type == mavutil.mavlink.MAV_TYPE_GCS:
                 continue
             if (m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_GUIDED_ENABLED or
-                m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_AUTO_ENABLED) and autonomous == False:
+                m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_AUTO_ENABLED) and not autonomous:
                 autonomous = True
                 autonomous_sections += 1
                 start_auto_time = timestamp
             elif (not m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_GUIDED_ENABLED and
-                not m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_AUTO_ENABLED) and autonomous == True:
+                not m.base_mode & mavutil.mavlink.MAV_MODE_FLAG_AUTO_ENABLED) and autonomous:
                 autonomous = False
                 auto_time += timestamp - start_auto_time
 
@@ -122,7 +122,7 @@ def PrintSummary(logfile):
         return
 
     # If the vehicle ends in autonomous mode, make sure we log the total time
-    if autonomous == True:
+    if autonomous:
         auto_time += timestamp - start_auto_time
 
     # Compute the total logtime, checking that timestamps are 2009 or newer for validity

--- a/tools/mavtomfile.py
+++ b/tools/mavtomfile.py
@@ -31,7 +31,7 @@ def process_tlog(filename):
     basename = '.'.join(tail.split('.')[:-1])
     mfilename = re.sub('[\.\-\+\*]','_', basename) + '.m'
     # Octave also doesn't like files that don't start with a letter
-    if (re.match('^[a-zA-z]', mfilename) == None):
+    if re.match('^[a-zA-z]', mfilename) is None:
         mfilename = 'm_' + mfilename
 
     if head is not None:


### PR DESCRIPTION
PEP8 [suggests](https://docs.quantifiedcode.com/python-anti-patterns/readability/comparison_to_none.html) to use `is None` to compare a value to `None`, instead of the equality operator.

This has an important consequence in the `parse_char` function in `mavgen_python.py`. When profiling a DroneKit-based application with yappi, I noticed that a lot of computation time (8.7%) was spent in the `__eq__` method of MAVLink message object.
After running my application for a few minutes, the profiler recorded 1.9 million calls to `MAVLink_attitude_message.__eq__`.
That was weird!

The problematic code resides in the [`parse_char` function](https://github.com/ArduPilot/pymavlink/blob/b4d048f16422ebe482593ff7ad0e35baaa92b833/generator/mavgen_python.py#L558):

```python
            if m != None:
                self.total_packets_received += 1
                self.__callbacks(m)
```

If `m` is not None, the inequality check results in a call to the [`__ne__()` method](https://github.com/ArduPilot/pymavlink/blob/b4d048f16422ebe482593ff7ad0e35baaa92b833/generator/mavgen_python.py#L162) of the `MAVLink_message` class, which in turn calls `__eq__`:

```python
    def __ne__(self, other):
        return not self.__eq__(other)
    def __eq__(self, other):
        if other == None:
            return False
```

By the way, if `other` is in turn a `MAVLink_message`, the equality operator would call `__eq__` again: **infinite loop**!

We can avoid the two function calls and the potential infinite loop by using the `is` operator to compare `m` with `None`.
I went ahead and searched for the same pattern in all the code.

This PR also simplifies [redundant binary comparisons](https://docs.quantifiedcode.com/python-anti-patterns/readability/comparison_to_true.html) (e.g. `== True`).