### PR TITLE
mavlogdump.py: add --profile using yappi

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -49,6 +49,8 @@ parser.add_argument("--verbose", action='store_true', help="Dump messages in a m
 parser.add_argument("--mav10", action='store_true', help="parse as MAVLink1")
 parser.add_argument("--reduce", type=int, default=0, help="reduce streaming messages")
 parser.add_argument("log", metavar="LOG")
+parser.add_argument("--profile", action='store_true', help="run the Yappi python profiler")
+
 args = parser.parse_args()
 
 if not args.mav10:
@@ -59,6 +61,9 @@ import inspect
 from pymavlink import mavutil
 
 
+if args.profile:
+    import yappi    # We do the import here so that we won't barf if run normally and yappi not available
+    yappi.start()
 
 filename = args.log
 mlog = mavutil.mavlink_connection(filename, planner_format=args.planner,
@@ -307,3 +312,7 @@ while True:
 if args.show_types:
     for msgType in available_types:
         print(msgType)
+
+if args.profile:
+    yappi.get_func_stats().print_all()
+    yappi.get_thread_stats().print_all()


### PR DESCRIPTION
```
pbarker@bluebottle:~/rc/pymavlink(pr/mavlogdump-profile)$ mavlogdump.py --profile -q /tmp/00000014.BIN 

Clock type: CPU
Ordered by: totaltime, desc

name                                  ncall  tsub      ttot      tavg      
...py:587 DFReader_binary.recv_match  126..  5.246718  60.71140  0.000048
..er.py:548 DFReader_binary.recv_msg  126..  3.190012  54.26146  0.000043
..py:805 DFReader_binary._parse_next  126..  15.23515  51.07469  0.000040
..er.py:551 DFReader_binary._add_msg  126..  8.371578  30.08962  0.000024
..r.py:541 DFReader_binary._set_time  126..  5.231683  18.85557  0.000015
..erClock_usec.set_message_timestamp  126..  5.240827  12.28539  0.000010
..mavutil.py:1613 mavlink_connection  1      0.000045  7.248892  7.248892
..er.py:647 DFReader_binary.__init__  1      0.000065  7.246480  7.246480
..eader.py:156 DFMessage.__getattr__  126..  5.527871  7.130457  0.000006
..py:691 DFReader_binary.init_arrays  1      4.308126  7.075842  7.075842
..DFReader.py:176 DFMessage.get_type  504..  5.713124  5.713124  0.000001
..egg/pymavlink/DFReader.py:53 u_ord  252..  3.228295  3.228295  0.000001
..k/mavutil.py:57 evaluate_condition  252..  2.668223  2.668223  0.000001
..DFReader.py:142 DFMessage.__init__  126..  1.907437  1.907437  0.000002
..DFReaderClock_usec.message_arrived  126..  1.334869  1.334869  0.000001
...py:452 DFReader_binary.init_clock  1      0.008989  0.170442  0.170442
..k/DFReader.py:57 DFFormat.__init__  479    0.073849  0.098823  0.000206
..ymavlink/DFReader.py:131 null_term  6509   0.027935  0.049891  0.000008
..interpolated.set_message_timestamp  1709   0.008607  0.012502  0.000007
..k_gps_interpolated.message_arrived  1709   0.005644  0.007710  0.000005
..ymavlink/DFReader.py:106 to_string  1434   0.003690  0.005965  0.000004
..rClock_usec.should_use_msec_field0  161    0.000882  0.002401  0.000015
..b._bootstrap>:997 _handle_fromlist  6/2    0.000045  0.002264  0.000377
..rap>:211 _call_with_frames_removed  4/1    0.000014  0.002218  0.000555
..lib._bootstrap>:966 _find_and_load  2/1    0.000049  0.002207  0.001104
..strap>:936 _find_and_load_unlocked  2/1    0.000023  0.002104  0.001052
..lib._bootstrap>:651 _load_unlocked  2/1    0.000048  0.001839  0.000919
..>:672 SourceFileLoader.exec_module  1      0.000010  0.001691  0.001691
..derClock_usec.type_has_good_TimeMS  161    0.000792  0.001281  0.000008
..g/pymavlink/DFReader.py:9 <module>  1      0.000060  0.001219  0.001219
..portlib._bootstrap>:870 _find_spec  2      0.000072  0.000814  0.000407
..bootstrap_external>:1149 find_spec  2      0.000009  0.000679  0.000339
..bootstrap_external>:1117 _get_spec  2      0.000057  0.000670  0.000335
..xternal>:1233 FileFinder.find_spec  4      0.000137  0.000590  0.000148
..nal>:743 SourceFileLoader.get_code  1      0.000029  0.000454  0.000454
..b._bootstrap>:564 module_from_spec  2      0.000020  0.000317  0.000158
..ap_external>:485 _compile_bytecode  1      0.000012  0.000293  0.000293
.._bootstrap_external>:57 _path_join  17     0.000086  0.000233  0.000014
.. ExtensionFileLoader.create_module  1      0.000007  0.000166  0.000166
..s_interpolated.gps_message_arrived  1      0.000072  0.000139  0.000139
.._bootstrap>:504 _init_module_attrs  2      0.000034  0.000124  0.000062
.._bootstrap_external>:59 <listcomp>  17     0.000074  0.000117  0.000007
.._bootstrap_external>:75 _path_stat  7      0.000021  0.000111  0.000016
..ymavlink/mavutil.py:80 set_dialect  1      0.000035  0.000099  0.000099
..>:147 _ModuleLockManager.__enter__  2      0.000017  0.000088  0.000044
..xternal>:1228 FileFinder._get_spec  2      0.000039  0.000074  0.000037
..ap_external>:263 cache_from_source  2      0.000024  0.000068  0.000034
..._bootstrap>:403 ModuleSpec.cached  3      0.000008  0.000063  0.000021
..util.py:2064 mode_mapping_bynumber  10     0.000057  0.000057  0.000006
..ootstrap_external>:361 _get_cached  2      0.000014  0.000054  0.000027
..b._bootstrap>:157 _get_module_lock  2      0.000029  0.000054  0.000027
..ootstrap_external>:94 _path_isfile  2      0.000021  0.000051  0.000026
..nal>:830 SourceFileLoader.get_data  1      0.000028  0.000049  0.000049
..ython3.6/posixpath.py:121 splitext  1      0.000019  0.000042  0.000042
..b._bootstrap>:222 _verbose_message  21     0.000039  0.000039  0.000002
..der.py:679 DFReader_binary._rewind  3      0.000011  0.000038  0.000013
..ap>:318 _installed_safely.__exit__  2      0.000013  0.000038  0.000019
..ap_external>:85 _path_is_mode_type  2      0.000008  0.000031  0.000015
..ernal>:524 spec_from_file_location  2      0.000023  0.000030  0.000015
..s_abc.py:664 _Environ.__contains__  1      0.000006  0.000030  0.000030
..nal>:430 _validate_bytecode_header  1      0.000018  0.000029  0.000029
..der.py:424 DFReader_binary._rewind  3      0.000024  0.000027  0.000009
.. DFReaderClock_usec.find_time_base  1      0.000010  0.000026  0.000026
..3.6/os.py:664 _Environ.__getitem__  1      0.000009  0.000023  0.000023
..>:843 _ImportLockContext.__enter__  6      0.000016  0.000023  0.000004
..p>:847 _ImportLockContext.__exit__  6      0.000015  0.000022  0.000004
..p>:151 _ModuleLockManager.__exit__  2      0.000008  0.000021  0.000011
..._bootstrap>:416 ModuleSpec.parent  4      0.000013  0.000021  0.000005
..bootstrap>:58 _ModuleLock.__init__  2      0.000013  0.000020  0.000010
..on3.6/genericpath.py:117 _splitext  1      0.000013  0.000018  0.000018
.._bootstrap>:78 _ModuleLock.acquire  2      0.000014  0.000017  0.000008
<frozen importlib._bootstrap>:176 cb  2      0.000010  0.000016  0.000008
..bootstrap>:103 _ModuleLock.release  2      0.000011  0.000014  0.000007
..46 DFReader_binary.init_clock_usec  1      0.000005  0.000013  0.000013
..bootstrap_external>:63 _path_split  2      0.000009  0.000013  0.000006
..l>:840 SourceFileLoader.path_stats  1      0.000003  0.000012  0.000012
..mportlib._bootstrap>:780 find_spec  2      0.000008  0.000011  0.000006
..27 ExtensionFileLoader.exec_module  1      0.000005  0.000010  0.000010
..derClock_gps_interpolated.__init__  2      0.000007  0.000010  0.000005
..xternal>:1080 _path_importer_cache  5      0.000010  0.000010  0.000002
..derClock_gps_interpolated.__init__  1      0.000004  0.000010  0.000010
..urceFileLoader._check_name_wrapper  1      0.000008  0.000009  0.000009
..ib._bootstrap_external>:52 _r_long  2      0.000006  0.000009  0.000004
../python3.6/platform.py:1084 system  1      0.000007  0.000008  0.000008
/usr/lib/python3.6/os.py:742 encode   1      0.000006  0.000008  0.000008
..mportlib._bootstrap>:321 <genexpr>  8      0.000008  0.000008  0.000001
..py:255 DFReaderClock_usec.__init__  1      0.000003  0.000008  0.000008
..mportlib._bootstrap>:707 find_spec  2      0.000005  0.000008  0.000004
..nk/DFReader.py:645 DFReader_binary  1      0.000007  0.000007  0.000007
..ck_gps_interpolated._gpsTimeToTime  2      0.000007  0.000007  0.000003
/usr/lib/python3.6/os.py:746 decode   1      0.000004  0.000006  0.000006
..bootstrap_external>:41 _relax_case  4      0.000006  0.000006  0.000001
..er.py:415 DFReader_binary.__init__  1      0.000005  0.000005  0.000005
..p>:143 _ModuleLockManager.__init__  2      0.000005  0.000005  0.000002
..bootstrap>:369 ModuleSpec.__init__  2      0.000005  0.000005  0.000002
..p>:311 _installed_safely.__enter__  2      0.000004  0.000004  0.000002
..pymavlink/DFReader.py:413 DFReader  1      0.000004  0.000004  0.000004
..lock_gps_interpolated.set_timebase  3      0.000004  0.000004  0.000001
../DFReader.py:314 DFReaderClock_px4  1      0.000003  0.000003  0.000003
..ymavlink/DFReader.py:141 DFMessage  1      0.000003  0.000003  0.000003
..ap>:307 _installed_safely.__init__  2      0.000003  0.000003  0.000001
..link/DFReader.py:914 DFReader_text  1      0.000003  0.000003  0.000003
..portlib._bootstrap>:35 _new_module  1      0.000003  0.000003  0.000003
..>:908 ExtensionFileLoader.__init__  1      0.000003  0.000003  0.000003
..49 DFReaderClock_usec.rewind_event  2      0.000003  0.000003  0.000001
..DFReader.py:253 DFReaderClock_usec  1      0.000003  0.000003  0.000003
..link/DFReader.py:231 DFReaderClock  1      0.000002  0.000002  0.000002
..strap>:424 ModuleSpec.has_location  2      0.000002  0.000002  0.000001
..338 DFReaderClock_gps_interpolated  1      0.000002  0.000002  0.000002
../pymavlink/DFReader.py:56 DFFormat  1      0.000002  0.000002  0.000002
..nal>:800 SourceFileLoader.__init__  1      0.000002  0.000002  0.000002
..ib/python3.6/platform.py:946 uname  1      0.000002  0.000002  0.000002
..DFReader.py:295 DFReaderClock_msec  1      0.000002  0.000002  0.000002
..:825 SourceFileLoader.get_filename  1      0.000001  0.000001  0.000001
..669 SourceFileLoader.create_module  1      0.000001  0.000001  0.000001

name           id     tid              ttot      scnt        
_MainThread    0      139874727114560  90.09795  1         
pbarker@bluebottle:~/rc/pymavlink(pr/mavlogdump-profile)$ mavlogdump.py -q /tmp/00000014.BIN 
pbarker@bluebottle:~/rc/pymavlink(pr/mavlogdump-profile)$ 
```
