### PR TITLE
Fix up CS generator file paths

### DIFF
--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -328,7 +328,8 @@ using System.Reflection;
     
     generatedCsFiles = [ serfilename, structsfilename]
     
-    includedCsFiles =  [ 'CS/common/ByteArrayUtil.cs', 'CS/common/FrameworkBitConverter.cs', 'CS/common/Mavlink.cs'  ]
+    cur_dir = os.path.dirname(os.path.abspath(__file__)) + '/'
+    includedCsFiles = [cur_dir + 'CS/common/ByteArrayUtil.cs', cur_dir + 'CS/common/FrameworkBitConverter.cs', cur_dir + 'CS/common/Mavlink.cs' ]
     
     outputLibraryPath = os.path.normpath(dir + "/mavlink.dll")
     


### PR DESCRIPTION
Fixes #151 

This just fixes up the generator so that it searches for file paths of include files relative to the current directory (originally suggested by @iliasam.

Testing shows that this allows the libraries to be built for both mavlink 2 and 1. Note that the main output files generated before this fix at the same - but you now get new files mavlink.dll, mavlink.pdb, mavlink.xml.
My assumption is that the defect meant that you couldn't link and debug into the library, but you could still use it. 

@peterbarker @amilcarlucas Can you please review.

