### PR TITLE
Fix for bug in CPP11 generator MESSAGE_ENTRIES initialiser list

### DIFF
--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -337,10 +337,11 @@ def generate_one(basename, xml):
     # we sort with primary key msgid
     xml.message_entry_len = len(xml.message_crcs)
     xml.message_entry_array = ', '.join([
-        '{%u, %u, %u, %u, %u, %u}' % (
+        '{%u, %u, %u, %u, %u, %u, %u}' % (
             msgid,
             xml.message_crcs[msgid],
             xml.message_min_lengths[msgid],
+            xml.message_lengths[msgid],
             xml.message_flags[msgid],
             xml.message_target_system_ofs[msgid],
             xml.message_target_component_ofs[msgid])


### PR DESCRIPTION
This is the fix for #362. I closed the other one, because my branching was not clean.

@tridge Please review.