### PR TITLE
mavlink_helpers: send one mavlink packet per uart write

### DIFF
--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -26,7 +26,8 @@ namespace mavlink {
 
 #define MAVLINK_CORE_HEADER_LEN 9 ///< Length of core header (of the comm. layer)
 #define MAVLINK_CORE_HEADER_MAVLINK1_LEN 5 ///< Length of MAVLink1 core header (of the comm. layer)
-#define MAVLINK_NUM_HEADER_BYTES (MAVLINK_CORE_HEADER_LEN + 1) ///< Length of all header bytes, including core and stx
+#define MAVLINK_NUM_HEADER_BYTES (MAVLINK_CORE_HEADER_LEN + 1) ///< Length of all header bytes (stx and core)
+#define MAVLINK_NUM_HEADER_BYTES_MAVLINK1 (MAVLINK_CORE_HEADER_MAVLINK1_LEN + 1) ///< Length of all MAVLink1 header bytes (stx and core)
 #define MAVLINK_NUM_CHECKSUM_BYTES 2
 #define MAVLINK_NUM_NON_PAYLOAD_BYTES (MAVLINK_NUM_HEADER_BYTES + MAVLINK_NUM_CHECKSUM_BYTES)
 


### PR DESCRIPTION
Most of the diff just consists of spacings because there were trailing spaces, mixed indentation, ...

The actual change is readability and how the function `_mav_finalize_message_chan_send` operates.

**Before:** It independently handled all the message parts magic number (size +1 everywhere), header, payload, crc, signature independently and also sent them independently each with a system call to the hardware. This saved one payload size of stack during the function call because the payload did need space in the buffer but had the disadvantage of 3-4 system calls to the UART and possibly even fragmentation of messages in the various applications the different users come up with like using the same UART for other protocols at the same time or forwarding the bytes over UDP without reparsing.

**New:** That's why I suggest to fill up one buffer per message and sending it all at once. I made an effort to make the implementation as readable, efficient and compatible as possible. I'm aware that there are other functions in the same helper which are partly duplicate and would also need adjustment. The calculation of the signature can still be simplified a lot since distinguishing the message parts is not necessary.  

Thanks for any feedback.
JFYI @LorenzMeier 