### PR TITLE
Add flight mode 24 ZIGZAG to mavutil

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1899,6 +1899,7 @@ mode_mapping_acm = {
     21 : 'SMART_RTL',
     22 : 'FLOWHOLD',
     23 : 'FOLLOW',
+    24 : 'ZIGZAG',
 }
 mode_mapping_rover = {
     0 : 'MANUAL',


### PR DESCRIPTION
added flight mode 24 ZIGZAG to mavutil.py to resolve the following issue. 
#332 