### PR TITLE
Update documentation for _mav_trim_payload

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -92,9 +92,11 @@ MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t *signing,
 }
 
 /**
- * return new packet length for trimming payload of any trailing zero
- * bytes. Used in MAVLink2 to give simple support for variable length
- * arrays.
+ * @brief Trim payload of any trailing zero-populated bytes (MAVLink 2 only).
+ *
+ * @param payload Serialised payload buffer.
+ * @param length Length of full-width payload buffer.
+ * @return Length of payload after empty bytes trimmed.
  */
 MAVLINK_HELPER uint8_t _mav_trim_payload(const char *payload, uint8_t length)
 {

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -96,7 +96,7 @@ MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t *signing,
  *
  * @param payload Serialised payload buffer.
  * @param length Length of full-width payload buffer.
- * @return Length of payload after empty bytes trimmed.
+ * @return Length of payload after zero-filled bytes are trimmed.
  */
 MAVLINK_HELPER uint8_t _mav_trim_payload(const char *payload, uint8_t length)
 {


### PR DESCRIPTION
The original docs state "Used in MAVLink2 to give simple support for variable length arrays.". 
MAVLink 2 does not support any kind of variable length arrays - the reordering rules mean that the smallest field types, whether an array or otherwise are ordered last, and these will be what gets truncated. In the guide we refer to behaviour here: https://mavlink.io/en/guide/serialization.html#payload_truncation

The new doc simply states what the method does.