### PR TITLE
array.array.fromstring() was removed in Python 3.9

### DIFF
--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -31,5 +31,8 @@ class x25crc(object):
         accum = self.crc
         import array
         bytes = array.array('B')
-        bytes.fromstring(buf)
+        try:
+            bytes.fromstring(buf)
+        except AttributeError:  # Python >= 3.9
+            bytes.frombytes(buf.encode())
         self.accumulate(bytes)


### PR DESCRIPTION
https://docs.python.org/3.9/library/array.html#array.array.frombytes

From [What’s New In Python 3.9](https://docs.python.org/3.9/whatsnew/3.9.html#removed))
> array.array: tostring() and fromstring() methods have been removed. They were aliases to tobytes() and frombytes(), deprecated since Python 3.2.


Swiped from https://github.com/ArduPilot/pymavlink/pull/449/files
