### PR TITLE
Add a port in udp dissector in mavgen_wlua.py

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -444,10 +444,11 @@ def generate_epilog(outf):
 wtap_encap = DissectorTable.get("wtap_encap")
 wtap_encap:add(wtap.USER0, mavlink_proto)
 
--- bind protocol dissector to port 14550
+-- bind protocol dissector to port 14550 and 14580
 
 local udp_dissector_table = DissectorTable.get("udp.port")
 udp_dissector_table:add(14550, mavlink_proto)
+udp_dissector_table:add(14580, mavlink_proto)
 """)
 
 def generate(basename, xml):


### PR DESCRIPTION
As shown in the [simulation section of devguide](https://dev.px4.io/en/simulation/), the PX4 also transports data on 14580 UDP port to communicate with external developer APIs by default.