### PR TITLE
Add Watt to list of units

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -118,6 +118,8 @@
     <xs:enumeration value="mgauss"/>   <!-- milli-Gauss -->
     <!-- energy -->
     <xs:enumeration value="hJ"/>       <!-- hecto-Joule -->
+    <!-- power -->
+    <xs:enumeration value="W"/>        <!-- Watt -->
     <!-- force -->
     <xs:enumeration value="mG"/>       <!-- milli-G -->
     <!-- mass -->


### PR DESCRIPTION
There was no unit for power, added Watt since this seems the most likely unit to be working with in drones. I plan on using it in a future pr