### PR TITLE
mavgen_wlua: add missing v2.0 fields

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -90,6 +90,8 @@ def generate_body_fields(outf):
 """
 f.magic = ProtoField.uint8("mavlink_proto.magic", "Magic value / version", base.HEX)
 f.length = ProtoField.uint8("mavlink_proto.length", "Payload length")
+f.incompatibility_flag = ProtoField.uint8("mavlink_proto.incompatibility_flag", "Incompatibility flag")
+f.compatibility_flag = ProtoField.uint8("mavlink_proto.compatibility_flag", "Compatibility flag")
 f.sequence = ProtoField.uint8("mavlink_proto.sequence", "Packet sequence")
 f.sysid = ProtoField.uint8("mavlink_proto.sysid", "System id", base.HEX)
 f.compid = ProtoField.uint8("mavlink_proto.compid", "Component id", base.HEX)
@@ -309,7 +311,13 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                 offset = offset + 1
                 local length = buffer(offset,1)
                 header:add(f.length, length)
-                offset = offset + 3
+                offset = offset + 1
+                local incompatibility_flag = buffer(offset,1)
+                header:add(f.incompatibility_flag, incompatibility_flag)
+                offset = offset + 1
+                local compatibility_flag = buffer(offset,1)
+                header:add(f.compatibility_flag, compatibility_flag)
+                offset = offset + 1
                 local sequence = buffer(offset,1)
                 header:add(f.sequence, sequence)
                 offset = offset + 1


### PR DESCRIPTION
before:

<img src="https://user-images.githubusercontent.com/46489434/53683373-67116b80-3d00-11e9-910f-9b0812d4c307.png" width="400" />

after:

<img src="https://user-images.githubusercontent.com/46489434/53683394-9922cd80-3d00-11e9-84d4-230c4f7239ee.png" width="400" />

This PR allows the Wireshark plugin to parse and display two fields that were added in Mavlink v2.0:
* incompatibility flag
* compatibility flag

These are currently skipped. In particular, adding the incompatibility flag is the first step in implementing signature parsing (which is also missing).
