### PR TITLE
Change mavutil.py license from GPLv3+ to LGPLv3+

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2,8 +2,8 @@
 '''
 mavlink python utility functions
 
-Copyright Andrew Tridgell 2011
-Released under GNU GPL version 3 or later
+Copyright Andrew Tridgell 2011-2019
+Released under GNU LGPL version 3 or later
 '''
 from __future__ import print_function
 from builtins import object


### PR DESCRIPTION
This allows this file to be used by dronekit-python, MavRos and other similar software.

I will contact the other commiters to this file per e-mail, but I would like to get the OK from the reviewers here first. The full list is bellow, it it be updated with the answers from the devs.
- [x]  1 Alex Krob
- [x]  1 Peter Hollands
- [x]  1 @danielwidmann
- [x]  1 @ssaamm
- [x]  1 Bryant Mairs
- [x]  1 Simon Wilks
- [x]  1 Lorenz Meier
- [x]  2 Dr.-Ing. Amilcar do Carmo Lucas
- [x]  2 Dirk Thomas
- [x]  3 Quy Tonthat
- [x]  3 Tim Ryan
- [x]  4 Huibean
- [x]  4 Eric Liao
- [x]  4 Sander Smeets
- [x]  7 Matthew Lloyd
- [x]  8 Pierre Kancir
- [x]  9  Patrick José Pereira
- [x]  9 Jonathan Challinger
- [x]  10 @pietrodn
- [ ]  15 Ben Nizette
- [x]  19 Jono Millin
- [x]  22 Jacob Walser
- [x]  26 Francisco Ferreira
- [x]  27 Bryant
- [x]  28 Kevin Hester
- [x]  30 Pat Hickey
- [x]  75 @squilter
- [x]  335 Peter Barker
- [x]  522 James Goppert
- [x]  1251 Andrew Tridgell