### PR TITLE
mavutil: add separate range check for mavlink2 messages

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1460,6 +1460,8 @@ class mavmmaplog(mavlogfile):
                 mtype = u_ord(self.data_map[ofs+13])
                 mlen += 8
             elif marker == MARKER_V2:
+                if ofs+8+10 < self.data_len:
+                    break
                 mtype = u_ord(self.data_map[ofs+15]) | (u_ord(self.data_map[ofs+16])<<8) | (u_ord(self.data_map[ofs+17])<<16)
                 mlen += 12
                 incompat_flags = u_ord(self.data_map[ofs+10])


### PR DESCRIPTION
We assume these messages are longer than the loop condition accounts for
on the lines following this patch.

  File "/home/pbarker/.local/lib/python2.7/site-packages/pymavlink-2.4.3-py2.7-linux-x86_64.egg/pymavlink/mavutil.py", line 1417, in __init__
    self.init_arrays(progress_callback)
  File "/home/pbarker/.local/lib/python2.7/site-packages/pymavlink-2.4.3-py2.7-linux-x86_64.egg/pymavlink/mavutil.py", line 1463, in init_arrays
    mtype = u_ord(self.data_map[ofs+15]) | (u_ord(self.data_map[ofs+16])<<8) | (u_ord(self.data_map[ofs+17])<<16)
IndexError: mmap index out of range