### PR TITLE
mavgen_wlua: add support for interpreting truncated MAVLink 2.0 packets

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -168,9 +168,19 @@ def generate_field_dissector(outf, msg, field):
             index_text = ''
         t.write(outf,
 """
-    tree:add_le(f.${fmsg}_${fname}${findex}, buffer(offset, ${fbytes}))
-    offset = offset + ${fbytes}
-    
+    if (truncated) then
+        tree:add_le(f.${fmsg}_${fname}${findex}, 0)
+    elseif (offset + ${fbytes} <= limit) then
+        tree:add_le(f.${fmsg}_${fname}${findex}, buffer(offset, ${fbytes}))
+        offset = offset + ${fbytes}
+    elseif (offset < limit) then
+        tree:add_le(f.${fmsg}_${fname}${findex}, buffer(offset, limit - offset))
+        offset = limit
+        truncated = true
+    else
+        tree:add_le(f.${fmsg}_${fname}${findex}, 0)
+        truncated = true
+    end
 """, {'fname':field.name, 'ftype':mtype, 'fmsg': msg.name, 'fbytes':size, 'findex':index_text})
     
 
@@ -179,7 +189,8 @@ def generate_payload_dissector(outf, msg):
     t.write(outf, 
 """
 -- dissect payload of message type ${msgname}
-function payload_fns.payload_${msgid}(buffer, tree, msgid, offset)
+function payload_fns.payload_${msgid}(buffer, tree, msgid, offset, limit)
+    local truncated = false
 """, {'msgid':msg.id, 'msgname':msg.name})
     
     for f in msg.ordered_fields:
@@ -239,9 +250,9 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                     -- no magic value found in the whole buffer. print the raw data and exit
                     if (unknownFrameBeginOffset ~= 0) then
                         if (msgCount == 1) then
-                            pinfo.cols.info:set("Unkown message")
+                            pinfo.cols.info:set("Unknown message")
                         else
-                            pinfo.cols.info:append("  Unkown message")
+                            pinfo.cols.info:append("  Unknown message")
                         end
                         size = offset - unknownFrameBeginOffset
                         subtree:add(f.rawpayload, buffer(unknownFrameBeginOffset,size))
@@ -253,7 +264,7 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
         end
         
         if (unknownFrameBeginOffset ~= 0) then
-            pinfo.cols.info:append("Unkown message22")
+            pinfo.cols.info:append("Unknown message")
             size = offset - unknownFrameBeginOffset
             subtree:add(f.rawpayload, buffer(unknownFrameBeginOffset,size))
             unknownFrameBeginOffset = 0
@@ -267,6 +278,8 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
         -- HEADER ----------------------------------------
     
         local msgid
+        local length
+
         if (version == 0xfe) then
             if (buffer:len() - 2 - offset > 6) then
                 -- normal header
@@ -274,7 +287,7 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                 header:add(f.magic, buffer(offset,1), version)
                 offset = offset + 1
             
-                local length = buffer(offset,1)
+                length = buffer(offset,1)
                 header:add(f.length, length)
                 offset = offset + 1
             
@@ -307,7 +320,7 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                 local header = subtree:add("Header")
                 header:add(f.magic, buffer(offset,1), version)
                 offset = offset + 1
-                local length = buffer(offset,1)
+                length = buffer(offset,1)
                 header:add(f.length, length)
                 offset = offset + 3
                 local sequence = buffer(offset,1)
@@ -323,6 +336,11 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
                 msgid = buffer(offset,3):le_uint()
                 header:add(f.msgid, buffer(offset,3), msgid)
                 offset = offset + 3
+            else 
+                -- handle truncated header
+                local hsize = buffer:len() - 2 - offset
+                subtree:add(f.rawheader, buffer(offset, hsize))
+                offset = offset + hsize
             end
         end
 
@@ -333,10 +351,21 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
         local msgnr = msgid
         local dissect_payload_fn = "payload_"..tostring(msgnr)
         local fn = payload_fns[dissect_payload_fn]
+        local limit = buffer:len() - 2
+
+        if (length) then
+            length = length:uint()
+        else
+            length = 0
+        end
+
+        if (offset + length < limit) then
+            limit = offset + length
+        end
     
         if (fn == nil) then
-            pinfo.cols.info:append ("Unkown message type   ")
-            subtree:add_expert_info(PI_MALFORMED, PI_ERROR, "Unkown message type")
+            pinfo.cols.info:append ("Unknown message type   ")
+            subtree:add_expert_info(PI_MALFORMED, PI_ERROR, "Unknown message type")
             size = buffer:len() - 2 - offset
             subtree:add(f.rawpayload, buffer(offset,size))
             offset = offset + size
@@ -349,7 +378,8 @@ function mavlink_proto.dissector(buffer,pinfo,tree)
             else
                 pinfo.cols.info:append("   "..messageName[msgid])
             end
-            offset = fn(buffer, payload, msgid, offset)
+            fn(buffer, payload, msgid, offset, limit)
+            offset = limit
         end
 
         -- CRC ----------------------------------------


### PR DESCRIPTION
This PR adds support for interpreting truncated MAVLink 2.0 packets where the trailing zero bytes are omitted in order to reduce the packet size.

The PR also includes the changes authored by @gswly in #279, #281 and #284 (thanks a lot!). In order to track authorship properly, I would advise merging #279, #281 and #284 first; then I can rebase my PR on the then-current master revision.
