### PR TITLE
DFReader.py: partial fix for string decoding issue

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -106,6 +106,10 @@ class DFFormat(object):
 def to_string(s):
     '''desperate attempt to convert a string regardless of what garbage we get'''
     try:
+        return s.decode("utf-8")
+    except Exception as e:
+        pass
+    try:
         s2 = s.encode('utf-8', 'ignore')
         x = u"%s" % s2
         return s2


### PR DESCRIPTION
Essentially a partial revert of fc57c0943a9a6b03d18ef801d256b95d43cd3ff6

I'm pretty sure the original patch is complete bogus - doing an encode rather than a debug...
