### PR TITLE
Use os.path.basename() for include base

### DIFF
--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -570,7 +570,7 @@ def generate_one(basename, xml):
     # work out the included headers
     xml.include_list = []
     for i in xml.include:
-        base = i[:-4]
+        base = os.path.basename(i)[:-4]
         xml.include_list.append(mav_include(base))
 
     # form message lengths array


### PR DESCRIPTION
This simple PR does this:

When one is generating the C files, the files which are included in a .xml file via a `<include>` are included in the dialect main header file via a `#include`. This PR ensures that path included via the `#include` is of the form "../dialect/dialect.h".

Why:

Currently, a new dialect needs to be added by creating a new dialect.xml file and placing it into the subfolder message_definitions/v1.0/. This is good and simple for those dialect owners which got the pleasure to have their dialect.xml files being added to the official mavlink git repository.

But for any other users this is quite painful. A git-ish way would be to fork the mavlink repo, create a branch with ones dialect.xml added, and then to submodule to this branch in the main project repo. What a pain. A much much simpler approach would be to simply place the dialect.xml somewhere outside of the mavlink repo folder, and in the generator call the xml from there. Normally the dialect.xml however wants to include a .xml from the main repo (it is technically supposed to at least include minimal.xml), and such a dialect.xml would then look e.g. as this:

```
<mavlink>
  <include>xxxx\mavlink\message_definitions\v1.0\ardupilotmega.xml</include>
  :
  :
</mavlink>

```

This indeed works nicely with the generator, except: In the dialect.h file the #include to the ardupilotmega.h file is screwed up, because the path is retained. This PR simply removes the path, with the result that the #include has the correct form "..\ardupilotmega\ardupilotmega.h", and all is fine and working.

Auxiliary:
In #https://stackoverflow.com/questions/8384737/extract-file-name-from-path-no-matter-what-the-os-path-format it is written that the best way (in terms of compatibility with oses) would be to use ntpath.basename() instead of os.path.basename(). I have seen however that the xml.basename field is also generated by using os.path.basename(), so I also used it. I however wonder if generally using path.basename() wouldn't be better.
