### PR TITLE
MAVLink v2 C library efficiency improvements

### DIFF
--- a/generator/C/include_v2.0/checksum.h
+++ b/generator/C/include_v2.0/checksum.h
@@ -32,17 +32,16 @@ extern "C" {
  * @param data new char to hash
  * @param crcAccum the already accumulated checksum
  **/
-static inline void crc_accumulate(uint8_t data, uint16_t *crcAccum)
+static inline void crc_accumulate(uint8_t data, uint16_t* crcAccum)
 {
-        /*Accumulate one byte of data into the CRC*/
-        uint8_t tmp;
+    /*Accumulate one byte of data into the CRC*/
+    uint8_t tmp;
 
-        tmp = data ^ (uint8_t)(*crcAccum &0xff);
-        tmp ^= (tmp<<4);
-        *crcAccum = (*crcAccum>>8) ^ (tmp<<8) ^ (tmp <<3) ^ (tmp>>4);
+    tmp = data ^ (uint8_t)(*crcAccum &0xff);
+    tmp ^= (tmp<<4);
+    *crcAccum = (*crcAccum>>8) ^ (tmp<<8) ^ (tmp <<3) ^ (tmp>>4);
 }
 #endif
-
 
 /**
  * @brief Initiliaze the buffer for the X.25 CRC
@@ -51,9 +50,8 @@ static inline void crc_accumulate(uint8_t data, uint16_t *crcAccum)
  */
 static inline void crc_init(uint16_t* crcAccum)
 {
-        *crcAccum = X25_INIT_CRC;
+    *crcAccum = X25_INIT_CRC;
 }
-
 
 /**
  * @brief Calculates the X.25 checksum on a byte buffer
@@ -64,14 +62,13 @@ static inline void crc_init(uint16_t* crcAccum)
  **/
 static inline uint16_t crc_calculate(const uint8_t* pBuffer, uint16_t length)
 {
-        uint16_t crcTmp;
-        crc_init(&crcTmp);
-	while (length--) {
-                crc_accumulate(*pBuffer++, &crcTmp);
-        }
-        return crcTmp;
+    uint16_t crcTmp;
+    crc_init(&crcTmp);
+    while (length--) {
+        crc_accumulate(*pBuffer++, &crcTmp);
+    }
+    return crcTmp;
 }
-
 
 /**
  * @brief Accumulate the X.25 CRC by adding an array of bytes
@@ -82,12 +79,12 @@ static inline uint16_t crc_calculate(const uint8_t* pBuffer, uint16_t length)
  * @param data new bytes to hash
  * @param crcAccum the already accumulated checksum
  **/
-static inline void crc_accumulate_buffer(uint16_t *crcAccum, const char *pBuffer, uint16_t length)
+static inline void crc_accumulate_buffer(uint16_t* crcAccum, const char* pBuffer, uint16_t length)
 {
-	const uint8_t *p = (const uint8_t *)pBuffer;
-	while (length--) {
-                crc_accumulate(*p++, crcAccum);
-        }
+    const uint8_t* p = (const uint8_t*)pBuffer;
+    while (length--) {
+        crc_accumulate(*p++, crcAccum);
+    }
 }
 
 #if defined(MAVLINK_USE_CXX_NAMESPACE) || defined(__cplusplus)

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -16,6 +16,8 @@
 namespace mavlink {
 #endif
 
+//FUNCTIONS WHICH THE USER MIGHT MODIFY
+
 /*
  * Internal function to give access to the channel status for each channel
  */
@@ -23,12 +25,12 @@ namespace mavlink {
 MAVLINK_HELPER mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
 {
 #ifdef MAVLINK_EXTERNAL_RX_STATUS
-	// No m_mavlink_status array defined in function,
-	// has to be defined externally
+    // No m_mavlink_status array defined in function,
+    // has to be defined externally
 #else
-	static mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
+    static mavlink_status_t m_mavlink_status[MAVLINK_COMM_NUM_BUFFERS];
 #endif
-	return &m_mavlink_status[chan];
+    return &m_mavlink_status[chan];
 }
 #endif
 
@@ -38,58 +40,203 @@ MAVLINK_HELPER mavlink_status_t* mavlink_get_channel_status(uint8_t chan)
 #ifndef MAVLINK_GET_CHANNEL_BUFFER
 MAVLINK_HELPER mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan)
 {
-	
 #ifdef MAVLINK_EXTERNAL_RX_BUFFER
-	// No m_mavlink_buffer array defined in function,
-	// has to be defined externally
+    // No m_mavlink_buffer array defined in function,
+    // has to be defined externally
 #else
-	static mavlink_message_t m_mavlink_buffer[MAVLINK_COMM_NUM_BUFFERS];
+    static mavlink_message_t m_mavlink_buffer[MAVLINK_COMM_NUM_BUFFERS];
 #endif
-	return &m_mavlink_buffer[chan];
+    return &m_mavlink_buffer[chan];
 }
 #endif // MAVLINK_GET_CHANNEL_BUFFER
+
+#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
+// To make MAVLink work on your MCU, define comm_send_ch() if you wish
+// to send 1 byte at a time, or MAVLINK_SEND_UART_BYTES() to send a
+// whole packet at a time
+/*
+#include "mavlink_types.h"
+
+void comm_send_ch(mavlink_channel_t chan, uint8_t ch)
+{
+    if (chan == MAVLINK_COMM_0) {
+        uart0_transmit(ch);
+    }
+    if (chan == MAVLINK_COMM_1) {
+        uart1_transmit(ch);
+    }
+}
+ */
+MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char* buf, uint16_t len)
+{
+#ifdef MAVLINK_SEND_UART_BYTES
+    /* this is the more efficient approach, if the platform defines it */
+    MAVLINK_SEND_UART_BYTES(chan, (const uint8_t*)buf, len);
+#else
+    /* fallback to one byte at a time */
+    uint16_t i;
+    for (i = 0; i < len; i++) {
+        comm_send_ch(chan, (uint8_t)buf[i]);
+    }
+#endif
+}
+#endif // MAVLINK_USE_CONVENIENCE_FUNCTIONS
+
+//MISCELANEOUS
 
 /**
  * @brief Reset the status of a channel.
  */
 MAVLINK_HELPER void mavlink_reset_channel_status(uint8_t chan)
 {
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-	status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+    mavlink_status_t* status = mavlink_get_channel_status(chan);
+    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+}
+
+/**
+ * Set the protocol version
+ */
+MAVLINK_HELPER void mavlink_set_proto_version(uint8_t chan, unsigned int version)
+{
+    mavlink_status_t* status = mavlink_get_channel_status(chan);
+    if (version > 1) {
+        status->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
+    } else {
+        status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
+    }
+}
+
+/**
+ * Get the protocol version
+ *
+ * @return 1 for v1, 2 for v2
+ */
+MAVLINK_HELPER unsigned int mavlink_get_proto_version(uint8_t chan)
+{
+    mavlink_status_t* status = mavlink_get_channel_status(chan);
+    if ((status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) > 0) {
+        return 1;
+    } else {
+        return 2;
+    }
 }
 
 /**
  * @brief create a signature block for a packet
  */
-MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t *signing,
-					   uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN],
-					   const uint8_t *header, uint8_t header_len,
-					   const uint8_t *packet, uint8_t packet_len,
-					   const uint8_t crc[2])
+MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t* signing,
+                                uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN],
+                                const uint8_t* header, uint8_t header_len,
+                                const uint8_t* packet, uint8_t packet_len,
+                                const uint8_t crc[2])
 {
-	mavlink_sha256_ctx ctx;
-	union {
-	    uint64_t t64;
-	    uint8_t t8[8];
-	} tstamp;
-	if (signing == NULL || !(signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
-	    return 0;
-	}
-	signature[0] = signing->link_id;
-	tstamp.t64 = signing->timestamp;
-	memcpy(&signature[1], tstamp.t8, 6);
-	signing->timestamp++;
-	
-	mavlink_sha256_init(&ctx);
-	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
-	mavlink_sha256_update(&ctx, header, header_len);
-	mavlink_sha256_update(&ctx, packet, packet_len);
-	mavlink_sha256_update(&ctx, crc, 2);
-	mavlink_sha256_update(&ctx, signature, 7);
-	mavlink_sha256_final_48(&ctx, &signature[7]);
-	
-	return MAVLINK_SIGNATURE_BLOCK_LEN;
+    mavlink_sha256_ctx ctx;
+    union {
+        uint64_t t64;
+        uint8_t t8[8];
+    } tstamp;
+    if (signing == NULL || !(signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING)) {
+        return 0;
+    }
+    signature[0] = signing->link_id;
+    tstamp.t64 = signing->timestamp;
+    memcpy(&signature[1], tstamp.t8, 6);
+    signing->timestamp++;
+
+    mavlink_sha256_init(&ctx);
+    mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
+    mavlink_sha256_update(&ctx, header, header_len);
+    mavlink_sha256_update(&ctx, packet, packet_len);
+    mavlink_sha256_update(&ctx, crc, 2);
+    mavlink_sha256_update(&ctx, signature, 7);
+    mavlink_sha256_final_48(&ctx, &signature[7]);
+
+    return MAVLINK_SIGNATURE_BLOCK_LEN;
 }
+
+/**
+ * @brief check a signature block for a packet
+ */
+MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t* signing,
+                                mavlink_signing_streams_t* signing_streams,
+                                const mavlink_message_t* msg)
+{
+    if (signing == NULL) {
+        return true;
+    }
+    const uint8_t* p = (const uint8_t*)&msg->magic;
+    const uint8_t* psig = msg->signature;
+    const uint8_t* incoming_signature = psig+7;
+    mavlink_sha256_ctx ctx;
+    uint8_t signature[6];
+    uint16_t i;
+
+    mavlink_sha256_init(&ctx);
+    mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
+    mavlink_sha256_update(&ctx, p, MAVLINK_CORE_HEADER_LEN+1+msg->len);
+    mavlink_sha256_update(&ctx, msg->ck, 2);
+    mavlink_sha256_update(&ctx, psig, 1+6);
+    mavlink_sha256_final_48(&ctx, signature);
+    if (memcmp(signature, incoming_signature, 6) != 0) {
+        return false;
+    }
+
+    // now check timestamp
+    union tstamp {
+        uint64_t t64;
+        uint8_t t8[8];
+    } tstamp;
+    uint8_t link_id = psig[0];
+    tstamp.t64 = 0;
+    memcpy(tstamp.t8, psig+1, 6);
+
+    if (signing_streams == NULL) {
+        return false;
+    }
+
+    // find stream
+    for (i=0; i<signing_streams->num_signing_streams; i++) {
+        if (msg->sysid == signing_streams->stream[i].sysid &&
+            msg->compid == signing_streams->stream[i].compid &&
+            link_id == signing_streams->stream[i].link_id) {
+            break;
+        }
+    }
+    if (i == signing_streams->num_signing_streams) {
+        if (signing_streams->num_signing_streams >= MAVLINK_MAX_SIGNING_STREAMS) {
+            // over max number of streams
+            return false;
+        }
+        // new stream. Only accept if timestamp is not more than 1 minute old
+        if (tstamp.t64 + 6000*1000UL < signing->timestamp) {
+            return false;
+        }
+        // add new stream
+        signing_streams->stream[i].sysid = msg->sysid;
+        signing_streams->stream[i].compid = msg->compid;
+        signing_streams->stream[i].link_id = link_id;
+        signing_streams->num_signing_streams++;
+    } else {
+        union tstamp last_tstamp;
+        last_tstamp.t64 = 0;
+        memcpy(last_tstamp.t8, signing_streams->stream[i].timestamp_bytes, 6);
+        if (tstamp.t64 <= last_tstamp.t64) {
+            // repeating old timestamp
+            return false;
+        }
+    }
+
+    // remember last timestamp
+    memcpy(signing_streams->stream[i].timestamp_bytes, psig+1, 6);
+
+    // our next timestamp must be at least this timestamp
+    if (tstamp.t64 > signing->timestamp) {
+        signing->timestamp = tstamp.t64;
+    }
+    return true;
+}
+
+// FINALIZE AND SEND FUNCTIONS
 
 /**
  * @brief Trim payload of any trailing zero-populated bytes (MAVLink 2 only).
@@ -98,99 +245,16 @@ MAVLINK_HELPER uint8_t mavlink_sign_packet(mavlink_signing_t *signing,
  * @param length Length of full-width payload buffer.
  * @return Length of payload after zero-filled bytes are trimmed.
  */
