### PR TITLE
Adding bitfield option to enum, to indicate multi bits enum

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -238,6 +238,7 @@
             <xs:element ref="entry" maxOccurs="unbounded"/>
         </xs:sequence>
         <xs:attribute ref="name" use="required"/>
+        <xs:attribute ref="bitmask" type="xs:boolean" default="false"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
as been discussed on [adding bitmask="true" for enums #1316
](https://github.com/mavlink/mavlink/pull/1316)