### PR TITLE
mavgen.py: correct handling of includes (updated)

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -66,37 +66,109 @@ def mavgen(opts, args):
             opts.validate = False
 
     def expand_includes():
-        """Expand includes in current list of all files, ignoring those already parsed."""
-        for x in xml[:]:
-            for i in x.include:
-                fname = os.path.join(os.path.dirname(x.filename), i)
+        """Expand includes. Root files already parsed objects in the xml list."""
 
-                # Only parse new include files
-                if fname in all_files:
+        def expand_oneiteration():
+            noincludeadded = True
+            for x in xml[:]: #deepcopy
+                for i in x.include:
+                    fname = os.path.join(os.path.dirname(x.filename), i)
+                    # Only parse new include files
+                    if fname in all_files:
+                        continue
+                    # Validate XML file with XSD file if possible.
+                    if opts.validate:
+                        print("Validating %s" % fname)
+                        if not mavgen_validate(fname):
+                            print("ERROR Validation of %s failed" % fname)
+                            exit(1)
+                    else:
+                        print("Validation skipped for %s." % fname)
+                    # Parsing
+                    print("Parsing %s" % fname)
+                    xml.append(mavparse.MAVXML(fname, opts.wire_protocol))
+                    all_files.add(fname)
+                    noincludeadded = False
+            return noincludeadded
+
+        for i in range(MAXIMUM_INCLUDE_FILE_NESTING):
+            if expand_oneiteration():
+                break
+
+        if mavparse.check_duplicates(xml):
+            sys.exit(1)
+
+    def update_includes():
+        """Update dialects with crcs etc of included files.
+        Included files were already found and parsed into xml list in expand_includes()."""
+        done = []
+        done_filenames = []
+
+        # 1: Mark files that don't have includes as "done"
+        atleastonefound = False
+        for x in xml:
+            #print("\n",x)
+            if len(x.include) == 0:
+                done.append(x)
+                done_filenames.append(x.filename)
+                atleastonefound = True
+                #print("\nFile with no includes found (ENDPOINT): %s" % x.filename )
+        if not atleastonefound:
+            print("\nERROR in includes tree, no base found!")
+            exit(1)
+
+        #print("\n",done)
+        #print("\n",done_filenames)
+
+        # 2: Update all 'not done' files for which all includes have been done (called recursively)
+        def update_oneiteration():
+            atleastonefound = False
+            for x in xml:
+                #print("\nCHECK %s" % x.filename)
+                if x in done:
+                    #print("  already done, skip")
                     continue
-                all_files.add(fname)
+                #check if all its includes were already done
+                allitsincludesaredone = True
+                for i in x.include:
+                    fname = os.path.join(os.path.dirname(x.filename), i)
+                    if not fname in done_filenames:
+                        allitsincludesaredone = False
+                if not allitsincludesaredone:
+                    #print("  not all includes ready, skip")
+                    continue
+                #Found file that where all includes are done
+                done.append(x)
+                done_filenames.append(x.filename)
+                atleastonefound = True
+                #print("  all includes ready, add" )
+                #now update it with the facts from all it's includes
+                for i in x.include:
+                    fname = os.path.join(os.path.dirname(x.filename), i)
+                    #print("  include file %s" % i )
+                    #Find the corresponding x
+                    for ix in xml:
+                        if ix.filename != fname: continue
+                        #print("    add %s" % ix.filename )
+                        x.message_crcs.update(ix.message_crcs)
+                        x.message_lengths.update(ix.message_lengths)
+                        x.message_min_lengths.update(ix.message_min_lengths)
+                        x.message_flags.update(ix.message_flags)
+                        x.message_target_system_ofs.update(ix.message_target_system_ofs)
+                        x.message_target_component_ofs.update(ix.message_target_component_ofs)
+                        x.message_names.update(ix.message_names)
+                        x.largest_payload = max(x.largest_payload, ix.largest_payload)
+            if len(done) == len(xml):
+                return True #finished
+            if not atleastonefound:
+                print("ERROR include tree can't be resolved, no base found!")
+                exit(1)
+            return False
 
