### PR TITLE
Improve skip debug

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -741,10 +741,11 @@ class DFReader_binary(DFReader):
                 self.id_to_name[mfmt.type] = mfmt.name
 
             ofs += mlen
-            new_pct = (100 * ofs) // self.data_len
-            if progress_callback is not None and new_pct != pct:
-                progress_callback(new_pct)
-                pct = new_pct
+            if progress_callback is not None:
+                new_pct = (100 * ofs) // self.data_len
+                if new_pct != pct:
+                    progress_callback(new_pct)
+                    pct = new_pct
 
         for i in range(256):
             self._count += self.counts[i]

--- a/DFReader.py
+++ b/DFReader.py
@@ -715,7 +715,8 @@ class DFReader_binary(DFReader):
 
             if lengths[mtype] == -1:
                 if not mtype in self.formats:
-                    print("unknown msg type 0x%02x" % mtype, file=sys.stderr)
+                    print("unknown msg type 0x%02x (%u)" % (mtype, mtype),
+                          file=sys.stderr)
                     break
                 self.offset = ofs
                 self._parse_next()

--- a/mavutil.py
+++ b/mavutil.py
@@ -361,7 +361,7 @@ class mavfile(object):
             if seq != seq2 and last_seq != -1:
                 diff = (seq2 - seq) % 256
                 self.mav_loss += diff
-                #print("lost %u seq=%u seq2=%u last_seq=%u src_system=%u %s" % (diff, seq, seq2, last_seq, src_system, msg.get_type()))
+                #print("lost %u seq=%u seq2=%u last_seq=%u src_tupe=%s %s" % (diff, seq, seq2, last_seq, str(src_tuple), msg.get_type()))
             self.last_seq[src_tuple] = seq2
             self.mav_count += 1
         


### PR DESCRIPTION
Knowing the previous type for a skipped message is very useful for working out how logs are corrupted.
