### PR TITLE
Add centiseconds as SI_Unit

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -67,6 +67,7 @@
     <!-- time -->
     <xs:enumeration value="s"/>        <!-- seconds -->
     <xs:enumeration value="ds"/>       <!-- deciseconds -->
+    <xs:enumeration value="cs"/>       <!-- centiseconds -->
     <xs:enumeration value="ms"/>       <!-- milliseconds -->
     <xs:enumeration value="us"/>       <!-- microseconds -->
     <xs:enumeration value="Hz"/>       <!-- Herz -->


### PR DESCRIPTION
As discussed in mavlink/mavlink#1009 we have to add centiseconds as SI unit.

@amilcarlucas Is this all I had to change?