-MAVLINK_HELPER uint8_t _mav_trim_payload(const char *payload, uint8_t length)
+MAVLINK_HELPER uint8_t _mav_trim_payload(const char* payload, uint8_t length)
 {
-	while (length > 1 && payload[length-1] == 0) {
-		length--;
-	}
-	return length;
+    while (length > 1 && payload[length-1] == 0) {
+        length--;
+    }
+    return length;
 }
 
 /**
- * @brief check a signature block for a packet
- */
-MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t *signing,
-					    mavlink_signing_streams_t *signing_streams,
-					    const mavlink_message_t *msg)
-{
-	if (signing == NULL) {
-		return true;
-	}
-        const uint8_t *p = (const uint8_t *)&msg->magic;
-	const uint8_t *psig = msg->signature;
-        const uint8_t *incoming_signature = psig+7;
-	mavlink_sha256_ctx ctx;
-	uint8_t signature[6];
-	uint16_t i;
-        
-	mavlink_sha256_init(&ctx);
-	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
-	mavlink_sha256_update(&ctx, p, MAVLINK_CORE_HEADER_LEN+1+msg->len);
-	mavlink_sha256_update(&ctx, msg->ck, 2);
-	mavlink_sha256_update(&ctx, psig, 1+6);
-	mavlink_sha256_final_48(&ctx, signature);
-	if (memcmp(signature, incoming_signature, 6) != 0) {
-		return false;
-	}
-
-	// now check timestamp
-	union tstamp {
-	    uint64_t t64;
-	    uint8_t t8[8];
-	} tstamp;
-	uint8_t link_id = psig[0];
-	tstamp.t64 = 0;
-	memcpy(tstamp.t8, psig+1, 6);
-
-	if (signing_streams == NULL) {
-		return false;
-	}
-	
-	// find stream
-	for (i=0; i<signing_streams->num_signing_streams; i++) {
-		if (msg->sysid == signing_streams->stream[i].sysid &&
-		    msg->compid == signing_streams->stream[i].compid &&
-		    link_id == signing_streams->stream[i].link_id) {
-			break;
-		}
-	}
-	if (i == signing_streams->num_signing_streams) {
-		if (signing_streams->num_signing_streams >= MAVLINK_MAX_SIGNING_STREAMS) {
-			// over max number of streams
-			return false;
-		}
-		// new stream. Only accept if timestamp is not more than 1 minute old
-		if (tstamp.t64 + 6000*1000UL < signing->timestamp) {
-			return false;
-		}
-		// add new stream
-		signing_streams->stream[i].sysid = msg->sysid;
-		signing_streams->stream[i].compid = msg->compid;
-		signing_streams->stream[i].link_id = link_id;
-		signing_streams->num_signing_streams++;
-	} else {
-		union tstamp last_tstamp;
-		last_tstamp.t64 = 0;
-		memcpy(last_tstamp.t8, signing_streams->stream[i].timestamp_bytes, 6);
-		if (tstamp.t64 <= last_tstamp.t64) {
-			// repeating old timestamp
-			return false;
-		}
-	}
-
-	// remember last timestamp
-	memcpy(signing_streams->stream[i].timestamp_bytes, psig+1, 6);
-
-	// our next timestamp must be at least this timestamp
-	if (tstamp.t64 > signing->timestamp) {
-		signing->timestamp = tstamp.t64;
-	}
-	return true;
-}
-
-
-/**
- * @brief Finalize a MAVLink message with channel assignment
+ * @brief Finalize a MAVLink message
  *
  * This function calculates the checksum and sets length and aircraft id correctly.
  * It assumes that the message id and the payload are already correctly set. This function
@@ -202,161 +266,162 @@ MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t *signing,
  * @param length Message length
  */
 MAVLINK_HELPER uint16_t mavlink_finalize_message_buffer(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
-						      mavlink_status_t* status, uint8_t min_length, uint8_t length, uint8_t crc_extra)
+                                mavlink_status_t* status, uint8_t min_length, uint8_t length, uint8_t crc_extra)
 {
-	bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
-	bool signing = 	(!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
-	uint8_t signature_len = signing? MAVLINK_SIGNATURE_BLOCK_LEN : 0;
-        uint8_t header_len = MAVLINK_CORE_HEADER_LEN+1;
-	uint8_t buf[MAVLINK_CORE_HEADER_LEN+1];
-	if (mavlink1) {
-		msg->magic = MAVLINK_STX_MAVLINK1;
-		header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN+1;
-	} else {
-		msg->magic = MAVLINK_STX;
-	}
-	msg->len = mavlink1?min_length:_mav_trim_payload(_MAV_PAYLOAD(msg), length);
-	msg->sysid = system_id;
-	msg->compid = component_id;
-	msg->incompat_flags = 0;
-	if (signing) {
-		msg->incompat_flags |= MAVLINK_IFLAG_SIGNED;
-	}
-	msg->compat_flags = 0;
-	msg->seq = status->current_tx_seq;
-	status->current_tx_seq = status->current_tx_seq + 1;
+    bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
+    bool signing =  (!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
+    uint8_t signature_len = signing ? MAVLINK_SIGNATURE_BLOCK_LEN : 0;
+    uint8_t header_len = MAVLINK_CORE_HEADER_LEN+1;
+    uint8_t buf[MAVLINK_CORE_HEADER_LEN+1];
+    if (mavlink1) {
+        msg->magic = MAVLINK_STX_MAVLINK1;
+        header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN+1;
+    } else {
+        msg->magic = MAVLINK_STX;
+    }
+    msg->len = mavlink1 ? min_length : _mav_trim_payload(_MAV_PAYLOAD(msg), length);
+    msg->sysid = system_id;
+    msg->compid = component_id;
+    msg->incompat_flags = 0;
+    if (signing) {
+        msg->incompat_flags |= MAVLINK_IFLAG_SIGNED;
+    }
+    msg->compat_flags = 0;
+    msg->seq = status->current_tx_seq;
+    status->current_tx_seq = status->current_tx_seq + 1;
 
-	// form the header as a byte array for the crc
-	buf[0] = msg->magic;
-	buf[1] = msg->len;
-	if (mavlink1) {
-		buf[2] = msg->seq;
-		buf[3] = msg->sysid;
-		buf[4] = msg->compid;
-		buf[5] = msg->msgid & 0xFF;
-	} else {
-		buf[2] = msg->incompat_flags;
-		buf[3] = msg->compat_flags;
-		buf[4] = msg->seq;
-		buf[5] = msg->sysid;
-		buf[6] = msg->compid;
-		buf[7] = msg->msgid & 0xFF;
-		buf[8] = (msg->msgid >> 8) & 0xFF;
-		buf[9] = (msg->msgid >> 16) & 0xFF;
-	}
-	
-	uint16_t checksum = crc_calculate(&buf[1], header_len-1);
-	crc_accumulate_buffer(&checksum, _MAV_PAYLOAD(msg), msg->len);
-	crc_accumulate(crc_extra, &checksum);
-	mavlink_ck_a(msg) = (uint8_t)(checksum & 0xFF);
-	mavlink_ck_b(msg) = (uint8_t)(checksum >> 8);
+    // form the header as a byte array for the crc
+    buf[0] = msg->magic;
+    buf[1] = msg->len;
+    if (mavlink1) {
+        buf[2] = msg->seq;
+        buf[3] = msg->sysid;
+        buf[4] = msg->compid;
+        buf[5] = msg->msgid & 0xFF;
+    } else {
+        buf[2] = msg->incompat_flags;
+        buf[3] = msg->compat_flags;
+        buf[4] = msg->seq;
+        buf[5] = msg->sysid;
+        buf[6] = msg->compid;
+        buf[7] = msg->msgid & 0xFF;
+        buf[8] = (msg->msgid >> 8) & 0xFF;
+        buf[9] = (msg->msgid >> 16) & 0xFF;
+    }
+    
+    uint16_t checksum = crc_calculate(&buf[1], header_len-1);
+    crc_accumulate_buffer(&checksum, _MAV_PAYLOAD(msg), msg->len);
+    crc_accumulate(crc_extra, &checksum);
+    mavlink_ck_a(msg) = (uint8_t)(checksum & 0xFF);
+    mavlink_ck_b(msg) = (uint8_t)(checksum >> 8);
 
-	msg->checksum = checksum;
+    msg->checksum = checksum;
 
-	if (signing) {
-		mavlink_sign_packet(status->signing,
-				    msg->signature,
-				    (const uint8_t *)buf, header_len,
-				    (const uint8_t *)_MAV_PAYLOAD(msg), msg->len,
-				    (const uint8_t *)_MAV_PAYLOAD(msg)+(uint16_t)msg->len);
-	}
-	
-	return msg->len + header_len + 2 + signature_len;
+    if (signing) {
+        mavlink_sign_packet(status->signing,
+                    msg->signature,
+                    (const uint8_t*)buf, header_len,
+                    (const uint8_t*)_MAV_PAYLOAD(msg), msg->len,
+                    (const uint8_t*)_MAV_PAYLOAD(msg)+(uint16_t)msg->len);
+    }
+    
+    return msg->len + header_len + 2 + signature_len;
 }
 
+/**
+ * @brief Finalize a MAVLink message with channel assignment
+ */
 MAVLINK_HELPER uint16_t mavlink_finalize_message_chan(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
-						      uint8_t chan, uint8_t min_length, uint8_t length, uint8_t crc_extra)
+                                uint8_t chan, uint8_t min_length, uint8_t length, uint8_t crc_extra)
 {
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-	return mavlink_finalize_message_buffer(msg, system_id, component_id, status, min_length, length, crc_extra);
+    mavlink_status_t* status = mavlink_get_channel_status(chan);
+    return mavlink_finalize_message_buffer(msg, system_id, component_id, status, min_length, length, crc_extra);
 }
 
 /**
  * @brief Finalize a MAVLink message with MAVLINK_COMM_0 as default channel
  */
-MAVLINK_HELPER uint16_t mavlink_finalize_message(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id, 
-						 uint8_t min_length, uint8_t length, uint8_t crc_extra)
+MAVLINK_HELPER uint16_t mavlink_finalize_message(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
+                                uint8_t min_length, uint8_t length, uint8_t crc_extra)
 {
     return mavlink_finalize_message_chan(msg, system_id, component_id, MAVLINK_COMM_0, min_length, length, crc_extra);
 }
 
-static inline void _mav_parse_error(mavlink_status_t *status)
+static inline void _mav_parse_error(mavlink_status_t* status)
 {
     status->parse_error++;
 }
 
 #ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
-MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char *buf, uint16_t len);
-
 /**
  * @brief Finalize a MAVLink message with channel assignment and send
  */
 MAVLINK_HELPER void _mav_finalize_message_chan_send(mavlink_channel_t chan, uint32_t msgid,
-                                                    const char *packet, 
-						    uint8_t min_length, uint8_t length, uint8_t crc_extra)
+                                const char* packet,
+                                uint8_t min_length, uint8_t length, uint8_t crc_extra)
 {
-	uint16_t checksum;
-	uint8_t buf[MAVLINK_NUM_HEADER_BYTES];
-	uint8_t ck[2];
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-        uint8_t header_len = MAVLINK_CORE_HEADER_LEN;
-	uint8_t signature_len = 0;
-	uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
-	bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
-	bool signing = 	(!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
+    uint16_t checksum;
+    uint8_t buf[MAVLINK_NUM_HEADER_BYTES];
+    uint8_t ck[2];
+    mavlink_status_t* status = mavlink_get_channel_status(chan);
+    uint8_t header_len = MAVLINK_CORE_HEADER_LEN;
+    uint8_t signature_len = 0;
+    uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
+    bool mavlink1 = (status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) != 0;
+    bool signing =  (!mavlink1) && status->signing && (status->signing->flags & MAVLINK_SIGNING_FLAG_SIGN_OUTGOING);
 
-        if (mavlink1) {
-            length = min_length;
-            if (msgid > 255) {
-                // can't send 16 bit messages
-                _mav_parse_error(status);
-                return;
-            }
-            header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
-            buf[0] = MAVLINK_STX_MAVLINK1;
-            buf[1] = length;
-            buf[2] = status->current_tx_seq;
-            buf[3] = mavlink_system.sysid;
-            buf[4] = mavlink_system.compid;
-            buf[5] = msgid & 0xFF;
-        } else {
-	    uint8_t incompat_flags = 0;
-	    if (signing) {
-		incompat_flags |= MAVLINK_IFLAG_SIGNED;
-	    }
-            length = _mav_trim_payload(packet, length);
-            buf[0] = MAVLINK_STX;
-            buf[1] = length;
-            buf[2] = incompat_flags;
-            buf[3] = 0; // compat_flags
-            buf[4] = status->current_tx_seq;
-            buf[5] = mavlink_system.sysid;
-            buf[6] = mavlink_system.compid;
-            buf[7] = msgid & 0xFF;
-            buf[8] = (msgid >> 8) & 0xFF;
-            buf[9] = (msgid >> 16) & 0xFF;
+    if (mavlink1) {
+        length = min_length;
+        if (msgid > 255) {
+            // can't send 16 bit messages
+            _mav_parse_error(status);       //XX ??? Why is this here, but not in all the others ???
+            return;
         }
-	status->current_tx_seq++;
-	checksum = crc_calculate((const uint8_t*)&buf[1], header_len);
-	crc_accumulate_buffer(&checksum, packet, length);
-	crc_accumulate(crc_extra, &checksum);
-	ck[0] = (uint8_t)(checksum & 0xFF);
-	ck[1] = (uint8_t)(checksum >> 8);
+        header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
+        buf[0] = MAVLINK_STX_MAVLINK1;
+        buf[1] = length;
+        buf[2] = status->current_tx_seq;
+        buf[3] = mavlink_system.sysid;
+        buf[4] = mavlink_system.compid;
+        buf[5] = msgid & 0xFF;
+    } else {
+        uint8_t incompat_flags = 0;
+        if (signing) {
+            incompat_flags |= MAVLINK_IFLAG_SIGNED;
+        }
+        length = _mav_trim_payload(packet, length);
+        buf[0] = MAVLINK_STX;
+        buf[1] = length;
+        buf[2] = incompat_flags;
+        buf[3] = 0; // compat_flags
+        buf[4] = status->current_tx_seq;
+        buf[5] = mavlink_system.sysid;
+        buf[6] = mavlink_system.compid;
+        buf[7] = msgid & 0xFF;
+        buf[8] = (msgid >> 8) & 0xFF;
+        buf[9] = (msgid >> 16) & 0xFF;
+    }
+    status->current_tx_seq++;
+    checksum = crc_calculate((const uint8_t*)&buf[1], header_len);
+    crc_accumulate_buffer(&checksum, packet, length);
+    crc_accumulate(crc_extra, &checksum);
+    ck[0] = (uint8_t)(checksum & 0xFF);
+    ck[1] = (uint8_t)(checksum >> 8);
 
-	if (signing) {
-		// possibly add a signature
-		signature_len = mavlink_sign_packet(status->signing, signature, buf, header_len+1,
-						    (const uint8_t *)packet, length, ck);
-	}
-	
-	MAVLINK_START_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
-	_mavlink_send_uart(chan, (const char *)buf, header_len+1);
-	_mavlink_send_uart(chan, packet, length);
-	_mavlink_send_uart(chan, (const char *)ck, 2);
-	if (signature_len != 0) {
-		_mavlink_send_uart(chan, (const char *)signature, signature_len);
-	}
-	MAVLINK_END_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
+    if (signing) {
+        // possibly add a signature
+        signature_len = mavlink_sign_packet(status->signing, signature, buf, header_len+1,
+                            (const uint8_t*)packet, length, ck);
+    }
+    
+    MAVLINK_START_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
+    _mavlink_send_uart(chan, (const char*)buf, header_len+1);
+    _mavlink_send_uart(chan, packet, length);
+    _mavlink_send_uart(chan, (const char*)ck, 2);
+    if (signature_len != 0) {
+        _mavlink_send_uart(chan, (const char*)signature, signature_len);
+    }
+    MAVLINK_END_UART_SEND(chan, header_len + 3 + (uint16_t)length + (uint16_t)signature_len);
 }
 
 /**
@@ -364,186 +429,175 @@ MAVLINK_HELPER void _mav_finalize_message_chan_send(mavlink_channel_t chan, uint
  * this is more stack efficient than re-marshalling the message
  * If the message is signed then the original signature is also sent
  */
-MAVLINK_HELPER void _mavlink_resend_uart(mavlink_channel_t chan, const mavlink_message_t *msg)
+MAVLINK_HELPER void _mavlink_resend_uart(mavlink_channel_t chan, const mavlink_message_t* msg)
 {
-	uint8_t ck[2];
-
-	ck[0] = (uint8_t)(msg->checksum & 0xFF);
-	ck[1] = (uint8_t)(msg->checksum >> 8);
-	// XXX use the right sequence here
-
-        uint8_t header_len;
-        uint8_t signature_len;
-        
-        if (msg->magic == MAVLINK_STX_MAVLINK1) {
-            header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1;
-            signature_len = 0;
-            MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
-            // we can't send the structure directly as it has extra mavlink2 elements in it
-            uint8_t buf[MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1];
-            buf[0] = msg->magic;
-            buf[1] = msg->len;
-            buf[2] = msg->seq;
-            buf[3] = msg->sysid;
-            buf[4] = msg->compid;
-            buf[5] = msg->msgid & 0xFF;
-            _mavlink_send_uart(chan, (const char*)buf, header_len);
-        } else {
-            header_len = MAVLINK_CORE_HEADER_LEN + 1;
-            signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
-            MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
-            uint8_t buf[MAVLINK_CORE_HEADER_LEN + 1];
-            buf[0] = msg->magic;
-            buf[1] = msg->len;
-            buf[2] = msg->incompat_flags;
-            buf[3] = msg->compat_flags;
-            buf[4] = msg->seq;
-            buf[5] = msg->sysid;
-            buf[6] = msg->compid;
-            buf[7] = msg->msgid & 0xFF;
-            buf[8] = (msg->msgid >> 8) & 0xFF;
-            buf[9] = (msg->msgid >> 16) & 0xFF;
-            _mavlink_send_uart(chan, (const char *)buf, header_len);
-        }
-	_mavlink_send_uart(chan, _MAV_PAYLOAD(msg), msg->len);
-	_mavlink_send_uart(chan, (const char *)ck, 2);
-        if (signature_len != 0) {
-	    _mavlink_send_uart(chan, (const char *)msg->signature, MAVLINK_SIGNATURE_BLOCK_LEN);
-        }
-        MAVLINK_END_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+    uint8_t header_len, signature_len;
+    uint8_t ck[2];
+    ck[0] = (uint8_t)(msg->checksum & 0xFF);
+    ck[1] = (uint8_t)(msg->checksum >> 8);
+    // XXX use the right sequence here
+       
+    if (msg->magic == MAVLINK_STX_MAVLINK1) {
+        header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1;
+        signature_len = 0;
+        MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+        // we can't send the structure directly as it has extra mavlink2 elements in it
+        uint8_t buf[MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1];
+        buf[0] = msg->magic;
+        buf[1] = msg->len;
+        buf[2] = msg->seq;
+        buf[3] = msg->sysid;
+        buf[4] = msg->compid;
+        buf[5] = msg->msgid & 0xFF;
+        _mavlink_send_uart(chan, (const char*)buf, header_len);
+    } else {
+        header_len = MAVLINK_CORE_HEADER_LEN + 1;
+        signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED) ? MAVLINK_SIGNATURE_BLOCK_LEN : 0;
+        MAVLINK_START_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
+        uint8_t buf[MAVLINK_CORE_HEADER_LEN + 1];
+        buf[0] = msg->magic;
+        buf[1] = msg->len;
+        buf[2] = msg->incompat_flags;
+        buf[3] = msg->compat_flags;
+        buf[4] = msg->seq;
+        buf[5] = msg->sysid;
+        buf[6] = msg->compid;
+        buf[7] = msg->msgid & 0xFF;
+        buf[8] = (msg->msgid >> 8) & 0xFF;
+        buf[9] = (msg->msgid >> 16) & 0xFF;
+        _mavlink_send_uart(chan, (const char*)buf, header_len);
+    }
+    _mavlink_send_uart(chan, _MAV_PAYLOAD(msg), msg->len);
+    _mavlink_send_uart(chan, (const char*)ck, 2);
+    if (signature_len != 0) {
+        _mavlink_send_uart(chan, (const char*)msg->signature, MAVLINK_SIGNATURE_BLOCK_LEN);
+    }
+    MAVLINK_END_UART_SEND(chan, header_len + msg->len + 2 + signature_len);
 }
 #endif // MAVLINK_USE_CONVENIENCE_FUNCTIONS
 
 /**
  * @brief Pack a message to send it over a serial byte stream
  */
-MAVLINK_HELPER uint16_t mavlink_msg_to_send_buffer(uint8_t *buf, const mavlink_message_t *msg)
+MAVLINK_HELPER uint16_t mavlink_msg_to_send_buffer(uint8_t* buf, const mavlink_message_t* msg)
 {
-	uint8_t signature_len, header_len;
-	uint8_t *ck;
-        uint8_t length = msg->len;
+    uint8_t signature_len, header_len;
+    uint8_t* ck;
+    uint8_t length = msg->len;
         
-	if (msg->magic == MAVLINK_STX_MAVLINK1) {
-		signature_len = 0;
-		header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
-		buf[0] = msg->magic;
-		buf[1] = length;
-		buf[2] = msg->seq;
-		buf[3] = msg->sysid;
-		buf[4] = msg->compid;
-		buf[5] = msg->msgid & 0xFF;
-		memcpy(&buf[6], _MAV_PAYLOAD(msg), msg->len);
-		ck = buf + header_len + 1 + (uint16_t)msg->len;
-	} else {
-		length = _mav_trim_payload(_MAV_PAYLOAD(msg), length);
-		header_len = MAVLINK_CORE_HEADER_LEN;
-		buf[0] = msg->magic;
-		buf[1] = length;
-		buf[2] = msg->incompat_flags;
-		buf[3] = msg->compat_flags;
-		buf[4] = msg->seq;
-		buf[5] = msg->sysid;
-		buf[6] = msg->compid;
-		buf[7] = msg->msgid & 0xFF;
-		buf[8] = (msg->msgid >> 8) & 0xFF;
-		buf[9] = (msg->msgid >> 16) & 0xFF;
-		memcpy(&buf[10], _MAV_PAYLOAD(msg), length);
-		ck = buf + header_len + 1 + (uint16_t)length;
-		signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
-	}
-	ck[0] = (uint8_t)(msg->checksum & 0xFF);
-	ck[1] = (uint8_t)(msg->checksum >> 8);
-	if (signature_len > 0) {
-		memcpy(&ck[2], msg->signature, signature_len);
-	}
+    if (msg->magic == MAVLINK_STX_MAVLINK1) {
+        signature_len = 0;
+        header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN;
+        buf[0] = msg->magic;
+        buf[1] = length;
+        buf[2] = msg->seq;
+        buf[3] = msg->sysid;
+        buf[4] = msg->compid;
+        buf[5] = msg->msgid & 0xFF;
+        memcpy(&buf[6], _MAV_PAYLOAD(msg), msg->len);
+        ck = buf + header_len + 1 + (uint16_t)msg->len;
+    } else {
+        length = _mav_trim_payload(_MAV_PAYLOAD(msg), length);
+        header_len = MAVLINK_CORE_HEADER_LEN;
+        buf[0] = msg->magic;
+        buf[1] = length;
+        buf[2] = msg->incompat_flags;
+        buf[3] = msg->compat_flags;
+        buf[4] = msg->seq;
+        buf[5] = msg->sysid;
+        buf[6] = msg->compid;
+        buf[7] = msg->msgid & 0xFF;
+        buf[8] = (msg->msgid >> 8) & 0xFF;
+        buf[9] = (msg->msgid >> 16) & 0xFF;
+        memcpy(&buf[10], _MAV_PAYLOAD(msg), length);
+        ck = buf + header_len + 1 + (uint16_t)length;
+        signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
+    }
+    ck[0] = (uint8_t)(msg->checksum & 0xFF);
+    ck[1] = (uint8_t)(msg->checksum >> 8);
+    if (signature_len > 0) {
+        memcpy(&ck[2], msg->signature, signature_len);
+    }
 
-	return header_len + 1 + 2 + (uint16_t)length + (uint16_t)signature_len;
+    return header_len + 1 + 2 + (uint16_t)length + (uint16_t)signature_len;
 }
 
-union __mavlink_bitfield {
-	uint8_t uint8;
-	int8_t int8;
-	uint16_t uint16;
-	int16_t int16;
-	uint32_t uint32;
-	int32_t int32;
-};
-
+// PARSER FUNCTIONS
 
 MAVLINK_HELPER void mavlink_start_checksum(mavlink_message_t* msg)
 {
-	uint16_t crcTmp = 0;
-	crc_init(&crcTmp);
-	msg->checksum = crcTmp;
+    uint16_t checksum = 0;
+    crc_init(&checksum);
+    msg->checksum = checksum;
 }
 
 MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c)
 {
-	uint16_t checksum = msg->checksum;
-	crc_accumulate(c, &checksum);
-	msg->checksum = checksum;
+    uint16_t checksum = msg->checksum;
+    crc_accumulate(c, &checksum);
+    msg->checksum = checksum;
 }
 
 /*
   return the crc_entry value for a msgid
 */
 #ifndef MAVLINK_GET_MSG_ENTRY
