### PR TITLE
support instance variable expressions in DF logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.6"
+  - "3.7"
 before_install:
   - pip install --upgrade pip
 install:

--- a/mavexpression.py
+++ b/mavexpression.py
@@ -31,4 +31,6 @@ def evaluate_expression(expression, vars):
         return None
     except ZeroDivisionError:
         return None
+    except IndexError:
+        return None
     return v


### PR DESCRIPTION
this allows for graphs like this:

 graph RFND[0].Dist RFND[1].Dist

The instance field names come from FMTU msgs in DF logs. For mavlink we'll need to add some XML markup for instance vars