### PR TITLE
Fix signature checking under Python3

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -681,8 +681,13 @@ class MAVLink(object):
             h = hashlib.new('sha256')
             h.update(self.signing.secret_key)
             h.update(msgbuf[:-6])
-            sig1 = str(h.digest())[:6]
-            sig2 = str(msgbuf)[-6:]
+            if str(type(msgbuf)) == "<class 'bytes'>":
+                # Python 3
+                sig1 = h.digest()[:6]
+                sig2 = msgbuf[-6:]
+            else:
+                sig1 = str(h.digest())[:6]
+                sig2 = str(msgbuf)[-6:]
             if sig1 != sig2:
                 # print('sig mismatch')
                 return False

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -212,7 +212,11 @@ class MAVLink_message(object):
         if WIRE_PROTOCOL_VERSION != '1.0' and not force_mavlink1:
             # in MAVLink2 we can strip trailing zeros off payloads. This allows for simple
             # variable length arrays and smaller packets
-            while plen > 1 and payload[plen-1] == chr(0):
+            nullbyte = chr(0)
+            # in Python2, type("fred') is str but also type("fred")==bytes
+            if str(type(payload)) == "<class 'bytes'>":
+                nullbyte = 0
+            while plen > 1 and payload[plen-1] == nullbyte:
                 plen -= 1
         self._payload = payload[:plen]
         incompat_flags = 0

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -1,0 +1,34 @@
+#!/usr/bin/python
+
+
+"""
+test for trimming under Python 3
+"""
+
+from __future__ import absolute_import, print_function
+import unittest
+import os
+import pkg_resources
+import sys
+from pymavlink import mavutil
+
+class PayLoadTrimZeros(unittest.TestCase):
+    '''Trivial test for trimming zeros from end of messages'''
+
+    def test_dump_length(self):
+        mavutil.mavlink.WIRE_PROTOCOL_VERSION = 2
+        mav = mavutil.mavudp(":12345")
+
+        ts = [ ((1, 1), 10),
+              ((1, 0), 9),
+              ((0, 0), 9)
+              ]
+        for t in ts:
+            ((sysid, compid), result) = t
+            m = mavutil.mavlink.MAVLink_param_request_list_message(sysid, compid)
+            packed = m.pack(mav.mav)
+            print("(%u/%u should be %u" % (sysid,compid, result))
+            self.assertEqual(len(packed), result)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Built on top of https://github.com/ArduPilot/pymavlink/pull/347 as it can't be easily tested without that.

Depending on Python version (and, I think, codepath), we may be passed in `bytes` as our payload - and using `chr()` to look into that doesn't work.

Similarly for signature checking - casting to string and taking a subset doesn't work well under Python3, so if we are passed `bytes` in then compare directly.
