### PR TITLE
mavgen_JS: fix for id field overridden by msgId

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -98,7 +98,7 @@ mavlink.message.prototype.set = function(args) {
 mavlink.message.prototype.pack = function(mav, crc_extra, payload) {
 
     this.payload = payload;
-    this.header = new mavlink.header(this.id, payload.length, mav.seq, mav.srcSystem, mav.srcComponent);    
+    this.header = new mavlink.header(this.msg_id, payload.length, mav.seq, mav.srcSystem, mav.srcComponent);    
     this.msgbuf = this.header.pack().concat(payload);
     var crc = mavlink.x25Crc(this.msgbuf.slice(1));
 
@@ -181,7 +181,7 @@ ${COMMENT}
         outf.write("""
 
     this.format = '%s';
-    this.id = mavlink.MAVLINK_MSG_ID_%s;
+    this.msg_id = mavlink.MAVLINK_MSG_ID_%s;
     this.order_map = %s;
     this.crc_extra = %u;
     this.name = '%s';
@@ -248,7 +248,7 @@ def generate_mavlink_class(outf, msgs, xml):
 
 // Special mavlink message to capture malformed data packets for debugging
 mavlink.messages.bad_data = function(data, reason) {
-    this.id = mavlink.MAVLINK_MSG_ID_BAD_DATA;
+    this.msg_id = mavlink.MAVLINK_MSG_ID_BAD_DATA;
     this.data = data;
     this.reason = reason;
     this.msgbuf = data;

--- a/test_generator.sh
+++ b/test_generator.sh
@@ -18,6 +18,8 @@ mavgen.py --lang C $MDEF/v1.0/ardupilotmega.xml -o generator/C/include_v2.0 --wi
 
 mavgen.py --lang C++11 $MDEF/v1.0/ardupilotmega.xml -o generator/CPP11/include_v2.0 --wire-protocol=2.0
 
+mavgen.py --lang JavaScript $MDEF/v1.0/ardupilotmega.xml -o generator/javascript/include_v1.0 --wire-protocol=1.0
+
 pushd generator/C/test/posix
 make clean testmav1.0_common testmav2.0_common testmav1.0_ardupilotmega testmav2.0_ardupilotmega
 ./testmav1.0_common


### PR DESCRIPTION
The data after packing the "id" field of LOG_REQUEST_DATA was strange.
Log ID (from LOG_ENTRY response) is packed with message id (119). To avoid confusion, I think that message id should be different.