### PR TITLE
mavlogdump: fix csv output for binary logs

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -124,7 +124,7 @@ last_timestamp = None
 available_types = set()
 
 # for DF logs pre-calculate types list
-match_types=None
+match_types = ['FMT']
 if types is not None and hasattr(mlog, 'name_to_id'):
     for k in mlog.name_to_id.keys():
         if match_type(k, types):


### PR DESCRIPTION
issue reported on pymavlink gitter channel, reproduced in WSL and Ubuntu 18.04:
```
mavlogdump.py --types XKF0 --zero-time-base --format csv log7.bin > xkf0csv.txt
Traceback (most recent call last):
File "/home/skeyetech/.local/bin/mavlogdump.py", line 4, in <module>
import('pkg_resources').run_script('pymavlink==2.2.21', 'mavlogdump.py')
File "/usr/lib/python2.7/dist-packages/pkg_resources/init.py", line 719, in run_script
self.require(requires)[0].run_script(script_name, ns)
File "/usr/lib/python2.7/dist-packages/pkg_resources/init.py", line 1504, in run_script
exec(code, namespace, namespace)
File "/home/skeyetech/.local/lib/python2.7/site-packages/pymavlink-2.2.21-py2.7-linux-x86_64.egg/EGG-INFO/scripts/mavlogdump.py", line 239, in <module>
csv_out[0] = "{:.8f}".format(last_timestamp)
NameError: name 'csv_out' is not defined
```
this PR fixes the problem for me with Python 2.7