-MAVLINK_HELPER const mavlink_msg_entry_t *mavlink_get_msg_entry(uint32_t msgid)
+MAVLINK_HELPER const mavlink_msg_entry_t* mavlink_get_msg_entry(uint32_t msgid)
 {
-	static const mavlink_msg_entry_t mavlink_message_crcs[] = MAVLINK_MESSAGE_CRCS;
-        /*
-	  use a bisection search to find the right entry. A perfect hash may be better
-	  Note that this assumes the table is sorted by msgid
-	*/
-        uint32_t low=0, high=sizeof(mavlink_message_crcs)/sizeof(mavlink_message_crcs[0]);
-        while (low < high) {
-            uint32_t mid = (low+1+high)/2;
-            if (msgid < mavlink_message_crcs[mid].msgid) {
-                high = mid-1;
-                continue;
-            }
-            if (msgid > mavlink_message_crcs[mid].msgid) {
-                low = mid;
-                continue;
-            }
+    static const mavlink_msg_entry_t mavlink_message_crcs[] = MAVLINK_MESSAGE_CRCS;
+    /*
+      use a bisection search to find the right entry. A perfect hash may be better
+      Note that this assumes the table is sorted by msgid
+    */
+    uint32_t low = 0, high = sizeof(mavlink_message_crcs)/sizeof(mavlink_message_crcs[0]);
+    while (low < high) {
+        uint32_t mid = (low+1+high)/2;
+        if (msgid < mavlink_message_crcs[mid].msgid) {
+            high = mid-1;
+            continue;
+        }
+        if (msgid > mavlink_message_crcs[mid].msgid) {
             low = mid;
-            break;
+            continue;
         }
-        if (mavlink_message_crcs[low].msgid != msgid) {
-            // msgid is not in the table
-            return NULL;
-        }
-        return &mavlink_message_crcs[low];
+        low = mid;
+        break;
+    }
+    if (mavlink_message_crcs[low].msgid != msgid) {
+        // msgid is not in the table
+        return NULL;
+    }
+    return &mavlink_message_crcs[low];
 }
 #endif // MAVLINK_GET_MSG_ENTRY
 
 /*
   return the crc_extra value for a message
 */
-MAVLINK_HELPER uint8_t mavlink_get_crc_extra(const mavlink_message_t *msg)
+MAVLINK_HELPER uint8_t mavlink_get_crc_extra(const mavlink_message_t* msg)
 {
-	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
-	return e?e->crc_extra:0;
+    const mavlink_msg_entry_t* msg_entry = mavlink_get_msg_entry(msg->msgid);
+    return msg_entry ? msg_entry->crc_extra : 0;
 }
 
 /*
   return the min message length
 */
 #define MAVLINK_HAVE_MIN_MESSAGE_LENGTH
-MAVLINK_HELPER uint8_t mavlink_min_message_length(const mavlink_message_t *msg)
+MAVLINK_HELPER uint8_t mavlink_min_message_length(const mavlink_message_t* msg)
 {
-	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
-        return e?e->min_msg_len:0;
+    const mavlink_msg_entry_t* msg_entry = mavlink_get_msg_entry(msg->msgid);
+    return msg_entry ? msg_entry->min_msg_len : 0;
 }
 
 /*
   return the max message length (including extensions)
 */
 #define MAVLINK_HAVE_MAX_MESSAGE_LENGTH
-MAVLINK_HELPER uint8_t mavlink_max_message_length(const mavlink_message_t *msg)
+MAVLINK_HELPER uint8_t mavlink_max_message_length(const mavlink_message_t* msg)
 {
-	const mavlink_msg_entry_t *e = mavlink_get_msg_entry(msg->msgid);
-        return e?e->max_msg_len:0;
+    const mavlink_msg_entry_t* msg_entry = mavlink_get_msg_entry(msg->msgid);
+    return msg_entry ? msg_entry->max_msg_len : 0;
 }
 
 /**
@@ -566,288 +620,278 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
                                                  mavlink_message_t* r_message, 
                                                  mavlink_status_t* r_mavlink_status)
 {
-	/* Enable this option to check the length of each message.
-	   This allows invalid messages to be caught much sooner. Use if the transmission
-	   medium is prone to missing (or extra) characters (e.g. a radio that fades in
-	   and out). Only use if the channel will only contain messages types listed in
-	   the headers.
-	*/
+    /* Enable this option to check the length of each message.
+       This allows invalid messages to be caught much sooner. Use if the transmission
+       medium is prone to missing (or extra) characters (e.g. a radio that fades in
+       and out). Only use if the channel will only contain messages types listed in
+       the headers.
+    */
 #ifdef MAVLINK_CHECK_MESSAGE_LENGTH
 #ifndef MAVLINK_MESSAGE_LENGTH
-	static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
+    static const uint8_t mavlink_message_lengths[256] = MAVLINK_MESSAGE_LENGTHS;
 #define MAVLINK_MESSAGE_LENGTH(msgid) mavlink_message_lengths[msgid]
 #endif
 #endif
 
-	int bufferIndex = 0;
+    int bufferIndex = 0;
 
-	status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
+    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
 
-	switch (status->parse_state)
-	{
-	case MAVLINK_PARSE_STATE_UNINIT:
-	case MAVLINK_PARSE_STATE_IDLE:
-		if (c == MAVLINK_STX)
-		{
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-			rxmsg->len = 0;
-			rxmsg->magic = c;
-                        status->flags &= ~MAVLINK_STATUS_FLAG_IN_MAVLINK1;
-			mavlink_start_checksum(rxmsg);
-		} else if (c == MAVLINK_STX_MAVLINK1)
-		{
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-			rxmsg->len = 0;
-			rxmsg->magic = c;
-                        status->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
-			mavlink_start_checksum(rxmsg);
-		}
-		break;
+    switch (status->parse_state)
+    {
+    case MAVLINK_PARSE_STATE_UNINIT:
+    case MAVLINK_PARSE_STATE_IDLE:
+        if (c == MAVLINK_STX) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+            rxmsg->len = 0;
+            rxmsg->magic = c;
+            status->flags &= ~MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+            mavlink_start_checksum(rxmsg);
+        } else if (c == MAVLINK_STX_MAVLINK1) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+            rxmsg->len = 0;
+            rxmsg->magic = c;
+            status->flags |= MAVLINK_STATUS_FLAG_IN_MAVLINK1;
+            mavlink_start_checksum(rxmsg);
+        }
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_STX:
-			if (status->msg_received 
-/* Support shorter buffers than the
-   default maximum packet size */
+    case MAVLINK_PARSE_STATE_GOT_STX:
+        if (status->msg_received 
+/* Support shorter buffers than the default maximum packet size */
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
-				|| c > MAVLINK_MAX_PAYLOAD_LEN
+                || c > MAVLINK_MAX_PAYLOAD_LEN
 #endif
-				)
-		{
-			status->buffer_overrun++;
-			_mav_parse_error(status);
-			status->msg_received = 0;
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-		}
-		else
-		{
-			// NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
-			rxmsg->len = c;
-			status->packet_idx = 0;
-			mavlink_update_checksum(rxmsg, c);
-                        if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
-                            rxmsg->incompat_flags = 0;
-                            rxmsg->compat_flags = 0;
-                            status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
-                        } else {
-                            status->parse_state = MAVLINK_PARSE_STATE_GOT_LENGTH;
-                        }
-		}
-		break;
+            ) {
+            status->buffer_overrun++;
+            _mav_parse_error(status);
+            status->msg_received = 0;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+        } else {
+            // NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
+            rxmsg->len = c;
+            status->packet_idx = 0;
+            mavlink_update_checksum(rxmsg, c);
+            if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+                rxmsg->incompat_flags = 0;
+                rxmsg->compat_flags = 0;
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
+            } else {
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_LENGTH;
+            }
+        }
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_LENGTH:
-		rxmsg->incompat_flags = c;
-		if ((rxmsg->incompat_flags & ~MAVLINK_IFLAG_MASK) != 0) {
-			// message includes an incompatible feature flag
-			_mav_parse_error(status);
-			status->msg_received = 0;
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-			break;
-		}
-		mavlink_update_checksum(rxmsg, c);
-		status->parse_state = MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_LENGTH:
+        rxmsg->incompat_flags = c;
+        if ((rxmsg->incompat_flags & ~MAVLINK_IFLAG_MASK) != 0) {
+            // message includes an incompatible feature flag
+            _mav_parse_error(status);
+            status->msg_received = 0;
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            break;
+        }
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS;
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS:
-		rxmsg->compat_flags = c;
-		mavlink_update_checksum(rxmsg, c);
-		status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_INCOMPAT_FLAGS:
+        rxmsg->compat_flags = c;
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS;
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS:
-		rxmsg->seq = c;
-		mavlink_update_checksum(rxmsg, c);
-		status->parse_state = MAVLINK_PARSE_STATE_GOT_SEQ;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_COMPAT_FLAGS:
+        rxmsg->seq = c;
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_SEQ;
+        break;
                 
