### PR TITLE
mavlink_start_checksum() eliminate possibility of unaligned memory access

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -470,12 +470,16 @@ union __mavlink_bitfield {
 
 MAVLINK_HELPER void mavlink_start_checksum(mavlink_message_t* msg)
 {
-	crc_init(&msg->checksum);
+	uint16_t crcTmp = 0;
+	crc_init(&crcTmp);
+	msg->checksum = crcTmp;
 }
 
 MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c)
 {
-	crc_accumulate(c, &msg->checksum);
+	uint16_t checksum = msg->checksum;
+	crc_accumulate(c, &checksum);
+	msg->checksum = checksum;
 }
 
 /*


### PR DESCRIPTION
@peterbarker here's another one. https://github.com/ArduPilot/pymavlink/pull/267

![image](https://user-images.githubusercontent.com/84712/52524518-bf0e0280-2c6b-11e9-96dc-1e205b797f64.png)
