### PR TITLE
#404 C mavlink_channel_t wrapping

### DIFF
--- a/generator/C/include_v0.9/mavlink_types.h
+++ b/generator/C/include_v0.9/mavlink_types.h
@@ -272,12 +272,14 @@ typedef struct __mavlink_message_info {
 #define mavlink_ck_a(msg) *((msg)->len + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 #define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 
+#ifndef MAVLINK_EXTERNAL_CHANNEL_T
 typedef enum {
     MAVLINK_COMM_0,
     MAVLINK_COMM_1,
     MAVLINK_COMM_2,
     MAVLINK_COMM_3
 } mavlink_channel_t;
+#endif // MAVLINK_EXTERNAL_CHANNEL_T
 
 /*
  * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number

--- a/generator/C/include_v1.0/mavlink_types.h
+++ b/generator/C/include_v1.0/mavlink_types.h
@@ -170,12 +170,14 @@ typedef struct __mavlink_message_info {
 #define mavlink_ck_a(msg) *((msg)->len + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 #define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 
+#ifndef MAVLINK_EXTERNAL_CHANNEL_T
 typedef enum {
     MAVLINK_COMM_0,
     MAVLINK_COMM_1,
     MAVLINK_COMM_2,
     MAVLINK_COMM_3
 } mavlink_channel_t;
+#endif // MAVLINK_EXTERNAL_CHANNEL_T
 
 /*
  * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number

--- a/generator/C/include_v2.0/mavlink_types.h
+++ b/generator/C/include_v2.0/mavlink_types.h
@@ -161,12 +161,14 @@ typedef struct __mavlink_message_info {
 #define mavlink_ck_a(msg) *((msg)->len + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 #define mavlink_ck_b(msg) *(((msg)->len+(uint16_t)1) + (uint8_t *)_MAV_PAYLOAD_NON_CONST(msg))
 
+#ifndef MAVLINK_EXTERNAL_CHANNEL_T
 typedef enum {
     MAVLINK_COMM_0,
     MAVLINK_COMM_1,
     MAVLINK_COMM_2,
     MAVLINK_COMM_3
 } mavlink_channel_t;
+#endif // MAVLINK_EXTERNAL_CHANNEL_T
 
 /*
  * applications can set MAVLINK_COMM_NUM_BUFFERS to the maximum number


### PR DESCRIPTION
This addresses the comment from @WickedShell in #404 , wrapping `mavlink_channel_t` in an ifndef.

I think it would be nice to tie `mavlink_channel_t` to `MAVLINK_COMM_NUM_BUFFERS` (ie: if COMM_BUFFERS=16 then mavlink_channel_t should support 16 channels) For now I've just wrapped it in its own ifndef. I would be interested in your opinion on this.

Thanks!