-	case MAVLINK_PARSE_STATE_GOT_SEQ:
-		rxmsg->sysid = c;
-		mavlink_update_checksum(rxmsg, c);
-		status->parse_state = MAVLINK_PARSE_STATE_GOT_SYSID;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_SEQ:
+        rxmsg->sysid = c;
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_SYSID;
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_SYSID:
-		rxmsg->compid = c;
-		mavlink_update_checksum(rxmsg, c);
-                status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPID;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_SYSID:
+        rxmsg->compid = c;
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_COMPID;
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_COMPID:
-		rxmsg->msgid = c;
-		mavlink_update_checksum(rxmsg, c);
-                if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
-                    if(rxmsg->len > 0){
-                        status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
-                    } else {
-                        status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
-                    }
+    case MAVLINK_PARSE_STATE_GOT_COMPID:
+        rxmsg->msgid = c;
+        mavlink_update_checksum(rxmsg, c);
+        if (status->flags & MAVLINK_STATUS_FLAG_IN_MAVLINK1) {
+            if(rxmsg->len > 0){
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
+            } else {
+                status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+            }
 #ifdef MAVLINK_CHECK_MESSAGE_LENGTH
-                    if (rxmsg->len != MAVLINK_MESSAGE_LENGTH(rxmsg->msgid))
-                    {
-			_mav_parse_error(status);
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-			break;
-                    }
+            if (rxmsg->len != MAVLINK_MESSAGE_LENGTH(rxmsg->msgid)) {
+                _mav_parse_error(status);
+                status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+                break;
+            }
 #endif
-                } else {
-                    status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID1;
-                }
-		break;
+        } else {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID1;
+        }
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_MSGID1:
-		rxmsg->msgid |= c<<8;
-		mavlink_update_checksum(rxmsg, c);
-		status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID2;
-		break;
+    case MAVLINK_PARSE_STATE_GOT_MSGID1:
+        rxmsg->msgid |= c<<8;
+        mavlink_update_checksum(rxmsg, c);
+        status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID2;
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_MSGID2:
-		rxmsg->msgid |= ((uint32_t)c)<<16;
-		mavlink_update_checksum(rxmsg, c);
-		if(rxmsg->len > 0){
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
-		} else {
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
-		}
+    case MAVLINK_PARSE_STATE_GOT_MSGID2:
+        rxmsg->msgid |= ((uint32_t)c)<<16;
+        mavlink_update_checksum(rxmsg, c);
+        if (rxmsg->len > 0) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID3;
+        } else {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+        }
 #ifdef MAVLINK_CHECK_MESSAGE_LENGTH
-	        if (rxmsg->len != MAVLINK_MESSAGE_LENGTH(rxmsg->msgid))
-		{
-			_mav_parse_error(status);
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-			break;
-                }
+        if (rxmsg->len != MAVLINK_MESSAGE_LENGTH(rxmsg->msgid)) {
+            _mav_parse_error(status);
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            break;
+        }
 #endif
-		break;
+        break;
                 
-	case MAVLINK_PARSE_STATE_GOT_MSGID3:
-		_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx++] = (char)c;
-		mavlink_update_checksum(rxmsg, c);
-		if (status->packet_idx == rxmsg->len)
-		{
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
-		}
-		break;
+    case MAVLINK_PARSE_STATE_GOT_MSGID3:
+        _MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx++] = (char)c;
+        mavlink_update_checksum(rxmsg, c);
+        if (status->packet_idx == rxmsg->len) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_PAYLOAD;
+        }
+        break;
 
-	case MAVLINK_PARSE_STATE_GOT_PAYLOAD: {
-		const mavlink_msg_entry_t *e = mavlink_get_msg_entry(rxmsg->msgid);
-		uint8_t crc_extra = e?e->crc_extra:0;
-		mavlink_update_checksum(rxmsg, crc_extra);
-		if (c != (rxmsg->checksum & 0xFF)) {
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_BAD_CRC1;
-		} else {
-			status->parse_state = MAVLINK_PARSE_STATE_GOT_CRC1;
-		}
-                rxmsg->ck[0] = c;
+    case MAVLINK_PARSE_STATE_GOT_PAYLOAD: {
+        const mavlink_msg_entry_t* e = mavlink_get_msg_entry(rxmsg->msgid);
+        uint8_t crc_extra = e ? e->crc_extra : 0;
+        mavlink_update_checksum(rxmsg, crc_extra);
+        if (c != (rxmsg->checksum & 0xFF)) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_BAD_CRC1;
+        } else {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_CRC1;
+        }
+        rxmsg->ck[0] = c;
 
-		// zero-fill the packet to cope with short incoming packets
-                if (e && status->packet_idx < e->max_msg_len) {
-                        memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, e->max_msg_len - status->packet_idx);
-		}
-		break;
+        // zero-fill the packet to cope with short incoming packets
+        if (e && status->packet_idx < e->max_msg_len) {
+            memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, e->max_msg_len - status->packet_idx);
+        }
+        break;
         }
 
-	case MAVLINK_PARSE_STATE_GOT_CRC1:
-	case MAVLINK_PARSE_STATE_GOT_BAD_CRC1:
-		if (status->parse_state == MAVLINK_PARSE_STATE_GOT_BAD_CRC1 || c != (rxmsg->checksum >> 8)) {
-			// got a bad CRC message
-			status->msg_received = MAVLINK_FRAMING_BAD_CRC;
-		} else {
-			// Successfully got message
-			status->msg_received = MAVLINK_FRAMING_OK;
-		}
-		rxmsg->ck[1] = c;
+    case MAVLINK_PARSE_STATE_GOT_CRC1:
+    case MAVLINK_PARSE_STATE_GOT_BAD_CRC1:
+        if (status->parse_state == MAVLINK_PARSE_STATE_GOT_BAD_CRC1 || c != (rxmsg->checksum >> 8)) {
+            // got a bad CRC message
+            status->msg_received = MAVLINK_FRAMING_BAD_CRC;
+        } else {
+            // Successfully got message
+            status->msg_received = MAVLINK_FRAMING_OK;
+        }
+        rxmsg->ck[1] = c;
 
-		if (rxmsg->incompat_flags & MAVLINK_IFLAG_SIGNED) {
-			status->parse_state = MAVLINK_PARSE_STATE_SIGNATURE_WAIT;
-			status->signature_wait = MAVLINK_SIGNATURE_BLOCK_LEN;
+        if (rxmsg->incompat_flags & MAVLINK_IFLAG_SIGNED) {
+            status->parse_state = MAVLINK_PARSE_STATE_SIGNATURE_WAIT;
+            status->signature_wait = MAVLINK_SIGNATURE_BLOCK_LEN;
 
-			// If the CRC is already wrong, don't overwrite msg_received,
-			// otherwise we can end up with garbage flagged as valid.
-			if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
-				status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
-			}
-		} else {
-			if (status->signing &&
-			   	(status->signing->accept_unsigned_callback == NULL ||
-			   	 !status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
-
-				// If the CRC is already wrong, don't overwrite msg_received.
-				if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
-					status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
-				}
-			}
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-			if (r_message != NULL) {
-				memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
-			}
-		}
-		break;
-	case MAVLINK_PARSE_STATE_SIGNATURE_WAIT:
-		rxmsg->signature[MAVLINK_SIGNATURE_BLOCK_LEN-status->signature_wait] = c;
-		status->signature_wait--;
-		if (status->signature_wait == 0) {
-			// we have the whole signature, check it is OK
-			bool sig_ok = mavlink_signature_check(status->signing, status->signing_streams, rxmsg);
-			if (!sig_ok &&
-			   	(status->signing->accept_unsigned_callback &&
-			   	 status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
-				// accepted via application level override
-				sig_ok = true;
-			}
-			if (sig_ok) {
-				status->msg_received = MAVLINK_FRAMING_OK;
-			} else {
-				status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
-			}
-			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-			if (r_message !=NULL) {
-				memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
-			}
-		}
-		break;
-	}
-
-	bufferIndex++;
-	// If a message has been sucessfully decoded, check index
-	if (status->msg_received == MAVLINK_FRAMING_OK)
-	{
-		//while(status->current_seq != rxmsg->seq)
-		//{
-		//	status->packet_rx_drop_count++;
-		//               status->current_seq++;
-		//}
-		status->current_rx_seq = rxmsg->seq;
-		// Initial condition: If no packet has been received so far, drop count is undefined
-		if (status->packet_rx_success_count == 0) status->packet_rx_drop_count = 0;
-		// Count this packet as received
-		status->packet_rx_success_count++;
-	}
-
-       if (r_message != NULL) {
-           r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
-       }
-       if (r_mavlink_status != NULL) {	
-           r_mavlink_status->parse_state = status->parse_state;
-           r_mavlink_status->packet_idx = status->packet_idx;
-           r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
-           r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
-           r_mavlink_status->packet_rx_drop_count = status->parse_error;
-           r_mavlink_status->flags = status->flags;
-       }
-       status->parse_error = 0;
-
-	if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
-		/*
-		  the CRC came out wrong. We now need to overwrite the
-		  msg CRC with the one on the wire so that if the
-		  caller decides to forward the message anyway that
-		  mavlink_msg_to_send_buffer() won't overwrite the
-		  checksum
-		 */
-            if (r_message != NULL) {
-                r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+            // If the CRC is already wrong, don't overwrite msg_received,
+            // otherwise we can end up with garbage flagged as valid.
+            if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
+                status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
             }
