### PR TITLE
Fix decoding of signed message on python3.

### DIFF
--- a/examples/mavtest.py
+++ b/examples/mavtest.py
@@ -28,7 +28,7 @@ def test_protocol(mavlink, signing=False):
     mav = mavlink.MAVLink(f)
 
     if signing:
-        mav.signing.secret_key = chr(42)*32
+        mav.signing.secret_key = bytearray(chr(42)*32, 'utf-8' )
         mav.signing.link_id = 0
         mav.signing.timestamp = 0
         mav.signing.sign_outgoing = True

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -730,7 +730,7 @@ class MAVLink(object):
             h = hashlib.new('sha256')
             h.update(self.signing.secret_key)
             h.update(msgbuf[:-6])
-            if str(type(msgbuf)) == "<class 'bytes'>":
+            if str(type(msgbuf)) == "<class 'bytes'>" or str(type(msgbuf)) == "<class 'bytearray'>":
                 # Python 3
                 sig1 = h.digest()[:6]
                 sig2 = msgbuf[-6:]


### PR DESCRIPTION
mavgen_python.py has a template for MAVLink.check_signature().
Modified that method's python3 detection to check for
class 'bytearray' as well as class 'bytes'. This fixes python3
decoding of signed messages.

Also changed examples/mavtest.py to pass a bytearray for the
secret key instead of a string. This is required to send
a signed message using python3.