### PR TITLE
generator: add kg units

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -124,6 +124,7 @@
     <xs:enumeration value="mG"/>       <!-- milli-G -->
     <!-- mass -->
     <xs:enumeration value="g"/>       <!-- grams -->
+    <xs:enumeration value="kg"/>      <!-- kilograms -->
     <!-- pressure -->
     <xs:enumeration value="Pa"/>       <!-- Pascal -->
     <xs:enumeration value="hPa"/>      <!-- hecto-Pascal -->


### PR DESCRIPTION
The mavschema currently as grams but not the SI unit kg so this PR adds it.  I plan to use this in a new WINCH_STATUS message that must report the "tension" (i.e. weight on the line).

I have no tested this because I really don't know how it can be tested.  Still, I think it must be safe.