-	}
+        } else {
+            if (status->signing &&
+                (status->signing->accept_unsigned_callback == NULL ||
+                 !status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
 
-	return status->msg_received;
+                // If the CRC is already wrong, don't overwrite msg_received.
+                if (status->msg_received != MAVLINK_FRAMING_BAD_CRC) {
+                    status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
+                }
+            }
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            if (r_message != NULL) {
+                memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
+            }
+        }
+        break;
+    case MAVLINK_PARSE_STATE_SIGNATURE_WAIT:
+        rxmsg->signature[MAVLINK_SIGNATURE_BLOCK_LEN-status->signature_wait] = c;
+        status->signature_wait--;
+        if (status->signature_wait == 0) {
+            // we have the whole signature, check it is OK
+            bool sig_ok = mavlink_signature_check(status->signing, status->signing_streams, rxmsg);
+            if (!sig_ok &&
+                (status->signing->accept_unsigned_callback &&
+                 status->signing->accept_unsigned_callback(status, rxmsg->msgid))) {
+                // accepted via application level override
+                sig_ok = true;
+            }
+            if (sig_ok) {
+                status->msg_received = MAVLINK_FRAMING_OK;
+            } else {
+                status->msg_received = MAVLINK_FRAMING_BAD_SIGNATURE;
+            }
+            status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+            if (r_message != NULL) {
+                memcpy(r_message, rxmsg, sizeof(mavlink_message_t));
+            }
+        }
+        break;
+    }
+
+    bufferIndex++;
+    // If a message has been sucessfully decoded, check index
+    if (status->msg_received == MAVLINK_FRAMING_OK) {
+        //while(status->current_seq != rxmsg->seq)
+        //{
+        //  status->packet_rx_drop_count++;
+        //               status->current_seq++;
+        //}
+        status->current_rx_seq = rxmsg->seq;
+        // Initial condition: If no packet has been received so far, drop count is undefined
+        if (status->packet_rx_success_count == 0) status->packet_rx_drop_count = 0;
+        // Count this packet as received
+        status->packet_rx_success_count++;
+    }
+
+    if (r_message != NULL) {
+        r_message->len = rxmsg->len; // Provide visibility on how far we are into current msg
+    }
+    if (r_mavlink_status != NULL) {  
+        r_mavlink_status->parse_state = status->parse_state;
+        r_mavlink_status->packet_idx = status->packet_idx;
+        r_mavlink_status->current_rx_seq = status->current_rx_seq+1;
+        r_mavlink_status->packet_rx_success_count = status->packet_rx_success_count;
+        r_mavlink_status->packet_rx_drop_count = status->parse_error;
+        r_mavlink_status->flags = status->flags;
+    }
+    status->parse_error = 0;
+
+    if (status->msg_received == MAVLINK_FRAMING_BAD_CRC) {
+        /*
+          the CRC came out wrong. We now need to overwrite the
+          msg CRC with the one on the wire so that if the
+          caller decides to forward the message anyway that
+          mavlink_msg_to_send_buffer() won't overwrite the
+          checksum
+        */
+        if (r_message != NULL) {
+            r_message->checksum = rxmsg->ck[0] | (rxmsg->ck[1]<<8);
+        }
+    }
+
+    return status->msg_received;
 }
 
 /**
@@ -894,39 +938,11 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
  */
 MAVLINK_HELPER uint8_t mavlink_frame_char(uint8_t chan, uint8_t c, mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status)
 {
-	return mavlink_frame_char_buffer(mavlink_get_channel_buffer(chan),
-					 mavlink_get_channel_status(chan),
-					 c,
-					 r_message,
-					 r_mavlink_status);
-}
-
-/**
- * Set the protocol version
- */
-MAVLINK_HELPER void mavlink_set_proto_version(uint8_t chan, unsigned int version)
-{
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-	if (version > 1) {
-		status->flags &= ~(MAVLINK_STATUS_FLAG_OUT_MAVLINK1);
-	} else {
-		status->flags |= MAVLINK_STATUS_FLAG_OUT_MAVLINK1;
-	}
-}
-
-/**
- * Get the protocol version
- *
- * @return 1 for v1, 2 for v2
- */
-MAVLINK_HELPER unsigned int mavlink_get_proto_version(uint8_t chan)
-{
-	mavlink_status_t *status = mavlink_get_channel_status(chan);
-	if ((status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) > 0) {
-		return 1;
-	} else {
-		return 2;
-	}
+    return mavlink_frame_char_buffer(mavlink_get_channel_buffer(chan),
+                                     mavlink_get_channel_status(chan),
+                                     c,
+                                     r_message,
+                                     r_mavlink_status);
 }
 
 /**
@@ -974,23 +990,33 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
 {
     uint8_t msg_received = mavlink_frame_char(chan, c, r_message, r_mavlink_status);
     if (msg_received == MAVLINK_FRAMING_BAD_CRC ||
-	msg_received == MAVLINK_FRAMING_BAD_SIGNATURE) {
-	    // we got a bad CRC. Treat as a parse failure
-	    mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan);
-	    mavlink_status_t* status = mavlink_get_channel_status(chan);
-	    _mav_parse_error(status);
-	    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
-	    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-	    if (c == MAVLINK_STX)
-	    {
-		    status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-		    rxmsg->len = 0;
-		    mavlink_start_checksum(rxmsg);
-	    }
-	    return 0;
+        msg_received == MAVLINK_FRAMING_BAD_SIGNATURE) {
+        // we got a bad CRC. Treat as a parse failure
+        mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan);
+        mavlink_status_t* status = mavlink_get_channel_status(chan);
+        _mav_parse_error(status);
+        status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
+        status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+        if (c == MAVLINK_STX) {
+            status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
+            rxmsg->len = 0;
+            mavlink_start_checksum(rxmsg);
+        }
+        return 0;
     }
     return msg_received;
 }
+
+// BITFIELD
+
+union __mavlink_bitfield {
+    uint8_t uint8;
+    int8_t int8;
+    uint16_t uint16;
+    int16_t int16;
+    uint32_t uint32;
+    int32_t int32;
+};
 
 /**
  * @brief Put a bitfield of length 1-32 bit into the buffer
@@ -1004,133 +1030,88 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
  */
 MAVLINK_HELPER uint8_t put_bitfield_n_by_index(int32_t b, uint8_t bits, uint8_t packet_index, uint8_t bit_index, uint8_t* r_bit_index, uint8_t* buffer)
 {
-	uint16_t bits_remain = bits;
-	// Transform number into network order
-	int32_t v;
-	uint8_t i_bit_index, i_byte_index, curr_bits_n;
+    uint16_t bits_remain = bits;
+    // Transform number into network order
+    int32_t v;
+    uint8_t i_bit_index, i_byte_index, curr_bits_n;
 #if MAVLINK_NEED_BYTE_SWAP
-	union {
-		int32_t i;
-		uint8_t b[4];
-	} bin, bout;
-	bin.i = b;
-	bout.b[0] = bin.b[3];
-	bout.b[1] = bin.b[2];
-	bout.b[2] = bin.b[1];
-	bout.b[3] = bin.b[0];
-	v = bout.i;
+    union {
+        int32_t i;
+        uint8_t b[4];
+    } bin, bout;
+    bin.i = b;
+    bout.b[0] = bin.b[3];
+    bout.b[1] = bin.b[2];
+    bout.b[2] = bin.b[1];
+    bout.b[3] = bin.b[0];
+    v = bout.i;
 #else
-	v = b;
+    v = b;
 #endif
 
-	// buffer in
-	// 01100000 01000000 00000000 11110001
-	// buffer out
-	// 11110001 00000000 01000000 01100000
+    // buffer in
+    // 01100000 01000000 00000000 11110001
+    // buffer out
+    // 11110001 00000000 01000000 01100000
 
-	// Existing partly filled byte (four free slots)
-	// 0111xxxx
+    // Existing partly filled byte (four free slots)
+    // 0111xxxx
 
-	// Mask n free bits
-	// 00001111 = 2^0 + 2^1 + 2^2 + 2^3 = 2^n - 1
-	// = ((uint32_t)(1 << n)) - 1; // = 2^n - 1
+    // Mask n free bits
+    // 00001111 = 2^0 + 2^1 + 2^2 + 2^3 = 2^n - 1
+    // = ((uint32_t)(1 << n)) - 1; // = 2^n - 1
 
-	// Shift n bits into the right position
-	// out = in >> n;
+    // Shift n bits into the right position
+    // out = in >> n;
 
-	// Mask and shift bytes
-	i_bit_index = bit_index;
-	i_byte_index = packet_index;
-	if (bit_index > 0)
-	{
-		// If bits were available at start, they were available
-		// in the byte before the current index
-		i_byte_index--;
-	}
-
-	// While bits have not been packed yet
-	while (bits_remain > 0)
-	{
-		// Bits still have to be packed
-		// there can be more than 8 bits, so
-		// we might have to pack them into more than one byte
-
-		// First pack everything we can into the current 'open' byte
-		//curr_bits_n = bits_remain << 3; // Equals  bits_remain mod 8
-		//FIXME
-		if (bits_remain <= (uint8_t)(8 - i_bit_index))
-		{
-			// Enough space
-			curr_bits_n = (uint8_t)bits_remain;
-		}
-		else
-		{
-			curr_bits_n = (8 - i_bit_index);
-		}
-		
-		// Pack these n bits into the current byte
-		// Mask out whatever was at that position with ones (xxx11111)
-		buffer[i_byte_index] &= (0xFF >> (8 - curr_bits_n));
-		// Put content to this position, by masking out the non-used part
-		buffer[i_byte_index] |= ((0x00 << curr_bits_n) & v);
-		
-		// Increment the bit index
-		i_bit_index += curr_bits_n;
-
-		// Now proceed to the next byte, if necessary
-		bits_remain -= curr_bits_n;
-		if (bits_remain > 0)
-		{
-			// Offer another 8 bits / one byte
-			i_byte_index++;
-			i_bit_index = 0;
-		}
-	}
-	
-	*r_bit_index = i_bit_index;
-	// If a partly filled byte is present, mark this as consumed
-	if (i_bit_index != 7) i_byte_index++;
-	return i_byte_index - packet_index;
-}
-
-#ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
-
-// To make MAVLink work on your MCU, define comm_send_ch() if you wish
-// to send 1 byte at a time, or MAVLINK_SEND_UART_BYTES() to send a
-// whole packet at a time
-
-/*
-
-#include "mavlink_types.h"
-
-void comm_send_ch(mavlink_channel_t chan, uint8_t ch)
-{
-    if (chan == MAVLINK_COMM_0)
-    {
-        uart0_transmit(ch);
+    // Mask and shift bytes
+    i_bit_index = bit_index;
+    i_byte_index = packet_index;
+    if (bit_index > 0) {
+        // If bits were available at start, they were available
+        // in the byte before the current index
+        i_byte_index--;
     }
-    if (chan == MAVLINK_COMM_1)
-    {
-    	uart1_transmit(ch);
-    }
-}
- */
 
-MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char *buf, uint16_t len)
-{
-#ifdef MAVLINK_SEND_UART_BYTES
-	/* this is the more efficient approach, if the platform
-	   defines it */
-	MAVLINK_SEND_UART_BYTES(chan, (const uint8_t *)buf, len);
-#else
-	/* fallback to one byte at a time */
-	uint16_t i;
-	for (i = 0; i < len; i++) {
-		comm_send_ch(chan, (uint8_t)buf[i]);
-	}
-#endif
+    // While bits have not been packed yet
+    while (bits_remain > 0) {
+        // Bits still have to be packed
+        // there can be more than 8 bits, so
+        // we might have to pack them into more than one byte
+
+        // First pack everything we can into the current 'open' byte
+        //curr_bits_n = bits_remain << 3; // Equals  bits_remain mod 8
+        //FIXME
+        if (bits_remain <= (uint8_t)(8 - i_bit_index)) {
+            // Enough space
+            curr_bits_n = (uint8_t)bits_remain;
+        } else {
+            curr_bits_n = (8 - i_bit_index);
+        }
+
+        // Pack these n bits into the current byte
+        // Mask out whatever was at that position with ones (xxx11111)
+        buffer[i_byte_index] &= (0xFF >> (8 - curr_bits_n));
+        // Put content to this position, by masking out the non-used part
+        buffer[i_byte_index] |= ((0x00 << curr_bits_n) & v);
+
+        // Increment the bit index
+        i_bit_index += curr_bits_n;
+
+        // Now proceed to the next byte, if necessary
+        bits_remain -= curr_bits_n;
+        if (bits_remain > 0) {
+            // Offer another 8 bits / one byte
+            i_byte_index++;
+            i_bit_index = 0;
+        }
+    }
+
+    *r_bit_index = i_bit_index;
+    // If a partly filled byte is present, mark this as consumed
+    if (i_bit_index != 7) i_byte_index++;
+    return i_byte_index - packet_index;
 }
-#endif // MAVLINK_USE_CONVENIENCE_FUNCTIONS
 
 #ifdef MAVLINK_USE_CXX_NAMESPACE
 } // namespace mavlink

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -684,6 +684,28 @@ MAVLINK_HELPER uint8_t mavlink_max_message_length(const mavlink_message_t* msg)
     return msg_entry ? msg_entry->max_msg_len : 0;
 }
 
+/*
+  return the target system
+*/
+MAVLINK_HELPER uint8_t mavlink_get_target_system(const mavlink_message_t* msg)
+{
+    if (msg->msg_entry && (msg->msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM)) {
+        return (uint8_t)_MAV_PAYLOAD(msg)[msg->msg_entry->target_system_ofs];
+    }
+    return 0;
+}
+
+/*
+  return the target component
+*/
+MAVLINK_HELPER uint8_t mavlink_get_target_component(const mavlink_message_t* msg)
+{
+    if (msg->msg_entry && (msg->msg_entry->flags & MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT)) {
+        return (uint8_t)_MAV_PAYLOAD(msg)[msg->msg_entry->target_component_ofs];
+    }
+    return 0;
+}
+
 /**
  * This is an optimized variant of the mavlink parser with caller supplied
  * parsing buffers. It is useful when you want to create a MAVLink parser in
@@ -850,6 +872,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_nextchar(mavlink_message_t* msg, mavlink_st
 
     case MAVLINK_PARSE_STATE_GOT_PAYLOAD: {
         const mavlink_msg_entry_t* msg_entry = mavlink_get_msg_entry(msg->msgid);
+        msg->msg_entry = msg_entry;
         uint8_t crc_extra = msg_entry ? msg_entry->crc_extra : 0;
         mavlink_update_checksum(msg, crc_extra);
         if (c != (msg->checksum & 0xFF)) {

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -18,6 +18,7 @@ namespace mavlink {
 
 //FUNCTIONS WHICH THE USER MIGHT MODIFY
 
+#ifdef MAVLINK_USE_CHAN_FUNCTIONS
 /*
  * Internal function to give access to the channel status for each channel
  */
@@ -49,6 +50,7 @@ MAVLINK_HELPER mavlink_message_t* mavlink_get_channel_buffer(uint8_t chan)
     return &m_mavlink_buffer[chan];
 }
 #endif // MAVLINK_GET_CHANNEL_BUFFER
+#endif
 
 #ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
 // To make MAVLink work on your MCU, define comm_send_ch() if you wish
@@ -85,6 +87,15 @@ MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char* buf, 
 //MISCELANEOUS
 
 /**
+ * @brief Reset the status.
+ */
+MAVLINK_HELPER void mavlink_reset_status(mavlink_status_t* status)
+{
+    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
+}
+
+#ifdef MAVLINK_USE_CHAN_FUNCTIONS
+/**
  * @brief Reset the status of a channel.
  */
 MAVLINK_HELPER void mavlink_reset_channel_status(uint8_t chan)
@@ -120,6 +131,7 @@ MAVLINK_HELPER unsigned int mavlink_get_proto_version(uint8_t chan)
         return 2;
     }
 }
+#endif
 
 /**
  * @brief create a signature block for a packet
@@ -398,6 +410,7 @@ MAVLINK_HELPER uint16_t mavlink_finalize_message_buffer(mavlink_message_t* msg, 
     return msg->len + header_len + 2 + signature_len;
 }
 
+#ifdef MAVLINK_USE_CHAN_FUNCTIONS
 /**
  * @brief Finalize a MAVLink message with channel assignment
  */
