### PR TITLE
CRCS and lengths for mulitple inclusion levels

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -136,7 +136,7 @@ def mavgen(opts, args):
                 x.message_target_system_ofs.update(xml_dict[child].message_target_system_ofs)
                 x.message_target_component_ofs.update(xml_dict[child].message_target_component_ofs)
                 x.message_names.update(xml_dict[child].message_names)
-                x.largest_payload = max(x.largest_payload, xml[-1].largest_payload)
+                # x.largest_payload = max(x.largest_payload, xml[-1].largest_payload)
 
 
 

--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -128,6 +128,7 @@ def mavgen(opts, args):
 
         # Update parents with child CRCs, message lengths, etc. 
         for x in xml:
+            
             for child in x.child:
                 x.message_crcs.update(xml_dict[child].message_crcs)
                 x.message_lengths.update(xml_dict[child].message_lengths)
@@ -136,7 +137,7 @@ def mavgen(opts, args):
                 x.message_target_system_ofs.update(xml_dict[child].message_target_system_ofs)
                 x.message_target_component_ofs.update(xml_dict[child].message_target_component_ofs)
                 x.message_names.update(xml_dict[child].message_names)
-                # x.largest_payload = max(x.largest_payload, xml[-1].largest_payload)
+                x.largest_payload = max(x.largest_payload, xml_dict[child].largest_payload)
 
 
 
@@ -187,10 +188,6 @@ def mavgen(opts, args):
     # expand includes
     expand_includes()
 
-    # work out max payload size across all includes
-    largest_payload = max(x.largest_payload for x in xml) if xml else 0
-    for x in xml:
-        x.largest_payload = largest_payload
 
     if mavparse.check_duplicates(xml):
         sys.exit(1)


### PR DESCRIPTION
The current code to include multiple dialect levels is a bit broken (which didn't matter too much because no one was using this). 
The problem is that dialect CRC lists have to include the CRCS of all included files (because the various bits are only included/#defined in the C code once). The previous version only added the previous parent CRCs.

What this code does is add all the CRCs for all the parents. It does this by calculating all the parents of each file in the first iteration. Then it works runs check to find all the children from all the parents. At that point it iterates the xml files a final time to add CRCs and other files.

I'm still running tests, but I think this is good for review.

@peterbarker ?