### PR TITLE
Generator: Add Mavlink 2.0 support for Javascript

### DIFF
--- a/generator/gen_js.sh
+++ b/generator/gen_js.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-for protocol in 1.0; do
- for xml in ../../message_definitions/v$protocol/*.xml; do
+for protocol in 1.0 2.0; do
+ for xml in ../../message_definitions/v1.0/*.xml; do
      base=$(basename $xml .xml)
      mkdir -p javascript/implementations/mavlink_${base}_v${protocol}
 

--- a/generator/javascript/.eslintrc.json
+++ b/generator/javascript/.eslintrc.json
@@ -1,0 +1,30 @@
+{
+    "env": {
+        "browser": false,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+        "eslint:recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parser": "babel-eslint",
+    "parserOptions": {
+        "ecmaFeatures": {
+            "jsx": true
+        },
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+    ],
+    "rules": {
+        "no-undef": 0,
+        "no-unused-vars": 0
+    },
+    "settings": {
+    }
+}

--- a/generator/javascript/package.json
+++ b/generator/javascript/package.json
@@ -1,23 +1,25 @@
 {
     "name" : "mavlink",
     "version" : "0.0.1",
-    "description" : "Implementation of the MAVLink protocol for various platforms and both 0.9 and 1.0 revisions of MAVLink",
+    "description" : "Implementation of the MAVLink protocol for various platforms and both 1.0 and 2.0 revisions of MAVLink",
     "repository": "private",
     "dependencies" : {
-      "underscore" : "",
-      "winston": "",
-      "jspack": "0.0.4"
+      "babel-eslint": "^10.0.3",
+      "jspack": "0.0.4",
+      "underscore": "1.9.1",
+      "winston": "3.2.1"
     },
     "devDependencies" : {
-      "should" : "",
+      "eslint" : "^6.1.0",
       "mocha" : "",
+      "should" : "",
       "sinon" : ""
     },
     "scripts": {
       "preinstall": "rm -rf implementations",
       "install": "cd .. && ./gen_js.sh",
-
       "pretest": "npm install",
-      "test": "mocha test"
+      "test": "mocha test/*10.js && mocha test/*20.js",
+      "lint": "./node_modules/.bin/eslint ./implementations/mavlink_common_v1.0/mavlink.js ./implementations/mavlink_common_v2.0/mavlink.js"
     }
 }

--- a/generator/javascript/test/mavlink10.js
+++ b/generator/javascript/test/mavlink10.js
@@ -1,0 +1,302 @@
+var {mavlink, MAVLinkProcessor} = require('../implementations/mavlink_common_v1.0/mavlink.js'),
+    should = require('should'),
+    sinon = require('sinon'),
+    fs = require('fs');
+
+// Actual data stream taken from APM.
+global.fixtures = global.fixtures || {};
+global.fixtures.serialStream = fs.readFileSync("test/capture.mavlink");
+//global.fixtures.heartbeatBinaryStream = fs.readFileSync("javascript/test/heartbeat-data-fixture");
+
+describe("Generated MAVLink 1.0 protocol handler object", function() {
+
+    beforeEach(function() {
+        this.m = new MAVLinkProcessor();
+
+        // Valid heartbeat payload
+        this.heartbeatPayload = new Buffer.from([0xfe, 0x09, 0x03, 0xff , 0x00 , 0x00 , 0x00 , 0x00 , 0x00 , 0x00 , 0x06 , 0x08 , 0x00 , 0x00 , 0x03, 0x9f, 0x5c]);
+
+        // Complete but invalid message
+        this.completeInvalidMessage = new Buffer.from([0xfe, 0x00, 0xfe, 0x00, 0x00, 0xe0, 0x00, 0x00]);
+    });
+
+    describe("message header handling", function() {
+        
+        it("IDs and sequence numbers are set on send", function(){
+            var mav = new MAVLinkProcessor(null, 42, 99);
+            var writer = {
+                write: function(){}
+            };
+            mav.file = writer;
+            var spy = sinon.spy(writer, 'write');
+
+            var msg = new mavlink.messages['heartbeat']();
+            mav.send(msg);
+
+            spy.calledOnce.should.be.true;
+            spy.getCall(0).args[0][2].should.be.eql(0); // seq
+            spy.getCall(0).args[0][3].should.be.eql(42); // sys
+            spy.getCall(0).args[0][4].should.be.eql(99); // comp
+        });
+
+        it("sequence number increases on send", function(){
+            var mav = new MAVLinkProcessor(null, 42, 99);
+            var writer = {
+                write: function(){}
+            };
+            mav.file = writer;
+            var spy = sinon.spy(writer, 'write');
+
+            var msg = new mavlink.messages['heartbeat']();
+            mav.send(msg);
+            mav.send(msg);
+
+            spy.callCount.should.be.eql(2);
+            spy.getCall(0).args[0][2].should.be.eql(0); // seq
+            spy.getCall(0).args[0][3].should.be.eql(42); // sys
+            spy.getCall(0).args[0][4].should.be.eql(99); // comp
+            spy.getCall(1).args[0][2].should.be.eql(1); // seq
+            spy.getCall(1).args[0][3].should.be.eql(42); // sys
+            spy.getCall(1).args[0][4].should.be.eql(99); // comp
+        });
+
+        it("sequence number turns over at 256", function(){
+            var mav = new MAVLinkProcessor(null, 42, 99);
+            var writer = {
+                write: function(){}
+            };
+            mav.file = writer;
+            var spy = sinon.spy(writer, 'write');
+
+            var msg = new mavlink.messages['heartbeat']();
+
+            for(var i = 0; i < 258; i++){
+                mav.send(msg);
+                var seq = i % 256;
+                spy.getCall(i).args[0][2].should.be.eql(seq); // seq
+            }
+        });
+
+    });
+
+    describe("buffer decoder (parseBuffer)", function() {
+
+        // This test prepopulates a single message as a binary buffer.
+        it("decodes a binary stream representation of a single message correctly", function() {
+            this.m.pushBuffer(global.fixtures.heartbeatBinaryStream);
+            var messages = this.m.parseBuffer();
+            
+        });
+
+        // This test includes a "noisy" signal, with non-mavlink data/messages/noise.
+        it("decodes a real serial binary stream into an array of MAVLink messages", function() {
+            this.m.pushBuffer(global.fixtures.serialStream);
+            var messages = this.m.parseBuffer();
+        });
+
+        it("decodes at most one message, even if there are more in its buffer", function() {
+
+        });
+        
+        it("returns null while no packet is available", function() {
+            (this.m.parseBuffer() === null).should.equal(true); // should's a bit tortured here
+        });
+
+    });
+
+    describe("decoding chain (parseChar)", function() {
+
+        it("returns a bad_data message if a borked message is encountered", function() {
+            var b = new Buffer.from([3, 0, 1, 2, 3, 4, 5]); // invalid message
+            var message = this.m.parseChar(b);
+            message.should.be.an.instanceof(mavlink.messages.bad_data);      
+        });
+
+        it("emits a 'message' event, provisioning callbacks with the message", function(done) {
+            this.m.on('message', function(message) {
+                message.should.be.an.instanceof(mavlink.messages.heartbeat);
+                done();
+            });
+            this.m.parseChar(this.heartbeatPayload);
+        });
+
+        it("emits a 'message' event for bad messages, provisioning callbacks with the message", function(done) {
+            var b = new Buffer.from([3, 0, 1, 2, 3, 4, 5]); // invalid message
+            this.m.on('message', function(message) {
+                message.should.be.an.instanceof(mavlink.messages.bad_data);
+                done();
+            });
+            this.m.parseChar(b);
+        });
+
+        it("on bad prefix: cuts-off first char in buffer and returns correct bad data", function() {
+            var b = new Buffer.from([3, 0, 1, 2, 3, 4, 5]); // invalid message
+            var message = this.m.parseChar(b);
+            message.msgbuf.length.should.be.eql(1);
+            message.msgbuf[0].should.be.eql(3);
+            this.m.buf.length.should.be.eql(6);
+            // should process next char
+            message = this.m.parseChar();
+            message.msgbuf.length.should.be.eql(1);
+            message.msgbuf[0].should.be.eql(0);
+            this.m.buf.length.should.be.eql(5);
+        });
+
+        it("on bad message: cuts-off message length and returns correct bad data", function() {
+            var message = this.m.parseChar(this.completeInvalidMessage);
+            message.msgbuf.length.should.be.eql(8);
+            message.msgbuf.should.be.eql(this.completeInvalidMessage);
+            this.m.buf.length.should.be.eql(0);
+        });
+
+        it("error counter is raised on error", function() {
+            var message = this.m.parseChar(this.completeInvalidMessage);
+            this.m.total_receive_errors.should.equal(1);
+            var message = this.m.parseChar(this.completeInvalidMessage);
+            this.m.total_receive_errors.should.equal(2);
+        });
+
+        // TODO: there is a option in python: robust_parsing. Maybe we should port this as well.
+        // If robust_parsing is off, the following should be tested:
+        // - (maybe) not returning subsequent errors for prefix errors
+        // - errors are thrown instead of catched inside
+
+        // TODO: add tests for "try hard" parsing when implemented
+
+    });
+
+    describe("stream buffer accumulator", function() {
+
+        it("increments total bytes received", function() {
+            this.m.total_bytes_received.should.equal(0);
+            var b = new Buffer.alloc(16);
+            b.fill("h");
+            this.m.pushBuffer(b);
+            this.m.total_bytes_received.should.equal(16);
+        });
+
+        it("appends data to its local buffer", function() {
+            this.m.buf.length.should.equal(0);
+            var b = new Buffer.alloc(16);
+            b.fill("h");
+            this.m.pushBuffer(b);
+            this.m.buf.should.eql(b); // eql = wiggly equality
+        });
+    });
+
+    describe("prefix decoder", function() {
+ 
+        it("consumes, unretrievably, the first byte of the buffer, if its a bad prefix", function() {
+
+            var b = new Buffer.from([1, 254]);
+            this.m.pushBuffer(b);
+            
+            // eat the exception here.
+            try {
+                this.m.parsePrefix();
+            } catch (e) {
+                this.m.buf.length.should.equal(1);
+                this.m.buf[0].should.equal(254);
+            }
+        
+        });
+
+        it("throws an exception if a malformed prefix is encountered", function() {
+
+            var b = new Buffer.from([15, 254, 1, 7, 7]); // borked system status packet, invalid
+            this.m.pushBuffer(b);
+            var m = this.m;
+            (function() { m.parsePrefix(); }).should.throw('Bad prefix (15)');
+
+        });
+
+    });
+
+    describe("length decoder", function() {
+        it("updates the expected length to the size of the expected full message", function() {
+            this.m.expected_length.should.equal(6); // default, header size
+            var b = new Buffer.from([254, 1, 1]); // packet length = 1
+            this.m.pushBuffer(b);
+            this.m.parseLength();
+            this.m.expected_length.should.equal(9); // 1+8 bytes for the message header
+        });
+    });
+
+    describe("payload decoder", function() {
+
+        it("resets the expected length of the next packet to 6 (header)", function() {
+            this.m.pushBuffer(this.heartbeatPayload);
+            this.m.parseLength(); // expected length should now be 9 (message) + 8 bytes (header) = 17
+            this.m.expected_length.should.equal(17);
+            this.m.parsePayload();
+            this.m.expected_length.should.equal(6);
+        });
+
+        it("submits a candidate message to the mavlink decode function", function() {
+            
+            var spy = sinon.spy(this.m, 'decode');
+        
+            this.m.pushBuffer(this.heartbeatPayload);
+            this.m.parseLength();
+            this.m.parsePayload();
+
+            // could improve this to check the args more closely.
+            // It'd be better but tricky because the type comparison doesn't quite work.
+            spy.called.should.be.true;
+
+        });
+
+        // invalid data should return bad_data message
+        it("parsePayload throws exception if a borked message is encountered", function() {
+            var b = new Buffer.from([3, 0, 1, 2, 3, 4, 5]); // invalid message
+            this.m.pushBuffer(b);
+            var message;
+            (function(){
+                message = this.m.parsePayload();
+            }).should.throw();
+        });
+
+        it("returns a valid mavlink packet if everything is OK", function() {
+            this.m.pushBuffer(this.heartbeatPayload);
+            this.m.parseLength();
+            var message = this.m.parsePayload();
+            message.should.be.an.instanceof(mavlink.messages.heartbeat);
+        });
+
+        it("increments the total packets received if a good packet is decoded", function() {
+            this.m.total_packets_received.should.equal(0);
+            this.m.pushBuffer(this.heartbeatPayload);
+            this.m.parseLength();
+            var message = this.m.parsePayload();
+            this.m.total_packets_received.should.equal(1);
+        });
+
+        
+
+    });
+
+});
+
+
+describe("MAVLink X25CRC Decoder", function() {
+
+    beforeEach(function() {
+        // Message header + payload, lacks initial MAVLink flag (FE) and CRC.
+        this.heartbeatMessage = new Buffer.from([0x09, 0x03, 0xff , 0x00 , 0x00 , 0x00 , 0x00 , 0x00 , 0x00 , 0x06 , 0x08 , 0x00 , 0x00 , 0x03]);
+
+    });
+
+    // This test matches the output directly taken by inspecting what the Python implementation
+    // generated for the above packet.
+    it('implements x25crc function', function() {
+            mavlink.x25Crc(this.heartbeatMessage).should.equal(27276);
+    });
+
+    // Heartbeat crc_extra value is 50.
+    it('can accumulate further bytes as needed (crc_extra)', function() {
+            var crc = mavlink.x25Crc(this.heartbeatMessage);
+            crc = mavlink.x25Crc([50], crc);
+            crc.should.eql(23711)
+    });
+
+});

--- a/generator/javascript/test/message10.js
+++ b/generator/javascript/test/message10.js
@@ -1,0 +1,252 @@
+var {mavlink, MAVLinkProcessor} = require('../implementations/mavlink_common_v1.0/mavlink.js'),
+should = require('should');
+
+describe('MAVLink 1.0 message registry', function() {
+
+    it('defines constructors for every message', function() {
+        mavlink.messages['gps_raw_int'].should.be.a.function;
+    });
+
+    it('assigns message properties, format with int64 (q), gps_raw_int', function() {
+        var m = new mavlink.messages['gps_raw_int']();
+        m.format.should.equal("<QiiiHHHHBB");
+        m.order_map.should.eql([0, 8, 1, 2, 3, 4, 5, 6, 7, 9]); // should.eql = shallow comparison
+        m.crc_extra.should.equal(24);
+        m.id.should.equal(mavlink.MAVLINK_MSG_ID_GPS_RAW_INT);
+    });
+
+    it('assigns message properties, heartbeat', function() {
+        var m = new mavlink.messages['heartbeat']();
+        m.format.should.equal("<IBBBBB");
+        m.order_map.should.eql([1, 2, 3, 0, 4, 5]); // should.eql = shallow comparison
+        m.crc_extra.should.equal(50);
+        m.id.should.equal(mavlink.MAVLINK_MSG_ID_HEARTBEAT);
+    });
+
+});
+
+describe('Complete MAVLink 1.0 packet', function() {
+
+    beforeEach(function() {
+        var {mavlink, MAVLinkProcessor} = require('../implementations/mavlink_common_v1.0/mavlink.js')
+        this.mav = new MAVLinkProcessor(null, 42, 150);
+    });
+
+    it('encode gps_raw_int', function() {
+
+        // 0x75bcd15 = 123456789
+        // as long as the number is no bigger than max signed int (2147483648) it can be passed like the following
+        var gpsraw = new mavlink.messages.gps_raw_int(
+            time_usec=[123456789, 0]
+            , fix_type=3
+            , lat=47123456
+            , lon=8123456
+            , alt=50000
+            , eph=6544
+            , epv=4566
+            , vel=1235
+            , cog=1234
+            , satellites_visible=9
+        );
+
+        this.mav.seq = 5;
+
+        // Create a buffer that matches what the Python version of MAVLink creates
+        var reference = new Buffer.from([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x15, 0xcd, 0x5b, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0xee, 0x16]);
+        new Buffer.from(gpsraw.pack(this.mav)).should.eql(reference);
+
+    });
+
+    it('encode gps_raw_int with long integer', function() {
+
+        // number ~2^60
+        // 1152221500606846977 = 0xffd8359 9e3d1801
+        var gpsraw = new mavlink.messages.gps_raw_int(
+            time_usec=[0x9e3d1801, 0xffd8359]
+            , fix_type=3
+            , lat=47123456
+            , lon=8123456
+            , alt=50000
+            , eph=6544
+            , epv=4566
+            , vel=1235
+            , cog=1234
+            , satellites_visible=9
+        );
+
+        this.mav.seq = 5;
+        
+        // Create a buffer that matches what the Python version of MAVLink creates
+        var reference = new Buffer.from([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0x6c, 0xe8]);
+        new Buffer.from(gpsraw.pack(this.mav)).should.eql(reference);
+
+    });
+
+    it('encode heartbeat', function() {
+
+        var heartbeat = new mavlink.messages.heartbeat(
+            type=5
+            , autopilot=3
+            , base_mode=45
+            , custom_mode=68
+            , system_status=13
+            , mavlink_version=1
+        );
+        
+        this.mav.seq = 7;
+
+        // Create a buffer that matches what the Python version of MAVLink creates
+        var reference = new Buffer.from([0xfe, 0x09, 0x07, 0x2a, 0x96, 0x00, 0x44, 0x00, 0x00, 0x00, 0x05, 0x03, 0x2d, 0x0d, 0x01, 0xac, 0x9d]);
+        new Buffer.from(heartbeat.pack(this.mav)).should.eql(reference);
+
+    });
+
+    it('decode gps_raw_int with long integer', function() {
+
+        // number ~2^60
+        // 1152221500606846977 = 0xffd8359 9e3d1801
+
+        // Create a buffer that matches what the Python version of MAVLink creates
+        var reference = new Buffer.from([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0x6c, 0xe8]);
+
+        var m = new MAVLinkProcessor();
+
+        var msg = m.parseBuffer(reference);
+
+        // check header
+        msg[0].header.seq.should.eql(5);
+        msg[0].header.srcSystem.should.eql(42);
+        msg[0].header.srcComponent.should.eql(150);
+
+        // check payload
+        msg[0].time_usec.should.eql([0x9e3d1801, 0xffd8359, true]);
+        msg[0].fix_type.should.eql(3);
+        msg[0].lat.should.eql(47123456);
+        msg[0].lon.should.eql(8123456);
+        msg[0].alt.should.eql(50000);
+        msg[0].eph.should.eql(6544);
+        msg[0].epv.should.eql(4566);
+        msg[0].vel.should.eql(1235);
+        msg[0].cog.should.eql(1234);
+        msg[0].satellites_visible.should.eql(9);
+
+    });
+
+
+});
+
+describe('MAVLink 1.0 header', function() {
+    beforeEach(function() {
+        var {mavlink, MAVLinkProcessor} = require('../implementations/mavlink_common_v1.0/mavlink.js');
+        this.h = new mavlink.header(mavlink.MAVLINK_MSG_ID_PARAM_REQUEST_LIST, 1, 2, 3, 4);
+    });
+
+    it('Can pack itself', function() {
+        this.h.pack().should.eql([254, 1, 2, 3, 4, 21]);
+    });
+
+});
+
+describe('MAVLink 1.0 message', function() {
+
+    beforeEach(function() {
+        // This is a heartbeat packet from a GCS to the APM.
+        this.heartbeat = new mavlink.messages.heartbeat(
+            mavlink.MAV_TYPE_GCS, // 6
+            mavlink.MAV_AUTOPILOT_INVALID, // 8
+            0, // base mode, mavlink.MAV_MODE_FLAG_***
+            0, // custom mode
+            mavlink.MAV_STATE_STANDBY, // system status
+            3 // MAVLink version
+        );
+
+        this.mav = new MAVLinkProcessor();
+
+    });
+
+    it('has a set function to facilitate vivifying the object', function() {
+        this.heartbeat.type.should.equal(mavlink.MAV_TYPE_GCS);
+        this.heartbeat.autopilot.should.equal(mavlink.MAV_AUTOPILOT_INVALID);
+        this.heartbeat.base_mode.should.equal(0);
+        this.heartbeat.custom_mode.should.equal(0);
+        this.heartbeat.system_status.should.equal(mavlink.MAV_STATE_STANDBY);
+    });
+
+    // TODO: the length below (9) should perhaps be instead 7.  See mavlink.unpack().
+    // might have to do with the length of the encoding (<I is 4 symbols in the array) 
+    it('Can pack itself', function() {
+
+        var packed = this.heartbeat.pack(this.mav);
+        packed.should.eql([254, 9, 0, 0, 0, mavlink.MAVLINK_MSG_ID_HEARTBEAT, // that bit is the header,
+            // this is the payload, arranged in the order map specified in the protocol,
+            // which differs from the constructor.
+            0, 0, 0, 0, // custom bitfield -- length 4 (type=I)
+            mavlink.MAV_TYPE_GCS,
+            mavlink.MAV_AUTOPILOT_INVALID,
+            0,
+            mavlink.MAV_STATE_STANDBY,
+            3,
+            109, // CRC
+            79 // CRC
+            ]);
+
+    });
+
+    describe('decode 1.0 function', function() {
+
+        beforeEach(function() {
+            this.m = new MAVLinkProcessor();
+        });
+
+        // need to add tests for the header fields as well, specifying seq etc.
+        it('Can decode itself', function() {
+
+            var packed = this.heartbeat.pack(this.m);
+            var message = this.m.decode(packed);
+
+            // this.fieldnames = ['type', 'autopilot', 'base_mode', 'custom_mode', 'system_status', 'mavlink_version'];
+            message.type.should.equal(mavlink.MAV_TYPE_GCS);  // supposed to be 6
+            message.autopilot.should.equal(mavlink.MAV_AUTOPILOT_INVALID); // supposed to be 8
+            message.base_mode.should.equal(0); // supposed to be 0
+            message.custom_mode.should.equal(0);
+            message.system_status.should.equal(mavlink.MAV_STATE_STANDBY); // supposed to be 3
+            message.mavlink_version.should.equal(3); //?
+
+        });
+
+        it('throws an error if the message has a bad prefix', function() {
+            var packed = [0, 3, 5, 7, 9, 11]; // bad data prefix in header (0, not 254)
+            var m = this.m;
+            (function() { m.decode(packed); }).should.throw('Invalid MAVLink prefix (0)');
+        });
+
+        it('throws an error if the message ID is not known', function() {
+            var packed = [254, 1, 0, 3, 0, 200, 1, 0, 0]; // 200 = invalid ID
+            var m = this.m;
+            (function() { m.decode(packed); }).should.throw('Unknown MAVLink message ID (200)');
+        });
+
+        it('throws an error if the message length is invalid', function() {
+            var packed = [254, 3, 257, 0, 0, 0, 0, 0];
+            var m = this.m;
+            (function() { m.decode(packed); }).should.throw('Invalid MAVLink message length.  Got 0 expected 3, msgId=0');
+        });
+
+        it('throws an error if the CRC cannot be unpacked', function() {
+            
+        });
+
+        it('throws an error if the CRC can not be decoded', function() {
+
+        });
+
+        it('throws an error if it is unable to unpack the payload', function() {
+
+        });
+
+        it('throws an error if it is unable to instantiate a MAVLink message object from the payload', function() {
+
+        });
+
+    });
+});

--- a/generator/javascript/test/message20.js
+++ b/generator/javascript/test/message20.js
@@ -1,7 +1,7 @@
-var mavlink = require('../implementations/mavlink_common_v1.0/mavlink.js'),
-    should = require('should');
+var {mavlink, MAVLinkProcessor} = require('../implementations/mavlink_common_v2.0/mavlink.js'),
+should = require('should');
 
-describe('MAVLink message registry', function() {
+describe('MAVLink 2.0 message registry', function() {
 
     it('defines constructors for every message', function() {
         mavlink.messages['gps_raw_int'].should.be.a.function;
@@ -9,8 +9,8 @@ describe('MAVLink message registry', function() {
 
     it('assigns message properties, format with int64 (q), gps_raw_int', function() {
         var m = new mavlink.messages['gps_raw_int']();
-        m.format.should.equal("<QiiiHHHHBB");
-        m.order_map.should.eql([0, 8, 1, 2, 3, 4, 5, 6, 7, 9]); // should.eql = shallow comparison
+        m.format.should.equal("<QiiiHHHHBBiIIII");
+        m.order_map.should.eql([0, 8, 1, 2, 3, 4, 5, 6, 7, 9, 10, 11, 12, 13, 14]); // should.eql = shallow comparison
         m.crc_extra.should.equal(24);
         m.id.should.equal(mavlink.MAVLINK_MSG_ID_GPS_RAW_INT);
     });
@@ -25,10 +25,10 @@ describe('MAVLink message registry', function() {
 
 });
 
-describe('Complete MAVLink packet', function() {
+describe('Complete MAVLink 2.0 packet', function() {
 
     beforeEach(function() {
-        this.mav = new MAVLink(null, 42, 150);
+        this.mav = new MAVLinkProcessor(null, 42, 150);
     });
 
     it('encode gps_raw_int', function() {
@@ -51,8 +51,8 @@ describe('Complete MAVLink packet', function() {
         this.mav.seq = 5;
 
         // Create a buffer that matches what the Python version of MAVLink creates
-        var reference = new Buffer([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x15, 0xcd, 0x5b, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0xee, 0x16]);
-        new Buffer(gpsraw.pack(this.mav)).should.eql(reference);
+        var reference = new Buffer.from([0xfd, 0x1e, 0x00, 0x00, 0x05, 0x2a, 0x96, 0x18, 0x00, 0x00, 0x15, 0xcd, 0x5b, 0x07, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0x20, 0x2d]);
+        new Buffer.from(gpsraw.pack(this.mav)).should.eql(reference);
 
     });
 
@@ -76,8 +76,8 @@ describe('Complete MAVLink packet', function() {
         this.mav.seq = 5;
         
         // Create a buffer that matches what the Python version of MAVLink creates
-        var reference = new Buffer([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0x6c, 0xe8]);
-        new Buffer(gpsraw.pack(this.mav)).should.eql(reference);
+        var reference = new Buffer.from([0xfd, 0x1e, 0x00, 0x00, 0x05, 0x2a, 0x96, 0x18, 0x00, 0x00, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0xa2, 0xd3]);
+        new Buffer.from(gpsraw.pack(this.mav)).should.eql(reference);
 
     });
 
@@ -89,14 +89,14 @@ describe('Complete MAVLink packet', function() {
             , base_mode=45
             , custom_mode=68
             , system_status=13
-            , mavlink_version=1
+            , mavlink_version=2
         );
         
         this.mav.seq = 7;
 
         // Create a buffer that matches what the Python version of MAVLink creates
-        var reference = new Buffer([0xfe, 0x09, 0x07, 0x2a, 0x96, 0x00, 0x44, 0x00, 0x00, 0x00, 0x05, 0x03, 0x2d, 0x0d, 0x01, 0xac, 0x9d]);
-        new Buffer(heartbeat.pack(this.mav)).should.eql(reference);
+         var reference = new Buffer.from([0xfd, 0x09, 0x00, 0x00, 0x07, 0x2a, 0x96, 0x00, 0x00, 0x00, 0x44, 0x00, 0x00, 0x00, 0x05, 0x03, 0x2d, 0x0d, 0x02, 0x7e, 0xfd]);
+        new Buffer.from(heartbeat.pack(this.mav)).should.eql(reference);
 
     });
 
@@ -106,9 +106,9 @@ describe('Complete MAVLink packet', function() {
         // 1152221500606846977 = 0xffd8359 9e3d1801
 
         // Create a buffer that matches what the Python version of MAVLink creates
-        var reference = new Buffer([0xfe, 0x1e, 0x05, 0x2a, 0x96, 0x18, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0x6c, 0xe8]);
+        var reference = new Buffer.from([0xfd, 0x1e, 0x00, 0x00, 0x05, 0x2a, 0x96, 0x18, 0x00, 0x00, 0x01, 0x18, 0x3d, 0x9e, 0x59, 0x83, 0xfd, 0x0f, 0x00, 0x0c, 0xcf, 0x02, 0x40, 0xf4, 0x7b, 0x00, 0x50, 0xc3, 0x00, 0x00, 0x90, 0x19, 0xd6, 0x11, 0xd3, 0x04, 0xd2, 0x04, 0x03, 0x09, 0xa2, 0xd3]);
 
-        var m = new MAVLink();
+        var m = new MAVLinkProcessor();
 
         var msg = m.parseBuffer(reference);
 
@@ -134,22 +134,20 @@ describe('Complete MAVLink packet', function() {
 
 });
 
-describe('MAVLink header', function() {
-
+describe('MAVLink 2.0 header', function() {
     beforeEach(function() {
         this.h = new mavlink.header(mavlink.MAVLINK_MSG_ID_PARAM_REQUEST_LIST, 1, 2, 3, 4);
-    })
+    });
 
     it('Can pack itself', function() {
-        this.h.pack().should.eql([254, 1, 2, 3, 4, 21]);
+        this.h.pack().should.eql([253, 1, 0, 0, 2, 3, 4, 21, 0, 0]);
     });
 
 });
 
-describe('MAVLink message', function() {
+describe('MAVLink 2.0 message', function() {
 
     beforeEach(function() {
-
         // This is a heartbeat packet from a GCS to the APM.
         this.heartbeat = new mavlink.messages.heartbeat(
             mavlink.MAV_TYPE_GCS, // 6
@@ -160,7 +158,7 @@ describe('MAVLink message', function() {
             3 // MAVLink version
         );
 
-        this.mav = new MAVLink(null, 0, 0);
+        this.mav = new MAVLinkProcessor();
 
     });
 
@@ -177,7 +175,7 @@ describe('MAVLink message', function() {
     it('Can pack itself', function() {
 
         var packed = this.heartbeat.pack(this.mav);
-        packed.should.eql([254, 9, 0, 0, 0, mavlink.MAVLINK_MSG_ID_HEARTBEAT, // that bit is the header,
+        packed.should.eql([253, 9, 0, 0, 0, 0, 0, mavlink.MAVLINK_MSG_ID_HEARTBEAT, 0, 0, // that bit is the header,
             // this is the payload, arranged in the order map specified in the protocol,
             // which differs from the constructor.
             0, 0, 0, 0, // custom bitfield -- length 4 (type=I)
@@ -186,16 +184,16 @@ describe('MAVLink message', function() {
             0,
             mavlink.MAV_STATE_STANDBY,
             3,
-            109, // CRC
-            79 // CRC
+            207, // CRC
+            58 // CRC
             ]);
 
     });
 
-    describe('decode function', function() {
+    describe('decode 2.0 function', function() {
 
         beforeEach(function() {
-            this.m = new MAVLink();
+            this.m = new MAVLinkProcessor();
         });
 
         // need to add tests for the header fields as well, specifying seq etc.
@@ -215,19 +213,19 @@ describe('MAVLink message', function() {
         });
 
         it('throws an error if the message has a bad prefix', function() {
-            var packed = [0, 3, 5, 7, 9, 11]; // bad data prefix in header (0, not 254)
+            var packed = [0, 3, 0, 0, 5, 7, 9, 0, 0, 11]; // bad data prefix in header (0, not 253)
             var m = this.m;
             (function() { m.decode(packed); }).should.throw('Invalid MAVLink prefix (0)');
         });
 
         it('throws an error if the message ID is not known', function() {
-            var packed = [254, 1, 0, 3, 0, 200, 1, 0, 0]; // 200 = invalid ID
+            var packed = [253, 1, 0, 0, 0, 3, 0, 200, 0, 0, 1, 0, 0]; // 200 = invalid ID
             var m = this.m;
             (function() { m.decode(packed); }).should.throw('Unknown MAVLink message ID (200)');
         });
 
         it('throws an error if the message length is invalid', function() {
-            var packed = [254, 3, 257, 0, 0, 0, 0, 0];
+            var packed = [253, 3, 0, 0, 257, 0, 0, 0, 0, 0, 0, 0];
             var m = this.m;
             (function() { m.decode(packed); }).should.throw('Invalid MAVLink message length.  Got 0 expected 3, msgId=0');
         });


### PR DESCRIPTION
As the title suggests, this PR patches the Javascript generator so it can generate Mavlink 2.0 messages.

Note it doesn't support signed packets at this time.

Unit tests in the ./generator/javascript/tests directory have been updated and all pass.

Tests can be run via:
```
cd ./generator/javascript
npm install
npm test
```

Also tested with latest APM with no issues.

Fixes #96 