@@ -416,6 +429,7 @@ MAVLINK_HELPER uint16_t mavlink_finalize_message(mavlink_message_t* msg, uint8_t
 {
     return mavlink_finalize_message_chan(msg, system_id, component_id, MAVLINK_COMM_0, min_length, length, crc_extra);
 }
+#endif
 
 static inline void _mav_parse_error(mavlink_status_t* status)
 {
@@ -964,6 +978,7 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
     return status->msg_received;
 }
 
+#ifdef MAVLINK_USE_CHAN_FUNCTIONS
 /**
  * This is a convenience function which handles the complete MAVLink parsing.
  * the function will parse one byte at a time and return the complete packet once
@@ -1076,6 +1091,7 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
     }
     return msg_received;
 }
+#endif
 
 // BITFIELD
 

--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -19,8 +19,8 @@ namespace mavlink {
   #define MAVPACKED( __Declaration__ ) __pragma( pack(push, 1) ) __Declaration__ __pragma( pack(pop) )
 #endif
 
-#ifndef MAVLINK_MAX_PAYLOAD_LEN
 // it is possible to override this, but be careful!
+#ifndef MAVLINK_MAX_PAYLOAD_LEN
 #define MAVLINK_MAX_PAYLOAD_LEN 255 ///< Maximum payload length
 #endif
 
@@ -45,19 +45,18 @@ namespace mavlink {
  */
 MAVPACKED(
 typedef struct param_union {
-	union {
-		float param_float;
-		int32_t param_int32;
-		uint32_t param_uint32;
-		int16_t param_int16;
-		uint16_t param_uint16;
-		int8_t param_int8;
-		uint8_t param_uint8;
-		uint8_t bytes[4];
-	};
-	uint8_t type;
+    union {
+        float param_float;
+        int32_t param_int32;
+        uint32_t param_uint32;
+        int16_t param_int16;
+        uint16_t param_uint16;
+        int8_t param_int8;
+        uint8_t param_uint8;
+        uint8_t bytes[4];
+    };
+    uint8_t type;
 }) mavlink_param_union_t;
-
 
 /**
  * New-style 8 byte param union
@@ -94,92 +93,78 @@ typedef struct param_union_extended {
     };
 }) mavlink_param_union_double_t;
 
-/**
- * This structure is required to make the mavlink_send_xxx convenience functions
- * work, as it tells the library what the current system and component ID are.
+#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM    1
+#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT 2
+
+/*
+  entry in table of information about each message type
  */
-MAVPACKED(
-typedef struct __mavlink_system {
-    uint8_t sysid;   ///< Used by the MAVLink message_xx_send() convenience function
-    uint8_t compid;  ///< Used by the MAVLink message_xx_send() convenience function
-}) mavlink_system_t;
+typedef struct __mavlink_msg_entry {
+    uint32_t msgid;
+    uint8_t crc_extra;
+    uint8_t min_msg_len;       // minimum message length
+    uint8_t max_msg_len;       // maximum message length (e.g. including mavlink2 extensions)
+    uint8_t flags;             // MAV_MSG_ENTRY_FLAG_*
+    uint8_t target_system_ofs; // payload offset to target_system, or 0
+    uint8_t target_component_ofs; // payload offset to target_component, or 0
+} mavlink_msg_entry_t;
 
 MAVPACKED(
 typedef struct __mavlink_message {
-	uint16_t checksum;      ///< sent at end of packet
-	uint8_t magic;          ///< protocol magic marker
-	uint8_t len;            ///< Length of payload
-	uint8_t incompat_flags; ///< flags that must be understood
-	uint8_t compat_flags;   ///< flags that can be ignored if not understood
-	uint8_t seq;            ///< Sequence of packet
-	uint8_t sysid;          ///< ID of message sender system/aircraft
-	uint8_t compid;         ///< ID of the message sender component
-	uint32_t msgid:24;      ///< ID of message in payload
-	uint64_t payload64[(MAVLINK_MAX_PAYLOAD_LEN+MAVLINK_NUM_CHECKSUM_BYTES+7)/8];
-	uint8_t ck[2];          ///< incoming checksum bytes
-	uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
+    uint16_t checksum;      ///< sent at end of packet
+    uint8_t magic;          ///< protocol magic marker
+    uint8_t len;            ///< Length of payload
+    uint8_t incompat_flags; ///< flags that must be understood
+    uint8_t compat_flags;   ///< flags that can be ignored if not understood
+    uint8_t seq;            ///< Sequence of packet
+    uint8_t sysid;          ///< ID of message sender system/aircraft
+    uint8_t compid;         ///< ID of the message sender component
+    uint32_t msgid:24;      ///< ID of message in payload
+    uint64_t payload64[(MAVLINK_MAX_PAYLOAD_LEN+MAVLINK_NUM_CHECKSUM_BYTES+7)/8];
+    uint8_t ck[2];          ///< incoming checksum bytes
+    uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
 }) mavlink_message_t;
 
 typedef enum {
-	MAVLINK_TYPE_CHAR     = 0,
-	MAVLINK_TYPE_UINT8_T  = 1,
-	MAVLINK_TYPE_INT8_T   = 2,
-	MAVLINK_TYPE_UINT16_T = 3,
-	MAVLINK_TYPE_INT16_T  = 4,
-	MAVLINK_TYPE_UINT32_T = 5,
-	MAVLINK_TYPE_INT32_T  = 6,
-	MAVLINK_TYPE_UINT64_T = 7,
-	MAVLINK_TYPE_INT64_T  = 8,
-	MAVLINK_TYPE_FLOAT    = 9,
-	MAVLINK_TYPE_DOUBLE   = 10
+    MAVLINK_TYPE_CHAR     = 0,
+    MAVLINK_TYPE_UINT8_T  = 1,
+    MAVLINK_TYPE_INT8_T   = 2,
+    MAVLINK_TYPE_UINT16_T = 3,
+    MAVLINK_TYPE_INT16_T  = 4,
+    MAVLINK_TYPE_UINT32_T = 5,
+    MAVLINK_TYPE_INT32_T  = 6,
+    MAVLINK_TYPE_UINT64_T = 7,
+    MAVLINK_TYPE_INT64_T  = 8,
+    MAVLINK_TYPE_FLOAT    = 9,
+    MAVLINK_TYPE_DOUBLE   = 10
 } mavlink_message_type_t;
 
 #define MAVLINK_MAX_FIELDS 64
 
 typedef struct __mavlink_field_info {
-	const char *name;                 // name of this field
-        const char *print_format;         // printing format hint, or NULL
-        mavlink_message_type_t type;      // type of this field
-        unsigned int array_length;        // if non-zero, field is an array
-        unsigned int wire_offset;         // offset of each field in the payload
-        unsigned int structure_offset;    // offset in a C structure
+    const char* name;                 // name of this field
+    const char* print_format;         // printing format hint, or NULL
+    mavlink_message_type_t type;      // type of this field
+    unsigned int array_length;        // if non-zero, field is an array
+    unsigned int wire_offset;         // offset of each field in the payload
+    unsigned int structure_offset;    // offset in a C structure
 } mavlink_field_info_t;
 
 // note that in this structure the order of fields is the order
 // in the XML file, not necessary the wire order
 typedef struct __mavlink_message_info {
-	uint32_t msgid;                                        // message ID
-	const char *name;                                      // name of the message
-	unsigned num_fields;                                   // how many fields in this message
-	mavlink_field_info_t fields[MAVLINK_MAX_FIELDS];       // field information
+    uint32_t msgid;                                        // message ID
+    const char* name;                                      // name of the message
+    unsigned num_fields;                                   // how many fields in this message
+    mavlink_field_info_t fields[MAVLINK_MAX_FIELDS];       // field information
 } mavlink_message_info_t;
 
-#define _MAV_PAYLOAD(msg) ((const char *)(&((msg)->payload64[0])))
-#define _MAV_PAYLOAD_NON_CONST(msg) ((char *)(&((msg)->payload64[0])))
+#define _MAV_PAYLOAD(msg) ((const char*)(&((msg)->payload64[0])))
+#define _MAV_PAYLOAD_NON_CONST(msg) ((char*)(&((msg)->payload64[0])))
 
 // checksum is immediately after the payload bytes
-#define mavlink_ck_a(msg) *((msg)->len + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
-#define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
-
-typedef enum {
-    MAVLINK_COMM_0,
-    MAVLINK_COMM_1,
-    MAVLINK_COMM_2,
-    MAVLINK_COMM_3
-} mavlink_channel_t;
-
-/*
- * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number
- * of buffers they will use. If more are used, then the result will be
- * a stack overrun
- */
-#ifndef MAVLINK_COMM_NUM_BUFFERS
-#if (defined linux) | (defined __linux) | (defined  __MACH__) | (defined _WIN32)
-# define MAVLINK_COMM_NUM_BUFFERS 16
-#else
-# define MAVLINK_COMM_NUM_BUFFERS 4
-#endif
-#endif
+#define mavlink_ck_a(msg) *((msg)->len + (uint8_t*)_MAV_PAYLOAD_NON_CONST(msg))
+#define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t*)_MAV_PAYLOAD_NON_CONST(msg))
 
 typedef enum {
     MAVLINK_PARSE_STATE_UNINIT=0,
@@ -226,14 +211,14 @@ typedef struct __mavlink_status {
     uint16_t packet_rx_drop_count;      ///< Number of packet drops
     uint8_t flags;                      ///< MAVLINK_STATUS_FLAG_*
     uint8_t signature_wait;             ///< number of signature bytes left to receive
-    struct __mavlink_signing *signing;  ///< optional signing state
-    struct __mavlink_signing_streams *signing_streams; ///< global record of stream timestamps
+    struct __mavlink_signing* signing;  ///< optional signing state
+    struct __mavlink_signing_streams* signing_streams; ///< global record of stream timestamps
 } mavlink_status_t;
 
 /*
   a callback function to allow for accepting unsigned packets
  */
-typedef bool (*mavlink_accept_unsigned_t)(const mavlink_status_t *status, uint32_t msgid);
+typedef bool (*mavlink_accept_unsigned_t)(const mavlink_status_t* status, uint32_t msgid);
 
 /*
   flags controlling signing
@@ -268,31 +253,50 @@ typedef struct __mavlink_signing_streams {
     } stream[MAVLINK_MAX_SIGNING_STREAMS];
 } mavlink_signing_streams_t;
 
-
 #define MAVLINK_BIG_ENDIAN 0
 #define MAVLINK_LITTLE_ENDIAN 1
-
-#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_SYSTEM    1
-#define MAV_MSG_ENTRY_FLAG_HAVE_TARGET_COMPONENT 2
-
-/*
-  entry in table of information about each message type
- */
-typedef struct __mavlink_msg_entry {
-	uint32_t msgid;
-	uint8_t crc_extra;
-        uint8_t min_msg_len;       // minimum message length
-        uint8_t max_msg_len;       // maximum message length (e.g. including mavlink2 extensions)
-        uint8_t flags;             // MAV_MSG_ENTRY_FLAG_*
-	uint8_t target_system_ofs; // payload offset to target_system, or 0
-	uint8_t target_component_ofs; // payload offset to target_component, or 0
-} mavlink_msg_entry_t;
 
 /*
   incompat_flags bits
  */
 #define MAVLINK_IFLAG_SIGNED  0x01
 #define MAVLINK_IFLAG_MASK    0x01 // mask of all understood bits
+
+//CONVENIENCE
+
+/**
+ * This structure is required to make the mavlink_send_xxx convenience functions
+ * work, as it tells the library what the current system and component ID are.
+ */
+MAVPACKED(
+typedef struct __mavlink_system {
+    uint8_t sysid;   ///< Used by the MAVLink message_xx_send() convenience function
+    uint8_t compid;  ///< Used by the MAVLink message_xx_send() convenience function
+}) mavlink_system_t;
+
+typedef enum {
+    MAVLINK_COMM_0,
+    MAVLINK_COMM_1,
+    MAVLINK_COMM_2,
+    MAVLINK_COMM_3
+} mavlink_channel_t;
+
+/*
+ * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number
+ * of buffers they will use. If more are used, then the result will be
+ * a stack overrun
+ */
+#ifndef MAVLINK_COMM_NUM_BUFFERS
+#if (defined linux) | (defined __linux) | (defined  __MACH__) | (defined _WIN32)
+# define MAVLINK_COMM_NUM_BUFFERS 16
+#else
+# define MAVLINK_COMM_NUM_BUFFERS 4
+#endif
+#endif
+
+#if MAVLINK_COMM_NUM_BUFFERS>0
+# define MAVLINK_USE_CHAN_FUNCTIONS
+#endif
 
 #ifdef MAVLINK_USE_CXX_NAMESPACE
 } // namespace mavlink

--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -123,6 +123,8 @@ typedef struct __mavlink_message {
     uint64_t payload64[(MAVLINK_MAX_PAYLOAD_LEN+MAVLINK_NUM_CHECKSUM_BYTES+7)/8];
     uint8_t ck[2];          ///< incoming checksum bytes
     uint8_t signature[MAVLINK_SIGNATURE_BLOCK_LEN];
+//metadata
+    const mavlink_msg_entry_t* msg_entry;
 }) mavlink_message_t;
 
 typedef enum {

--- a/generator/C/include_v2.0/protocol.h
+++ b/generator/C/include_v2.0/protocol.h
@@ -48,25 +48,22 @@
     MAVLINK_HELPER uint16_t mavlink_finalize_message(mavlink_message_t* msg, uint8_t system_id, uint8_t component_id,
                                                      uint8_t min_length, uint8_t length, uint8_t crc_extra);
     #ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
-    MAVLINK_HELPER void _mav_finalize_message_chan_send(mavlink_channel_t chan, uint32_t msgid, const char *packet,
+    MAVLINK_HELPER void _mav_finalize_message_chan_send(mavlink_channel_t chan, uint32_t msgid, const char* packet,
                                                         uint8_t min_length, uint8_t length, uint8_t crc_extra);
     #endif
-    MAVLINK_HELPER uint16_t mavlink_msg_to_send_buffer(uint8_t *buffer, const mavlink_message_t *msg);
+    MAVLINK_HELPER uint16_t mavlink_msg_to_send_buffer(uint8_t* buffer, const mavlink_message_t* msg);
     MAVLINK_HELPER void mavlink_start_checksum(mavlink_message_t* msg);
     MAVLINK_HELPER void mavlink_update_checksum(mavlink_message_t* msg, uint8_t c);
-    MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg, 
-						     mavlink_status_t* status,
-						     uint8_t c, 
-						     mavlink_message_t* r_message, 
-						     mavlink_status_t* r_mavlink_status);
+    MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg, mavlink_status_t* status, uint8_t c, 
+                                                     mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status);
     MAVLINK_HELPER uint8_t mavlink_frame_char(uint8_t chan, uint8_t c, mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status);
     MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_message_t* r_message, mavlink_status_t* r_mavlink_status);
     MAVLINK_HELPER uint8_t put_bitfield_n_by_index(int32_t b, uint8_t bits, uint8_t packet_index, uint8_t bit_index,
-                               uint8_t* r_bit_index, uint8_t* buffer);
-    MAVLINK_HELPER const mavlink_msg_entry_t *mavlink_get_msg_entry(uint32_t msgid);
+                                                   uint8_t* r_bit_index, uint8_t* buffer);
+    MAVLINK_HELPER const mavlink_msg_entry_t* mavlink_get_msg_entry(uint32_t msgid);
     #ifdef MAVLINK_USE_CONVENIENCE_FUNCTIONS
-    MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char *buf, uint16_t len);
-    MAVLINK_HELPER void _mavlink_resend_uart(mavlink_channel_t chan, const mavlink_message_t *msg);
+    MAVLINK_HELPER void _mavlink_send_uart(mavlink_channel_t chan, const char* buf, uint16_t len);
+    MAVLINK_HELPER void _mavlink_resend_uart(mavlink_channel_t chan, const mavlink_message_t* msg);
     #endif
 
 #else
@@ -76,114 +73,112 @@
 
 #endif // MAVLINK_SEPARATE_HELPERS
 
-
 /**
  * @brief Get the required buffer size for this message
  */
 static inline uint16_t mavlink_msg_get_send_buffer_length(const mavlink_message_t* msg)
 {
-	if (msg->magic == MAVLINK_STX_MAVLINK1) {
-		return msg->len + MAVLINK_CORE_HEADER_MAVLINK1_LEN+1 + 2;
-	}
-    	uint16_t signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED)?MAVLINK_SIGNATURE_BLOCK_LEN:0;
-	return msg->len + MAVLINK_NUM_NON_PAYLOAD_BYTES + signature_len;
+    if (msg->magic == MAVLINK_STX_MAVLINK1) {
+        return msg->len + MAVLINK_CORE_HEADER_MAVLINK1_LEN+1 + 2;
+    }
+    uint16_t signature_len = (msg->incompat_flags & MAVLINK_IFLAG_SIGNED) ? MAVLINK_SIGNATURE_BLOCK_LEN : 0;
+    return msg->len + MAVLINK_NUM_NON_PAYLOAD_BYTES + signature_len;
 }
 
 #if MAVLINK_NEED_BYTE_SWAP
-static inline void byte_swap_2(char *dst, const char *src)
+static inline void byte_swap_2(char* dst, const char* src)
 {
-	dst[0] = src[1];
-	dst[1] = src[0];
+    dst[0] = src[1];
+    dst[1] = src[0];
 }
-static inline void byte_swap_4(char *dst, const char *src)
+static inline void byte_swap_4(char* dst, const char* src)
 {
-	dst[0] = src[3];
-	dst[1] = src[2];
-	dst[2] = src[1];
-	dst[3] = src[0];
+    dst[0] = src[3];
+    dst[1] = src[2];
+    dst[2] = src[1];
+    dst[3] = src[0];
 }
-static inline void byte_swap_8(char *dst, const char *src)
+static inline void byte_swap_8(char* dst, const char* src)
 {
-	dst[0] = src[7];
-	dst[1] = src[6];
-	dst[2] = src[5];
-	dst[3] = src[4];
-	dst[4] = src[3];
-	dst[5] = src[2];
-	dst[6] = src[1];
-	dst[7] = src[0];
+    dst[0] = src[7];
+    dst[1] = src[6];
+    dst[2] = src[5];
+    dst[3] = src[4];
+    dst[4] = src[3];
+    dst[5] = src[2];
+    dst[6] = src[1];
+    dst[7] = src[0];
 }
 #elif !MAVLINK_ALIGNED_FIELDS
-static inline void byte_copy_2(char *dst, const char *src)
+static inline void byte_copy_2(char* dst, const char* src)
 {
-	dst[0] = src[0];
-	dst[1] = src[1];
+    dst[0] = src[0];
+    dst[1] = src[1];
 }
-static inline void byte_copy_4(char *dst, const char *src)
+static inline void byte_copy_4(char* dst, const char* src)
 {
-	dst[0] = src[0];
-	dst[1] = src[1];
-	dst[2] = src[2];
-	dst[3] = src[3];
+    dst[0] = src[0];
+    dst[1] = src[1];
+    dst[2] = src[2];
+    dst[3] = src[3];
 }
-static inline void byte_copy_8(char *dst, const char *src)
+static inline void byte_copy_8(char* dst, const char* src)
 {
-	memcpy(dst, src, 8);
+    memcpy(dst, src, 8);
 }
 #endif
 
-#define _mav_put_uint8_t(buf, wire_offset, b) buf[wire_offset] = (uint8_t)b
-#define _mav_put_int8_t(buf, wire_offset, b)  buf[wire_offset] = (int8_t)b
-#define _mav_put_char(buf, wire_offset, b)    buf[wire_offset] = b
+#define _mav_put_uint8_t(buf, wire_offset, b)   buf[wire_offset] = (uint8_t)b
+#define _mav_put_int8_t(buf, wire_offset, b)    buf[wire_offset] = (int8_t)b
+#define _mav_put_char(buf, wire_offset, b)      buf[wire_offset] = b
 
 #if MAVLINK_NEED_BYTE_SWAP
