### PR TITLE
Fix occasional truncate params

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -307,7 +307,7 @@ class MAVXML(object):
             elif in_element == "mavlink.enums.enum.entry.description":
                 self.enum[-1].entry[-1].description += data
             elif in_element == "mavlink.enums.enum.entry.param":
-                self.enum[-1].entry[-1].param[-1].set_description(data.strip())
+                self.enum[-1].entry[-1].param[-1].description += data
             elif in_element == "mavlink.version":
                 self.version = int(data)
             elif in_element == "mavlink.include":


### PR DESCRIPTION
This reverts part of a change my commit https://github.com/ArduPilot/pymavlink/commit/2e19ed5dd8ef60dbf07c0571d4beb8e2c552cdae 

Basically I did not understand that the parser gets the param description in chunks and assembles them. As a result a small percentage of param descriptions got truncated.

For example, in asluav.h

![image](https://user-images.githubusercontent.com/5368500/57502643-f1dd9a80-732f-11e9-9847-560390123010.png)

This fixes that errors. 