### PR TITLE
mavprase.py: stop magically prefixing descriptions with their index

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -159,7 +159,6 @@ class MAVEnumParam(object):
             self.description = 'Reserved (default:%s)' % self.default
         else:
             self.description = description
-        self.description = '%s: %s' % (self.index, self.description)
 
 class MAVEnumEntry(object):
     def __init__(self, name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0):


### PR DESCRIPTION
This breaks MAVProxy's waypoint display as it string-matches against
this description.

The value should be available as separate metadata anyway so any user of
the metadata should be able to synthesise this themselves.

@hamishwillee https://github.com/ArduPilot/pymavlink/pull/269/files#diff-47dc7d87fdc00f28b7816950fba41176R162 added this line.  I wish to remove it.  Was this vital for something you were doing?
