### PR TITLE
mavschema: Add default and restricted attributes to params

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -31,6 +31,7 @@
         <xs:pattern value="\d{1,10}"/> <!-- base 10 int -->
         <xs:pattern value="0[xX][0-9a-fA-F]{1,8}"/> <!-- base 16 -->
         <xs:pattern value="0[bB][0-1]{1,32}"/> <!-- base 1 -->
+        <xs:pattern value="NaN"/> <!-- Allow not-a-number as a default (for params) -->
     </xs:restriction>
   </xs:simpleType>
 </xs:attribute>
@@ -145,6 +146,7 @@
 <xs:attribute name="increment" type="xs:float"/>                       <!-- parameter increment -->
 <xs:attribute name="minValue" type="xs:float"/>                        <!-- parameter minimum value -->
 <xs:attribute name="maxValue" type="xs:float"/>                        <!-- parameter maximum value -->
+<xs:attribute name="reserved" type="xs:boolean" default="false"/>      <!-- parameter is reserved -->
 
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
 <xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry has lat/lon/alt location -->
@@ -161,6 +163,8 @@
         <xs:attribute ref="increment"/>
         <xs:attribute ref="minValue"/>
         <xs:attribute ref="maxValue"/>
+        <xs:attribute ref="reserved"/>
+        <xs:attribute ref="default"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
MAV_CMD param values are current indicated as reserved using a tag content of "Reserved" or "Empty" (if no param is defined, this is also assumed to be reserved). The default value is typically default set by Mission Planner and QGC as 0, though sometimes a user will indicate default value of NaN in the description. 

> **Note** The default value is a bit of a pain for params, because once it is set to 0 or NaN the param can't be reused for a real param where the default value means anything other than "unchanged". Big discussion of reasons [here](https://github.com/mavlink/mavlink/issues/1050).

This PR adds `reserved` attribute to allow a param to explicitly be marked as reserved, and `default` to allow a default value (along with enabling `NaN` as a possible default).

@amilcarlucas @peterbarker I would love to further add tests to assert that NaN cannot be assigned to param 5, 6 (which can be sent in COMMAND_INT), and also to ensure that a unique index must be applied for every param. However when I try add xs:assertion I get error `WARNING: Unable to load XML validator libraries. XML validation will not be performed`. Any ideas on how to do this would be great, but otherwise happy for this to go in/be reviewed.