### PR TITLE
mavgen_python: correct trailing-zero-byte trimming under Python3

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -212,7 +212,11 @@ class MAVLink_message(object):
         if WIRE_PROTOCOL_VERSION != '1.0' and not force_mavlink1:
             # in MAVLink2 we can strip trailing zeros off payloads. This allows for simple
             # variable length arrays and smaller packets
-            while plen > 1 and payload[plen-1] == chr(0):
+            nullbyte = chr(0)
+            # in Python2, type("fred') is str but also type("fred")==bytes
+            if str(type(payload)) == "<class 'bytes'>":
+                nullbyte = 0
+            while plen > 1 and payload[plen-1] == nullbyte:
                 plen -= 1
         self._payload = payload[:plen]
         incompat_flags = 0

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+
+"""
+test for trimming under Python 3
+"""
+
+from __future__ import absolute_import, print_function
+import unittest
+import os
+import pkg_resources
+import sys
+from pymavlink import mavutil
+
+class PayLoadTrimZeros(unittest.TestCase):
+    '''Trivial test for trimming zeros from end of messages'''
+
+    def test_dump_length(self):
+        mavutil.mavlink.WIRE_PROTOCOL_VERSION = 2
+        mav = mavutil.mavudp(":12345")
+
+        ts = [ ((1, 1), 10),
+              ((1, 0), 9),
+              ((0, 0), 9)
+              ]
+        for t in ts:
+            ((sysid, compid), result) = t
+            m = mavutil.mavlink.MAVLink_param_request_list_message(sysid, compid)
+            packed = m.pack(mav.mav)
+            print("(%u/%u should be %u" % (sysid,compid, result))
+            self.assertEqual(len(packed), result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The struct.pack emits str under Python 2 and bytes under Python3.  bytes
are compared directly against zero but the str form needs the chr().


```
pbarker@bluebottle:~$ cat test-struct.py 
#!/usr/bin/choose-your-own-Python

import struct

x = struct.pack("<BB", 0, 0)
if x[0] == chr(0):
    print("First one is a zero using chr")
else:
    print("First one is NOT a zero using chr")

if x[0] == 0:
    print("First one is a zero using literal zero")
else:
    print("First one is NOT a zero using literal zero")
pbarker@bluebottle:~$ python2 test-struct.py 
First one is a zero using chr
First one is NOT a zero using literal zero
pbarker@bluebottle:~$ python3 test-struct.py 
First one is NOT a zero using chr
First one is a zero using literal zero
pbarker@bluebottle:~$ 
```