### PR TITLE
Make gps_velocity_body consider GPS z-velocity

### DIFF
--- a/mavextra.py
+++ b/mavextra.py
@@ -633,7 +633,14 @@ def gps_velocity_old(GPS_RAW_INT):
     return Vector3(GPS_RAW_INT.vel*0.01*cos(radians(GPS_RAW_INT.cog*0.01)),
                    GPS_RAW_INT.vel*0.01*sin(radians(GPS_RAW_INT.cog*0.01)), 0)
 
-def gps_velocity_body(GPS_RAW_INT, ATTITUDE):
+
+def gps_velocity_body_(GLOBAL_POSITION_INT, ATTITUDE):
+    '''return GPS velocity vector in body frame'''
+    r = rotation(ATTITUDE)
+    return r * Vector3(GLOBAL_POSITION_INT.vx, GLOBAL_POSITION_INT.vy, GLOBAL_POSITION_INT.vz) * 0.01
+
+
+def gps_velocity_body_old(GPS_RAW_INT, ATTITUDE):
     '''return GPS velocity vector in body frame'''
     r = rotation(ATTITUDE)
     return r.transposed() * Vector3(GPS_RAW_INT.vel*0.01*cos(radians(GPS_RAW_INT.cog*0.01)),


### PR DESCRIPTION
Fixed a bug where GPS z-velocity was not considered when rotating GPS velocity into body frame. This resulted in incorrect output from gps_velocity_body. The original gps_velocity_body has been renamed to gps_velocity_body_old for continuity.