### PR TITLE
Added check to enable pymavlink to build against musl

### DIFF
--- a/mavnative/mavnative.c
+++ b/mavnative/mavnative.c
@@ -322,7 +322,11 @@ static void set_pyerror(const char *msg) {
 }
 
 // Pass assertion failures back to python (if we can)
+#ifdef __GLIBC__
 extern void __assert_fail(const char *__assertion, const char *__file, unsigned int __line, const char *__function)
+#else
+extern void __assert_fail(const char *__assertion, const char *__file, int __line, const char *__function)
+#endif
 {
     char msg[256];
 


### PR DESCRIPTION
This should resolve #294 . I test built it against Alpine 3.10 and Ubuntu 18.04.