-#define _mav_put_uint16_t(buf, wire_offset, b) byte_swap_2(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int16_t(buf, wire_offset, b)  byte_swap_2(&buf[wire_offset], (const char *)&b)
-#define _mav_put_uint32_t(buf, wire_offset, b) byte_swap_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int32_t(buf, wire_offset, b)  byte_swap_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_uint64_t(buf, wire_offset, b) byte_swap_8(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int64_t(buf, wire_offset, b)  byte_swap_8(&buf[wire_offset], (const char *)&b)
-#define _mav_put_float(buf, wire_offset, b)    byte_swap_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_double(buf, wire_offset, b)   byte_swap_8(&buf[wire_offset], (const char *)&b)
+#define _mav_put_uint16_t(buf, wire_offset, b)  byte_swap_2(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int16_t(buf, wire_offset, b)   byte_swap_2(&buf[wire_offset], (const char*)&b)
+#define _mav_put_uint32_t(buf, wire_offset, b)  byte_swap_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int32_t(buf, wire_offset, b)   byte_swap_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_uint64_t(buf, wire_offset, b)  byte_swap_8(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int64_t(buf, wire_offset, b)   byte_swap_8(&buf[wire_offset], (const char*)&b)
+#define _mav_put_float(buf, wire_offset, b)     byte_swap_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_double(buf, wire_offset, b)    byte_swap_8(&buf[wire_offset], (const char*)&b)
 #elif !MAVLINK_ALIGNED_FIELDS
-#define _mav_put_uint16_t(buf, wire_offset, b) byte_copy_2(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int16_t(buf, wire_offset, b)  byte_copy_2(&buf[wire_offset], (const char *)&b)
-#define _mav_put_uint32_t(buf, wire_offset, b) byte_copy_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int32_t(buf, wire_offset, b)  byte_copy_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_uint64_t(buf, wire_offset, b) byte_copy_8(&buf[wire_offset], (const char *)&b)
-#define _mav_put_int64_t(buf, wire_offset, b)  byte_copy_8(&buf[wire_offset], (const char *)&b)
-#define _mav_put_float(buf, wire_offset, b)    byte_copy_4(&buf[wire_offset], (const char *)&b)
-#define _mav_put_double(buf, wire_offset, b)   byte_copy_8(&buf[wire_offset], (const char *)&b)
+#define _mav_put_uint16_t(buf, wire_offset, b)  byte_copy_2(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int16_t(buf, wire_offset, b)   byte_copy_2(&buf[wire_offset], (const char*)&b)
+#define _mav_put_uint32_t(buf, wire_offset, b)  byte_copy_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int32_t(buf, wire_offset, b)   byte_copy_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_uint64_t(buf, wire_offset, b)  byte_copy_8(&buf[wire_offset], (const char*)&b)
+#define _mav_put_int64_t(buf, wire_offset, b)   byte_copy_8(&buf[wire_offset], (const char*)&b)
+#define _mav_put_float(buf, wire_offset, b)     byte_copy_4(&buf[wire_offset], (const char*)&b)
+#define _mav_put_double(buf, wire_offset, b)    byte_copy_8(&buf[wire_offset], (const char*)&b)
 #else
-#define _mav_put_uint16_t(buf, wire_offset, b) *(uint16_t *)&buf[wire_offset] = b
-#define _mav_put_int16_t(buf, wire_offset, b)  *(int16_t *)&buf[wire_offset] = b
-#define _mav_put_uint32_t(buf, wire_offset, b) *(uint32_t *)&buf[wire_offset] = b
-#define _mav_put_int32_t(buf, wire_offset, b)  *(int32_t *)&buf[wire_offset] = b
-#define _mav_put_uint64_t(buf, wire_offset, b) *(uint64_t *)&buf[wire_offset] = b
-#define _mav_put_int64_t(buf, wire_offset, b)  *(int64_t *)&buf[wire_offset] = b
-#define _mav_put_float(buf, wire_offset, b)    *(float *)&buf[wire_offset] = b
-#define _mav_put_double(buf, wire_offset, b)   *(double *)&buf[wire_offset] = b
+#define _mav_put_uint16_t(buf, wire_offset, b)  *(uint16_t*)&buf[wire_offset] = b
+#define _mav_put_int16_t(buf, wire_offset, b)   *(int16_t*)&buf[wire_offset] = b
+#define _mav_put_uint32_t(buf, wire_offset, b)  *(uint32_t*)&buf[wire_offset] = b
+#define _mav_put_int32_t(buf, wire_offset, b)   *(int32_t*)&buf[wire_offset] = b
+#define _mav_put_uint64_t(buf, wire_offset, b)  *(uint64_t*)&buf[wire_offset] = b
+#define _mav_put_int64_t(buf, wire_offset, b)   *(int64_t*)&buf[wire_offset] = b
+#define _mav_put_float(buf, wire_offset, b)     *(float*)&buf[wire_offset] = b
+#define _mav_put_double(buf, wire_offset, b)    *(double*)&buf[wire_offset] = b
 #endif
 
 /*
   like memcpy(), but if src is NULL, do a memset to zero
 */
-static inline void mav_array_memcpy(void *dest, const void *src, size_t n)
+static inline void mav_array_memcpy(void* dest, const void* src, size_t n)
 {
-	if (src == NULL) {
-		memset(dest, 0, n);
-	} else {
-		memcpy(dest, src, n);
-	}
+    if (src == NULL) {
+        memset(dest, 0, n);
+    } else {
+        memcpy(dest, src, n);
+    }
 }
 
 /*
  * Place a char array into a buffer
  */
-static inline void _mav_put_char_array(char *buf, uint8_t wire_offset, const char *b, uint8_t array_length)
+static inline void _mav_put_char_array(char* buf, uint8_t wire_offset, const char* b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+    mav_array_memcpy(&buf[wire_offset], b, array_length);
 }
 
 /*
@@ -191,37 +186,35 @@ static inline void _mav_put_char_array(char *buf, uint8_t wire_offset, const cha
  */
 static inline void _mav_put_uint8_t_array(char *buf, uint8_t wire_offset, const uint8_t *b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+    mav_array_memcpy(&buf[wire_offset], b, array_length);
 }
 
 /*
  * Place a int8_t array into a buffer
  */
-static inline void _mav_put_int8_t_array(char *buf, uint8_t wire_offset, const int8_t *b, uint8_t array_length)
+static inline void _mav_put_int8_t_array(char* buf, uint8_t wire_offset, const int8_t* b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+    mav_array_memcpy(&buf[wire_offset], b, array_length);
 }
 
 #if MAVLINK_NEED_BYTE_SWAP
 #define _MAV_PUT_ARRAY(TYPE, V) \
-static inline void _mav_put_ ## TYPE ##_array(char *buf, uint8_t wire_offset, const TYPE *b, uint8_t array_length) \
+static inline void _mav_put_ ## TYPE ##_array(char* buf, uint8_t wire_offset, const TYPE* b, uint8_t array_length) \
 { \
-	if (b == NULL) { \
-		memset(&buf[wire_offset], 0, array_length*sizeof(TYPE)); \
-	} else { \
-		uint16_t i; \
-		for (i=0; i<array_length; i++) { \
-			_mav_put_## TYPE (buf, wire_offset+(i*sizeof(TYPE)), b[i]); \
-		} \
-	} \
+    if (b == NULL) { \
+        memset(&buf[wire_offset], 0, array_length*sizeof(TYPE)); \
+    } else { \
+        uint16_t i; \
+        for (i=0; i<array_length; i++) { \
+            _mav_put_## TYPE (buf, wire_offset+(i*sizeof(TYPE)), b[i]); \
+        } \
+    } \
 }
 #else
-#define _MAV_PUT_ARRAY(TYPE, V)					\
-static inline void _mav_put_ ## TYPE ##_array(char *buf, uint8_t wire_offset, const TYPE *b, uint8_t array_length) \
+#define _MAV_PUT_ARRAY(TYPE, V)                 \
+static inline void _mav_put_ ## TYPE ##_array(char* buf, uint8_t wire_offset, const TYPE* b, uint8_t array_length) \
 { \
-	mav_array_memcpy(&buf[wire_offset], b, array_length*sizeof(TYPE)); \
+    mav_array_memcpy(&buf[wire_offset], b, array_length*sizeof(TYPE)); \
 }
 #endif
 
@@ -234,13 +227,13 @@ _MAV_PUT_ARRAY(int64_t,  i64)
 _MAV_PUT_ARRAY(float,    f)
 _MAV_PUT_ARRAY(double,   d)
 
-#define _MAV_RETURN_char(msg, wire_offset)             (char)_MAV_PAYLOAD(msg)[wire_offset]
-#define _MAV_RETURN_int8_t(msg, wire_offset)   (int8_t)_MAV_PAYLOAD(msg)[wire_offset]
-#define _MAV_RETURN_uint8_t(msg, wire_offset) (uint8_t)_MAV_PAYLOAD(msg)[wire_offset]
+#define _MAV_RETURN_char(msg, wire_offset)      (char)_MAV_PAYLOAD(msg)[wire_offset]
+#define _MAV_RETURN_int8_t(msg, wire_offset)    (int8_t)_MAV_PAYLOAD(msg)[wire_offset]
+#define _MAV_RETURN_uint8_t(msg, wire_offset)   (uint8_t)_MAV_PAYLOAD(msg)[wire_offset]
 
 #if MAVLINK_NEED_BYTE_SWAP
 #define _MAV_MSG_RETURN_TYPE(TYPE, SIZE) \
-static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t *msg, uint8_t ofs) \
+static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t* msg, uint8_t ofs) \
 { TYPE r; byte_swap_## SIZE((char*)&r, &_MAV_PAYLOAD(msg)[ofs]); return r; }
 
 _MAV_MSG_RETURN_TYPE(uint16_t, 2)
@@ -254,7 +247,7 @@ _MAV_MSG_RETURN_TYPE(double,   8)
 
 #elif !MAVLINK_ALIGNED_FIELDS
 #define _MAV_MSG_RETURN_TYPE(TYPE, SIZE) \
-static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t *msg, uint8_t ofs) \
+static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t* msg, uint8_t ofs) \
 { TYPE r; byte_copy_## SIZE((char*)&r, &_MAV_PAYLOAD(msg)[ofs]); return r; }
 
 _MAV_MSG_RETURN_TYPE(uint16_t, 2)
@@ -267,8 +260,8 @@ _MAV_MSG_RETURN_TYPE(float,    4)
 _MAV_MSG_RETURN_TYPE(double,   8)
 #else // nicely aligned, no swap
 #define _MAV_MSG_RETURN_TYPE(TYPE) \
-static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t *msg, uint8_t ofs) \
-{ return *(const TYPE *)(&_MAV_PAYLOAD(msg)[ofs]);}
+static inline TYPE _MAV_RETURN_## TYPE(const mavlink_message_t* msg, uint8_t ofs) \
+{ return *(const TYPE*)(&_MAV_PAYLOAD(msg)[ofs]);}
 
 _MAV_MSG_RETURN_TYPE(uint16_t)
 _MAV_MSG_RETURN_TYPE(int16_t)
@@ -280,45 +273,45 @@ _MAV_MSG_RETURN_TYPE(float)
 _MAV_MSG_RETURN_TYPE(double)
 #endif // MAVLINK_NEED_BYTE_SWAP
 
-static inline uint16_t _MAV_RETURN_char_array(const mavlink_message_t *msg, char *value, 
-						     uint8_t array_length, uint8_t wire_offset)
+static inline uint16_t _MAV_RETURN_char_array(const mavlink_message_t* msg, char* value, 
+                            uint8_t array_length, uint8_t wire_offset)
 {
-	memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
-	return array_length;
+    memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
+    return array_length;
 }
 
-static inline uint16_t _MAV_RETURN_uint8_t_array(const mavlink_message_t *msg, uint8_t *value, 
-							uint8_t array_length, uint8_t wire_offset)
+static inline uint16_t _MAV_RETURN_uint8_t_array(const mavlink_message_t* msg, uint8_t* value, 
+                            uint8_t array_length, uint8_t wire_offset)
 {
-	memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
-	return array_length;
+    memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
+    return array_length;
 }
 
-static inline uint16_t _MAV_RETURN_int8_t_array(const mavlink_message_t *msg, int8_t *value, 
-						       uint8_t array_length, uint8_t wire_offset)
+static inline uint16_t _MAV_RETURN_int8_t_array(const mavlink_message_t* msg, int8_t* value, 
+                            uint8_t array_length, uint8_t wire_offset)
 {
-	memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
-	return array_length;
+    memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length);
+    return array_length;
 }
 
 #if MAVLINK_NEED_BYTE_SWAP
 #define _MAV_RETURN_ARRAY(TYPE, V) \
-static inline uint16_t _MAV_RETURN_## TYPE ##_array(const mavlink_message_t *msg, TYPE *value, \
-							 uint8_t array_length, uint8_t wire_offset) \
+static inline uint16_t _MAV_RETURN_## TYPE ##_array(const mavlink_message_t* msg, TYPE* value, \
+                            uint8_t array_length, uint8_t wire_offset) \
 { \
-	uint16_t i; \
-	for (i=0; i<array_length; i++) { \
-		value[i] = _MAV_RETURN_## TYPE (msg, wire_offset+(i*sizeof(value[0]))); \
-	} \
-	return array_length*sizeof(value[0]); \
+    uint16_t i; \
+    for (i=0; i<array_length; i++) { \
+        value[i] = _MAV_RETURN_## TYPE (msg, wire_offset+(i*sizeof(value[0]))); \
+    } \
+    return array_length*sizeof(value[0]); \
 }
 #else
