### PR TITLE
mavutil.py: Adds set_mode_send message to set_mode_apm

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -674,6 +674,9 @@ class mavfile(object):
                                    0,
                                    0,
                                    0)
+        self.mav.set_mode_send(self.target_system,
+                               mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED,
+                               mode)
 
     def set_mode_px4(self, mode, custom_mode, custom_sub_mode):
         '''enter arbitrary mode'''


### PR DESCRIPTION
I'm using AC 3.5.7.
I also use AC4.1.X.
I can no longer change the flight mode with the SITL mode command due to the PR of "mavutil: use command_long for change modes for ardupilot" (AC3.5.7).
I know that if the flight modes are the same, the switching process does not work.
I also support older versions by sending a SET_MODE message (11).
I know that Mission Planner and APM Planner2 use the SET_MODE message when changing the flight mode.

Message ID received by the flight controller:.
![Screenshot from 2020-10-03 14-53-46](https://user-images.githubusercontent.com/646194/94984904-29379180-058c-11eb-9aa5-32010db2a9e3.png)

After the change, I was able to change the flight mode with AC3.5.7.
![Screenshot from 2020-10-03 15-11-29](https://user-images.githubusercontent.com/646194/94984925-7d427600-058c-11eb-8661-c39eeedee280.png)