### PR TITLE
mavlink_helpers.h eliminate possibility of unaligned memory access

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -243,11 +243,13 @@ MAVLINK_HELPER uint16_t mavlink_finalize_message_buffer(mavlink_message_t* msg, 
 		buf[9] = (msg->msgid >> 16) & 0xFF;
 	}
 	
-	msg->checksum = crc_calculate(&buf[1], header_len-1);
-	crc_accumulate_buffer(&msg->checksum, _MAV_PAYLOAD(msg), msg->len);
-	crc_accumulate(crc_extra, &msg->checksum);
-	mavlink_ck_a(msg) = (uint8_t)(msg->checksum & 0xFF);
-	mavlink_ck_b(msg) = (uint8_t)(msg->checksum >> 8);
+	uint16_t checksum = crc_calculate(&buf[1], header_len-1);
+	crc_accumulate_buffer(&checksum, _MAV_PAYLOAD(msg), msg->len);
+	crc_accumulate(crc_extra, &checksum);
+	mavlink_ck_a(msg) = (uint8_t)(checksum & 0xFF);
+	mavlink_ck_b(msg) = (uint8_t)(checksum >> 8);
+
+	msg->checksum = checksum;
 
 	if (signing) {
 		mavlink_sign_packet(status->signing,


### PR DESCRIPTION
Likely fine in this case (checksum is the first field), but it's easy enough to avoid entirely and enable the warning. `-Waddress-of-packed-member` is on by default in GCC 9 and Clang 4.

	In file included from ../../mavlink/include/mavlink/v2.0/common/mavlink.h:32:
	In file included from ../../mavlink/include/mavlink/v2.0/common/common.h:30:
	In file included from ../../mavlink/include/mavlink/v2.0/common/../protocol.h:75:

	../../mavlink/include/mavlink/v2.0/mavlink_helpers.h:247:25: fatal error: taking address of packed member 'checksum' of class or structure '__mavlink_message' may result in an unaligned pointer value [-Waddress-of-packed-member]

		crc_accumulate_buffer(&msg->checksum, _MAV_PAYLOAD(msg), msg->len);

		                       ^~~~~~~~~~~~~

	1 error generated.
