### PR TITLE
Support reserved/default params in generated libraries

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -316,6 +316,26 @@ class MAVXML(object):
         f.close()
    
 
+        #Post process to add reserved params (for docs)
+        for current_enum in self.enum:
+            if not 'MAV_CMD' in current_enum.name:
+                continue
+            print(current_enum.name)
+            for enum_entry in current_enum.entry:
+                print(enum_entry.name)
+                if len(enum_entry.param) == 7:
+                    continue
+                params_dict=dict()
+                for param_index in range (1,8):
+                    params_dict[param_index] = MAVEnumParam(param_index, label='', units='', enum='', increment='', 
+                                                        minValue='', maxValue='', default='0', reserved='True')
+
+                for a_param in enum_entry.param:
+                    params_dict[int(a_param.index)] = a_param
+                enum_entry.param=params_dict.values()
+                
+
+
         self.message_lengths = {}
         self.message_min_lengths = {}
         self.message_flags = {}

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -139,9 +139,27 @@ class MAVType(object):
         return len(self.fields[:self.extensions_start])
 
 class MAVEnumParam(object):
-    def __init__(self, index, description=''):
+    def __init__(self, index, description='', label='', units='', enum='', increment='', minValue='', maxValue='', reserved=False, default=''):
         self.index = index
         self.description = description
+        self.label = label
+        self.units = units
+        self.enum = enum
+        self.increment = increment
+        self.minValue = minValue
+        self.maxValue = maxValue
+        self.reserved = reserved
+        self.default = default
+        if self.reserved and not self.default:
+            self.default = '0'
+        self.set_description(description)
+
+    def set_description(self, description):
+        if not description.strip() and self.reserved:
+            self.description = 'Reserved (default:%s)' % self.default
+        else:
+            self.description = description
+        self.description = '%s: %s' % (self.index, self.description)
 
 class MAVEnumEntry(object):
     def __init__(self, name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0):
@@ -260,7 +278,13 @@ class MAVXML(object):
                 self.enum[-1].entry.append(MAVEnumEntry(attrs['name'], value, '', False, autovalue, self.filename, p.CurrentLineNumber))
             elif in_element == "mavlink.enums.enum.entry.param":
                 check_attrs(attrs, ['index'], 'enum param')
-                self.enum[-1].entry[-1].param.append(MAVEnumParam(attrs['index']))
+                self.enum[-1].entry[-1].param.append(
+                                                MAVEnumParam(attrs['index'], 
+                                                        label=attrs.get('label', ''), units=attrs.get('units', ''), 
+                                                        enum=attrs.get('enum', ''), increment=attrs.get('increment', ''), 
+                                                        minValue=attrs.get('minValue', ''), 
+                                                        maxValue=attrs.get('maxValue', ''), default=attrs.get('default', '0'), 
+                                                        reserved=attrs.get('reserved', False) ))
 
         def end_element(name):
             in_element_list.pop()
@@ -277,7 +301,7 @@ class MAVXML(object):
             elif in_element == "mavlink.enums.enum.entry.description":
                 self.enum[-1].entry[-1].description += data
             elif in_element == "mavlink.enums.enum.entry.param":
-                self.enum[-1].entry[-1].param[-1].description += data
+                self.enum[-1].entry[-1].param[-1].set_description(data.strip())
             elif in_element == "mavlink.version":
                 self.version = int(data)
             elif in_element == "mavlink.include":
@@ -290,6 +314,7 @@ class MAVXML(object):
         p.CharacterDataHandler = char_data
         p.ParseFile(f)
         f.close()
+   
 
         self.message_lengths = {}
         self.message_min_lengths = {}


### PR DESCRIPTION
XML definition files can now declare command params as reserved and define a default value of 0 or NaN. If a param is not declared it is assumed to be reserved with default of zero.

What this PR does is implement that behaviour and generate improved docs:
- adds a numeric prefix (e.g. **3. Param description**) for all `param` value descriptions. This makes it much easier to work out what text maps to which param, and makes it clear that you're in a param even if it has no description.
- adds standard text for reserved values
- Creates "reserved" params for index values that were not declared in XML. This improves docs, but also means we can remove all reserved params from XML if we want. 

The change is in the stored description in the parser, so will flow to all outputs.

It doesn't prevent someone declaring param 6 or 5 as reserved values with NaN default value (which is invalid when sending in COMMAND_INT). My understanding is that the schema should prevent that in validation, but the parser should respect XML  if validation is not run (?)