### PR TITLE
Fix compile warnings in mavlink_conversions.h

### DIFF
--- a/generator/C/include_v2.0/mavlink_conversions.h
+++ b/generator/C/include_v2.0/mavlink_conversions.h
@@ -38,10 +38,10 @@
  */
 MAVLINK_HELPER void mavlink_quaternion_to_dcm(const float quaternion[4], float dcm[3][3])
 {
-    double a = quaternion[0];
-    double b = quaternion[1];
-    double c = quaternion[2];
-    double d = quaternion[3];
+    double a = (double)quaternion[0];
+    double b = (double)quaternion[1];
+    double c = (double)quaternion[2];
+    double d = (double)quaternion[3];
     double aSq = a * a;
     double bSq = b * b;
     double cSq = c * c;


### PR DESCRIPTION
Modern compilers might throw a warning due to the implicit increase in precision. The explicit cast (in C syntax to not force C++ for MAVLink library adopters) tells the compiler that this is intentional. We store as an intermediate double to ensure that compilers use full double precision for the operation.