### PR TITLE
mavgen_wlua: fix parsing of v2.0 message ids

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -93,7 +93,7 @@ f.length = ProtoField.uint8("mavlink_proto.length", "Payload length")
 f.sequence = ProtoField.uint8("mavlink_proto.sequence", "Packet sequence")
 f.sysid = ProtoField.uint8("mavlink_proto.sysid", "System id", base.HEX)
 f.compid = ProtoField.uint8("mavlink_proto.compid", "Component id", base.HEX)
-f.msgid = ProtoField.uint8("mavlink_proto.msgid", "Message id", base.HEX)
+f.msgid = ProtoField.uint24("mavlink_proto.msgid", "Message id", base.HEX)
 f.crc = ProtoField.uint16("mavlink_proto.crc", "Message CRC", base.HEX)
 f.payload = ProtoField.uint8("mavlink_proto.payload", "Payload", base.DEC, messageName)
 f.rawheader = ProtoField.bytes("mavlink_proto.rawheader", "Unparsable header fragment")
@@ -320,17 +320,9 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                 header:add(f.compid, compid)
                 offset = offset + 1
                 pinfo.cols.src = "System: "..tostring(sysid:uint())..', Component: '..tostring(compid:uint())
-                local msgidt1 = buffer(offset,1):uint()
-                offset = offset + 1
-                local msgidt2 = buffer(offset,1):uint()
-                offset = offset + 1
-                local msgidt3 = buffer(offset,1):uint()
-                msgidt1 = bit.rshift(msgidt1, 8)
-                msgidt2 = bit.rshift(msgidt2, 16)
-                msgid = msgidt1+msgidt2+msgidt3
-                header:add(f.msgid, msgid)
-                print(msgid)
-                offset = offset + 2
+                msgid = buffer(offset,3):le_uint()
+                header:add(f.msgid, buffer(offset,3), msgid)
+                offset = offset + 3
             end
         end
 


### PR DESCRIPTION
before:

<img src="https://user-images.githubusercontent.com/46489434/53683767-e86afd00-3d04-11e9-8615-679307a7aeba.png" width="400" />

after:

<img src="https://user-images.githubusercontent.com/46489434/53683769-eacd5700-3d04-11e9-8145-345e86db282e.png" width="400" />

Message ids of v2.0 frames are parsed in a completely wrong way, consequently payloads are not identified and frames are not displayed correctly.

Message IDs are saved in up to 3 bytes (24 bits) (1 byte in v1.0, 3 bytes in v2.0).

What the original author did:
* take the 1st byte, right shift by 8, i.e. 255 >> 8, always resulting in zero.
* take the 2nd byte, right shift by 16, i.e. 255 >> 16, always resulting in zero.
* take the 3rd byte, summing all three up and putting the result in a byte (mess is complete).

What i did:
* take all 3 bytes together, parse them as a single 24bits, little endian, unsigned number
* put the result in a uint24.

PS: the Wireshark Lua dissector has a huge quantity of bugs, and it's a pity since it could be a good entry point for people who wants to approach the protocol and understand how it works.
