### PR TITLE
examples: fix a couple of Python3 problems in mavtest.py

### DIFF
--- a/examples/mavtest.py
+++ b/examples/mavtest.py
@@ -34,11 +34,11 @@ def test_protocol(mavlink, signing=False):
         mav.signing.sign_outgoing = True
 
     # set the WP_RADIUS parameter on the MAV at the end of the link
-    mav.param_set_send(7, 1, "WP_RADIUS", 101, mavlink.MAV_PARAM_TYPE_REAL32)
+    mav.param_set_send(7, 1, b"WP_RADIUS", 101, mavlink.MAV_PARAM_TYPE_REAL32)
 
     # alternatively, produce a MAVLink_param_set object 
     # this can be sent via your own transport if you like
-    m = mav.param_set_encode(7, 1, "WP_RADIUS", 101, mavlink.MAV_PARAM_TYPE_REAL32)
+    m = mav.param_set_encode(7, 1, b"WP_RADIUS", 101, mavlink.MAV_PARAM_TYPE_REAL32)
 
     m.pack(mav)
 


### PR DESCRIPTION
This doesn't actually make the thing work; there's some signing weirdness going on in Python3; key needs to be handled differently.

