### PR TITLE
Add support for instance field markup in mavlink XML

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -262,7 +262,7 @@ class DFMessage(object):
         '''support indexing, allowing for multi-instance sensors in one message'''
         if self.fmt.instance_field is None:
             raise IndexError()
-        k = '%s_%s' % (self.fmt.name, str(key))
+        k = '%s[%s]' % (self.fmt.name, str(key))
         if not k in self._parent.messages:
             raise IndexError()
         return self._parent.messages[k]
@@ -600,7 +600,7 @@ class DFReader(object):
         self.messages[type] = m
         if m.fmt.instance_field is not None:
             i = m.__getattr__(m.fmt.instance_field)
-            self.messages["%s_%s" % (type, str(i))] = m
+            self.messages["%s[%s]" % (type, str(i))] = m
 
         if self.clock:
             self.clock.message_arrived(m)

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -16,6 +16,7 @@
 <xs:attribute name="enum" type="xs:string"/> <!-- used in field,param elements -->
 <xs:attribute name="display" type="xs:string"/> <!-- used in field elements -->
 <xs:attribute name="units" type="SI_Unit"/> <!-- this will get changed on the fly to xs:string if no strict-units command line option is used -->
+<xs:attribute name="instance" type="xs:boolean"/>
 <xs:attribute name="value"> <!-- used in entry elements -->
   <xs:simpleType>
     <xs:restriction base="xs:string">
@@ -170,6 +171,7 @@
         <xs:attribute ref="index" use="required"/>
         <xs:attribute ref="label"/>
         <xs:attribute ref="units"/>
+        <xs:attribute ref="instance"/>
         <xs:attribute ref="enum" />
         <xs:attribute ref="decimalPlaces"/>
         <xs:attribute ref="increment"/>
@@ -210,6 +212,7 @@
         <xs:attribute ref="display" />
         <xs:attribute ref="units" />
         <xs:attribute ref="default" />
+        <xs:attribute ref="instance" />
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
This allows for array indexing of mavlink messages, so that array syntax can be used for messages like BATTERY_STATUS which have an instance field
