### PR TITLE
CI: Update build environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.6"
   - "3.7"
 before_install:
+  - nvm install 12.18.1 # need recent version of nodejs
   - pip install --upgrade pip
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
The version of Ubuntu used in TravisCI needs to be updated in order to use a modern version of nodejs.

Currently, the nodejs tests are failing with the same error over as https://github.com/mavlink/mavlink/issues/1404.