### PR TITLE
mavgen_wlua: link version byte to corresponding hex dump

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -271,7 +271,7 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
             if (buffer:len() - 2 - offset > 6) then
                 -- normal header
                 local header = subtree:add("Header")
-                header:add(f.magic,version)
+                header:add(f.magic, buffer(offset,1), version)
                 offset = offset + 1
             
                 local length = buffer(offset,1)
@@ -305,7 +305,7 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
             if (buffer:len() - 2 - offset > 10) then
                 -- normal header
                 local header = subtree:add("Header")
-                header:add(f.magic,version)
+                header:add(f.magic, buffer(offset,1), version)
                 offset = offset + 1
                 local length = buffer(offset,1)
                 header:add(f.length, length)


### PR DESCRIPTION
before:

<img src="https://user-images.githubusercontent.com/46489434/53682383-4d1e5b80-3cf5-11e9-81fb-aaa7135ed1fc.png" width="400" />

after:

<img src="https://user-images.githubusercontent.com/46489434/53682387-53143c80-3cf5-11e9-9ce8-e3dc198aa1fe.png" width="400" />

When analyzing a packet in Wireshark, evey field should be linked to a slice of the hex dump. This already happens with most of the fields, it does not happen with the version field.
This PR fixes the problem and links the version byte to the corresponding slice of the hex dump.

