### PR TITLE
README.md: Encourage Windows users to install current lxml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Examples can be found [in the repository](examples/) or in the [ArduSub book](ht
 
 Pymavlink supports both Python 2 and Python 3.
 
-The following instructions assume you are using Python 3 and a Debian-based (like Ubuntu) installation.
+The following instructions assume you are using Python 2.7 and a Debian-based (like Ubuntu) installation.
 
 .. note::
 
@@ -29,7 +29,7 @@ Pymavlink has several dependencies :
 
     - [future](http://python-future.org/) : for Python 2 and Python 3 interoperability
     - [lxml](http://lxml.de/installation.html) : for checking and parsing xml file 
-    - python3-dev : for mavnative (or python-dev for Python 2)
+    - python-dev : for mavnative (or python3-dev for Python 3)
     - a C compiler : for mavnative
 
 Optional :
@@ -45,19 +45,19 @@ lxml has some additional dependencies that can be installed with your package ma
    If you continue to use Python 2 you may need to change package names here (e.g. python3-dev => python-dev)
 
 ```bash
-sudo apt-get install gcc python3-dev libxml2-dev libxslt-dev
+sudo apt-get install gcc python-dev libxml2-dev libxslt-dev
 ```
 
 Optional for FFT scripts and tests:
 
 ```bash
-sudo apt-get install python3-numpy python3-pytest
+sudo apt-get install python-numpy python-pytest
 ```
 
 Using pip you can install the required dependencies for pymavlink :
 
 ```bash
-sudo python -m pip install --upgrade future lxml
+sudo pip2 install --upgrade future lxml
 ```
 
 ### On Windows
@@ -73,7 +73,7 @@ Lxml can be installed with a Windows installer from here : https://pypi.org/proj
 It is recommended to install pymavlink from PyPI with pip, that way dependencies should be auto installed by pip.
 
 ```bash
-sudo python -m pip install --upgrade pymavlink
+sudo pip2 install --upgrade pymavlink
 ```
 
 #### Mavnative
@@ -82,7 +82,7 @@ By default, pymavlink will try to compile and install mavnative which is a C ext
 To skip mavnative installation and reduce dependencies like `gcc` and `python-dev`, you can pass `DISABLE_MAVNATIVE=True` environment variable to the installation command:
 
 ```bash
-sudo DISABLE_MAVNATIVE=True python -m pip install --upgrade pymavlink
+sudo DISABLE_MAVNATIVE=True pip2 install --upgrade pymavlink
 ```
 
 ### For developers
@@ -90,7 +90,7 @@ sudo DISABLE_MAVNATIVE=True python -m pip install --upgrade pymavlink
 From the pymavlink directory, you can use :
 
 ```bash
-sudo MDEF=PATH_TO_message_definitions python -m pip install . -v
+sudo MDEF=PATH_TO_message_definitions pip2 install . -v
 ```
 
 Since pip installation is executed from /tmp, it is necessary to point to the directory containing message definitions with MDEF. MDEF should not be set to any particular message version directory but the parent folder instead. If you have cloned from mavlink/mavlink then this is ```/mavlink/message_definitions``` . Using pip should auto install dependencies and allow you to keep them up-to-date. 
@@ -98,7 +98,7 @@ Since pip installation is executed from /tmp, it is necessary to point to the di
 Or:
 
 ```bash
-sudo python setup.py install
+sudo python2 setup.py install
 ```
 
 


### PR DESCRIPTION
[Current lxml](https://pypi.org/project/lxml) is 4.5.2, not 3.6.0.  This matches with https://github.com/ArduPilot/pymavlink/blob/master/requirements.txt#L1