-                # Validate XML file with XSD file if possible.
-                if opts.validate:
-                    print("Validating %s" % fname)
-                    if not mavgen_validate(fname):
-                        return False
-                else:
-                    print("Validation skipped for %s." % fname)
-
-                # Parsing
-                print("Parsing %s" % fname)
-                xml.append(mavparse.MAVXML(fname, opts.wire_protocol))
-
-                # include message lengths and CRCs too
-                x.message_crcs.update(xml[-1].message_crcs)
-                x.message_lengths.update(xml[-1].message_lengths)
-                x.message_min_lengths.update(xml[-1].message_min_lengths)
-                x.message_flags.update(xml[-1].message_flags)
-                x.message_target_system_ofs.update(xml[-1].message_target_system_ofs)
-                x.message_target_component_ofs.update(xml[-1].message_target_component_ofs)
-                x.message_names.update(xml[-1].message_names)
-                x.largest_payload = max(x.largest_payload, xml[-1].largest_payload)
+        for i in range(MAXIMUM_INCLUDE_FILE_NESTING):
+            #print("\nITERATION "+str(i))
+            if update_oneiteration():
+                break
 
     def mavgen_validate(xmlfile):
         """Uses lxml to validate an XML file. We define mavgen_validate
@@ -143,20 +215,8 @@ def mavgen(opts, args):
         xml.append(mavparse.MAVXML(fname, opts.wire_protocol))
 
     # expand includes
-    for i in range(MAXIMUM_INCLUDE_FILE_NESTING):
-        len_allfiles = len(all_files)
-        expand_includes()
-        if len(all_files) == len_allfiles:
-            # stop when loop doesn't add any more included files
-            break
-
-    # work out max payload size across all includes
-    largest_payload = max(x.largest_payload for x in xml) if xml else 0
-    for x in xml:
-        x.largest_payload = largest_payload
-
-    if mavparse.check_duplicates(xml):
-        sys.exit(1)
+    expand_includes()
+    update_includes()
 
     print("Found %u MAVLink message types in %u XML files" % (
         mavparse.total_msgs(xml), len(xml)))

--- a/tests/generation/child.xml
+++ b/tests/generation/child.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<mavlink>
+<include>root.xml</include>
+<messages>
+    <message id="2222" name="CHILDMSG">
+      <description>This is a child message field</description>
+      <field type="uint32_t" name="CHILDFIELD">child Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/grandchild1.xml
+++ b/tests/generation/grandchild1.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<mavlink>
+<include>child.xml</include>
+<messages>
+    <message id="3333" name="GRANDCHILD1MSG">
+      <description>This is a grandchild1 message field</description>
+      <field type="uint32_t" name="GRANDCHILD1FIELD">grandchild1 Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/grandchild2.xml
+++ b/tests/generation/grandchild2.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<mavlink>
+<include>child.xml</include>
+<messages>
+    <message id="4444" name="GRANDCHILD2MSG">
+      <description>This is a grandchild2 message field</description>
+      <field type="uint32_t" name="GRANDCHILD2MSG">grandchild2 Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/inbred.xml
+++ b/tests/generation/inbred.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<mavlink>
+<include>grandchild1.xml</include>
+<include>grandchild2.xml</include>
+<messages>
+    <message id="5555" name="INBREDMSG">
+      <description>This is a inbred message field</description>
+      <field type="uint32_t" name="INBREDFIELD">Inbred Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/mixin.xml
+++ b/tests/generation/mixin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<mavlink>
+<messages>
+    <message id="7777" name="MIXIN">
+      <description>This is a MIXIN message field</description>
+      <field type="uint32_t" name="MIXINFIELD">Mixin Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/mixiner.xml
+++ b/tests/generation/mixiner.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<mavlink>
+<!-- extends child.xml by mixing in mixin.xml.  A Mixiner is one who mixes in... -->
+<include>child.xml</include>
+<include>mixin.xml</include>
+<messages>
+    <message id="6666" name="MIXINER">
+      <description>This is a MIXINER message field</description>
+      <field type="uint32_t" name="MIXINERFIELD">Mixiner Field</field>
+    </message>
+</messages>
+</mavlink>

--- a/tests/generation/root.xml
+++ b/tests/generation/root.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<mavlink>
+<messages>
+    <message id="1111" name="ROOTMSG">
+      <description>This is a root message field</description>
+      <field type="uint32_t" name="ROOTFIELD">Root Field</field>
+    </message>
+</messages>
+</mavlink>


### PR DESCRIPTION
This supersedes #338 and #339. It updates @olliw42 recursive nesting code so I hope it can be merged. #339 will be closed.

Changes w.r.t 338.
1. Removes the changes to default mavlink version etc (were just debug changes that hadn't been cleaned up)
2. Comments out the success-path debug print statements. The fail case statements stay (e.g. indicating for example, unresolvable inclusion)
3. Removes the test xml from the tree. 

@peterbarker I have taken the time to convince myself that this code works. I have also run both Ollie test code and some of my own for both c and Python. The only differences are those that are expected - ie it fixes up the parent dialect headers with the CRCs etc of the nested dialects.

I have not included the test xml because I'm not sure where it would make sense to do so if the testing cannot be automated - and this case would be difficult to do.

I will withdraw my original PR. What do we need to do to get this in? 

@auturgy FYI