### PR TITLE
fix MAVLink_bad_data being initialized with str instead of bytearray

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -577,7 +577,7 @@ class MAVLink(object):
                 magic = self.buf[self.buf_index]
                 self.buf_index += 1
                 if self.robust_parsing:
-                    m = MAVLink_bad_data(chr(magic), 'Bad prefix')
+                    m = MAVLink_bad_data(bytearray([magic]), 'Bad prefix')
                     self.expected_length = header_len+2
                     self.total_receive_errors += 1
                     return m


### PR DESCRIPTION
This broke MAVProxy under Python3, see this issue: https://github.com/ArduPilot/MAVProxy/issues/600