-#define _MAV_RETURN_ARRAY(TYPE, V)					\
-static inline uint16_t _MAV_RETURN_## TYPE ##_array(const mavlink_message_t *msg, TYPE *value, \
-							 uint8_t array_length, uint8_t wire_offset) \
+#define _MAV_RETURN_ARRAY(TYPE, V)                  \
+static inline uint16_t _MAV_RETURN_## TYPE ##_array(const mavlink_message_t* msg, TYPE* value, \
+                            uint8_t array_length, uint8_t wire_offset) \
 { \
-	memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length*sizeof(TYPE)); \
-	return array_length*sizeof(TYPE); \
+    memcpy(value, &_MAV_PAYLOAD(msg)[wire_offset], array_length*sizeof(TYPE)); \
+    return array_length*sizeof(TYPE); \
 }
 #endif
 

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -116,14 +116,13 @@ extern "C" {
 #define MAVLINK_ENABLED_${basename_upper}
 
 // ENUM DEFINITIONS
-
 ${{enum:
 /** @brief ${description} */
 #ifndef HAVE_ENUM_${name}
 #define HAVE_ENUM_${name}
 typedef enum ${name}
 {
-${{entry:   ${name}=${value}, /* ${description} |${{param:${description}| }} */
+${{entry:    ${name}=${value}, /* ${description} |${{param:${description}| }} */
 }}
 } ${name};
 #endif
@@ -141,10 +140,12 @@ ${{entry:   ${name}=${value}, /* ${description} |${{param:${description}| }} */
 #endif
 
 // MESSAGE DEFINITIONS
+
 ${{message:#include "./mavlink_msg_${name_lower}.h"
 }}
 
-// base include
+// BASE INCLUDES
+
 ${{include_list:#include "../${base}/${base}.h"
 }}
 
@@ -152,11 +153,11 @@ ${{include_list:#include "../${base}/${base}.h"
 #define MAVLINK_THIS_XML_IDX ${xml_idx}
 
 #if MAVLINK_THIS_XML_IDX == MAVLINK_PRIMARY_XML_IDX
-# define MAVLINK_MESSAGE_INFO {${message_info_array}}
-# define MAVLINK_MESSAGE_NAMES {${message_name_array}}
-# if MAVLINK_COMMAND_24BIT
-#  include "../mavlink_get_info.h"
-# endif
+#  define MAVLINK_MESSAGE_INFO {${message_info_array}}
+#  define MAVLINK_MESSAGE_NAMES {${message_name_array}}
+#  if MAVLINK_COMMAND_24BIT
+#    include "../mavlink_get_info.h"
+#  endif
 #endif
 
 #ifdef __cplusplus
@@ -179,7 +180,7 @@ def generate_message_h(directory, m):
 
 MAVPACKED(
 typedef struct __mavlink_${name_lower}_t {
-${{ordered_fields: ${type} ${name}${array_suffix}; /*< ${units} ${description}*/
+${{ordered_fields:    ${type} ${name}${array_suffix}; /*< ${units} ${description}*/
 }}
 }) mavlink_${name_lower}_t;
 
@@ -222,7 +223,7 @@ ${{arg_fields: * @param ${name} ${units} ${description}
  * @return length of the message in bytes (excluding serial stream start sign)
  */
 static inline uint16_t mavlink_msg_${name_lower}_pack(uint8_t system_id, uint8_t component_id, mavlink_message_t* msg,
-                              ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
+                                ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
     char buf[MAVLINK_MSG_ID_${name}_LEN];
@@ -230,14 +231,14 @@ ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
 }}
-        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_${name}_LEN);
+    memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_${name}_LEN);
 #else
     mavlink_${name_lower}_t packet;
 ${{scalar_fields:    packet.${name} = ${putname};
 }}
 ${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
 }}
-        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
+    memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
 #endif
 
     msg->msgid = MAVLINK_MSG_ID_${name};
@@ -255,8 +256,8 @@ ${{arg_fields: * @param ${name} ${units} ${description}
  * @return length of the message in bytes (excluding serial stream start sign)
  */
 static inline uint16_t mavlink_msg_${name_lower}_pack_chan(uint8_t system_id, uint8_t component_id, uint8_t chan,
-                               mavlink_message_t* msg,
-                                   ${{arg_fields:${array_const}${type} ${array_prefix}${name},}})
+                                mavlink_message_t* msg,
+                               ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
     char buf[MAVLINK_MSG_ID_${name}_LEN];
@@ -264,14 +265,14 @@ ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
 }}
-        memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_${name}_LEN);
+    memcpy(_MAV_PAYLOAD_NON_CONST(msg), buf, MAVLINK_MSG_ID_${name}_LEN);
 #else
     mavlink_${name_lower}_t packet;
 ${{scalar_fields:    packet.${name} = ${putname};
 }}
 ${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
 }}
-        memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
+    memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
 #endif
 
     msg->msgid = MAVLINK_MSG_ID_${name};
@@ -329,7 +330,7 @@ ${{scalar_fields:    packet.${name} = ${putname};
 }}
 ${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
 }}
-    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char *)&packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char*)&packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #endif
 }
 
@@ -343,7 +344,7 @@ static inline void mavlink_msg_${name_lower}_send_struct(mavlink_channel_t chan,
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
     mavlink_msg_${name_lower}_send(chan,${{arg_fields: ${name_lower}->${name},}});
 #else
-    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char *)${name_lower}, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char*)${name_lower}, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #endif
 }
 
@@ -355,22 +356,22 @@ static inline void mavlink_msg_${name_lower}_send_struct(mavlink_channel_t chan,
   is usually the receive buffer for the channel, and allows a reply to an
   incoming message with minimum stack space usage.
  */
-static inline void mavlink_msg_${name_lower}_send_buf(mavlink_message_t *msgbuf, mavlink_channel_t chan, ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
+static inline void mavlink_msg_${name_lower}_send_buf(mavlink_message_t* msgbuf, mavlink_channel_t chan,${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
-    char *buf = (char *)msgbuf;
+    char *buf = (char*)msgbuf;
 ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
 }}
     _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, buf, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #else
-    mavlink_${name_lower}_t *packet = (mavlink_${name_lower}_t *)msgbuf;
+    mavlink_${name_lower}_t* packet = (mavlink_${name_lower}_t*)msgbuf;
 ${{scalar_fields:    packet->${name} = ${putname};
 }}
 ${{array_fields:    mav_array_memcpy(packet->${name}, ${name}, sizeof(${type})*${array_length});
 }}
-    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char *)packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
+    _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char*)packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #endif
 }
 #endif
@@ -387,7 +388,7 @@ ${{fields:
  */
 static inline ${return_type} mavlink_msg_${name_lower}_get_${name}(const mavlink_message_t* msg${get_arg})
 {
-    return _MAV_RETURN_${type}${array_tag}(msg, ${array_return_arg} ${wire_offset});
+    return _MAV_RETURN_${type}${array_tag}(msg, ${array_return_arg}${wire_offset});
 }
 }}
 
@@ -403,8 +404,8 @@ static inline void mavlink_msg_${name_lower}_decode(const mavlink_message_t* msg
 ${{ordered_fields:    ${decode_left}mavlink_msg_${name_lower}_get_${name}(msg${decode_right});
 }}
 #else
-        uint8_t len = msg->len < MAVLINK_MSG_ID_${name}_LEN? msg->len : MAVLINK_MSG_ID_${name}_LEN;
-        memset(${name_lower}, 0, MAVLINK_MSG_ID_${name}_LEN);
+    uint8_t len = msg->len < MAVLINK_MSG_ID_${name}_LEN ? msg->len : MAVLINK_MSG_ID_${name}_LEN;
+    memset(${name_lower}, 0, MAVLINK_MSG_ID_${name}_LEN);
     memcpy(${name_lower}, _MAV_PAYLOAD(msg), len);
 #endif
 }

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -293,6 +293,7 @@ ${{array_fields:    mav_array_memcpy(packet->${name}, ${name}, sizeof(${type})*$
                                           MAVLINK_MSG_ID_${name}, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 }
 
+#ifdef MAVLINK_USE_CHAN_FUNCTIONS
 /**
  * @brief Pack a ${name_lower} message
  * @param system_id ID of this system
@@ -386,6 +387,8 @@ static inline uint16_t mavlink_msg_${name_lower}_encode_chan(uint8_t system_id, 
 {
     return mavlink_msg_${name_lower}_pack_chan(system_id, component_id, chan, msg,${{arg_fields: ${name_lower}->${name},}});
 }
+
+#endif
 
 /**
  * @brief Send a ${name_lower} message

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -255,6 +255,45 @@ ${{array_fields:#define MAVLINK_MSG_${msg_name}_FIELD_${name_upper}_LEN ${array_
 #endif
 
 /**
+ * @brief Pack a ${name_lower} message into a transmit buffer
+ * @param mav_txbuf The transmit buffer
+ * @param mav_status The parsing status buffer
+ * @param system_id ID of this system
+ * @param component_id ID of this component (e.g. 200 for IMU)
+ *
+${{arg_fields: * @param ${name} ${units} ${description}
+}}
+ * @return length of the complete message in bytes in the transmit buffer
+ */
+static inline uint16_t mavlink_msg_${name_lower}_pack_txbuf(char* mav_txbuf, mavlink_status_t* mav_status, uint8_t system_id, uint8_t component_id,
+                                  ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
+{
+    uint8_t header_len;
+    if (mav_status->flags & MAVLINK_STATUS_FLAG_OUT_MAVLINK1) {
+        header_len = MAVLINK_CORE_HEADER_MAVLINK1_LEN+1;
+    } else {
+        header_len = MAVLINK_CORE_HEADER_LEN+1;
+    }
+
+#if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
+    char* buf = (char*)(&mav_txbuf[header_len]);
+${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
+}}
+${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
+}}
+#else
+    mavlink_${name_lower}_t* packet = (mavlink_${name_lower}_t*)(&mav_txbuf[header_len]);
+${{scalar_fields:    packet->${name} = ${putname};
+}}
+${{array_fields:    mav_array_memcpy(packet->${name}, ${name}, sizeof(${type})*${array_length});
+}}
+#endif
+
+    return mavlink_finalize_message_txbuf(mav_txbuf, mav_status, system_id, component_id,
+                                          MAVLINK_MSG_ID_${name}, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
+}
+
+/**
  * @brief Pack a ${name_lower} message
  * @param system_id ID of this system
  * @param component_id ID of this component (e.g. 200 for IMU)


### PR DESCRIPTION
**This was originaly posted by @olliw42 on mavlink/mavlink#1127 . I moved it here where it belongs**

although saying to be "highly optimized for resource-constrained systems with limited RAM and flash memory" the MAVLink C lib fails to be efficient in most aspects, flash, ram, stack, computation time, which can be relevant especially for resource constrained embeeded applications. This PR adds extensions which much improve the situation. It is offered just in case anyone might be interested.

It deals with only C and v2.0.

It is used in two applications, the STorM32 gimbal controller, which now makes heavy use of the new 'light' features, and the UC4H MavlinkBridge, which doesn't use them but uses the convenience functions (and thus kind of tests compatibility). That is, various, but by far not all aspects of the lib are tested, e.g. I don't use signatures at all, etc.

The additions/extensions are essentially non-intrusive, with maybe one exception.

I couldn't figure out how to properly deal with git submodules, so I simply created a new folder "pymavlink-light", into which I put all my changes, and added a mavgenerate_light.py which is to be used. For this PR I recreated all anew in order to achieve a series of commits which hopefully helps following.

The additions/extensions in detail:

**1) Receiving memory usage**

Currently the memory usage in receiving a message may be sketched as follows

user data -> payload_t -> msg_t of user -> buffer of user -> uart tx buf

There are several versions, pack, encode, send etc, which allow several things to do and skip/simplify some steps, e.g. the "msg_t of user" can be send directly to the "uart tx buf".

However, what is not possible is to put the provided message data directly into the "buffer of user". In many cases that's however what is desired since the "msg_t of user" typically has no further use. Msg_t is a quite big structure, and thus costly.

I thus added functions mavlink_msg_MSG_pack_txbuf() to the messages .h files. For instance, for the heartbeat there is now a function mavlink_msg_heartbeat_pack_txbuf(), which skips the need of "msg_t of user".

This is a totally non-intrusive addition, as it doesn't affect any of the other code.

**2) Parsing memory usage**

Currently the memory usage in parsing may be sketched as follows:

uart rx buf -> msg_t in COMM buffer -> msg_t of user -> payload_t

In many cases the double use of a msg_t structure is not needed, since the parsing could directly go into "msg_t of user". Msg_t is a quite big structure, and thus costly.

The new NULL check changes in mavlink_frame_char_buffer() allow to do that, however the whole thing is still quite back-through-the-door, e.g. the user needs to define his own mavlink_get_channel_buffer() to refer to his own msg_t variable, or keep using the COMM_BUF, etc..

I thus added a new function mavlink_parse_nextchar() which is much simpler to use, and also results in a logically structured API (i.e. mavlink_frame_char_buffer() is supposed to use now mavlink_parse_nextchar(), like mavlink_frame_char() uses mavlink_parse_nextchar(), and mavlink_parse_char() uses mavlink_frame_char()).

This easily could be made to be a totally non-intrusive addition, as it doesn't have to affect any of the other code. As is, it is intrusive however, since it also adds the handling of the msg_entry extension (see below). (is just one line of code, so easily removed if not wanted)

**3) FLASH usage and computation time**

MAVLINK_MESSAGE_CRCS is typically quite big, which has two implications, lots of flash used, and in addition the search by mavlink_get_msg_entry() takes long.

In many cases the application doesn't use all messages of a dialect, but just a relatively small subset, 10-20% or so. Having MAVLINK_MESSAGE_CRCS to only contain the entries for the used (incoming) messages can thus lower flash usage as well as make the search faster. With the lib as is this can be achieved in several ways, e.g. by doing one's own xml, or by copying the dialect's original MAVLINK_MESSAGE_CRCS and deleting all unused entries, etc. But all that is not very convenient and can add maintenance burdens.

I thus added a message_entries.h file to the respective dialect subfolder, which offers macros for each message entry. This allows the user to very simply build her own MAVLINK_MESSAGE_CRCS.

The gains can be quite substantial. E.g. for the STorM32, which has a decent MAVLink support, this saved 2760 bytes of flash. Also the computation time for mavlink_get_msg_entry() has become more than twice faster.

This is a totally non-intrusive addition, as it doesn't affect any of the other code.

**4) msg_entry_t, computation time**

Handling of incoming messages requires parsing the data stream, as well as some sort of identification if the received message should be handled (kind of the first step of routing). Currently, with the lib as is, the mavlink_get_msg_entry() is called at least twice: It is called in the parsing function, and then has to be called by the identification code to get the target system/component.

Note that mavlink_get_msg_entry() does a search which by principle has to be rated as costly (for as long as quantum computers have not yet become reality for us), and double-doing the search isn't clever.

I thus added a msg_entry field to the message_t structure as additional metadata. 

This allows to set it in the parsing function, and then later be reused whenever needed without any additional search. Since it's just a pointer it's insignificant memory wise in comparison to the size of the message_t structure.

This easily could be made to be totally non-intrusive, as it doesn't have to affect any of the other code. As is, it is intrusive however, since it adds this additional field to the message_t structure. I note that message_t has already some meta data, so this shouldn't be a shocking approach, and that I would not think that this is very troublesome (unless the user does "strange things" like relying explicitly on the length of the structure). Adding of the msg_entry to the message_t structure could have been avoided by returning it by the parse function (which would need double pointers, argh), but I just think that the approach I've taken is clean and simple.

Along with that change I've added helper functions to get the target system/component. 

I note that this improvement should be very significant also and especially for "big" applications, which use huge dialects and many MAVLink channels with lots of incoming traffic, and thus many search events. I thus think that this improvement should also be seriously considered for the c++ lib.

**5) MAVLINK_USE_CHAN_FUNCTIONS**

In some analogy to MAVLINK_USE_CONVENIENCE_FUNCTIONS I've added a MAVLINK_USE_CHAN_FUNCTIONS, which wraps all functions which use chan and/or the COMM buffers. 

It is defined when MAVLINK_COMM_NUM_BUFFERS is larger than zero. That way the user simply has to do a #define MAVLINK_COMM_NUM_BUFFERS 0 to ensure that none of all that is used. 

This is an essentially non-intrusive addition, since it normally doesn't affect any of the code.

**6) Formatting, few rearrangements, few renamings**

I've made plenty of changes which result in more properly formatted .h files. I've also rearranged some functions/structures to arrive at what I consider more logical and user friendly. For instance, I've moved the COMM related functions in mavlink_helpers.h to the top. Finally, I renamed some local variable names (only very few instances).

All of this is supposed to be totally non-intrusive, as it shouldn't affect the code behavior at all.


As said, I just share in case it might be of interest. Do what you want with it :).

Cheers, and as always, have fun, Olli
