### PR TITLE
mavutil: Allow for custom mapping of vehicle modes

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2009,19 +2009,28 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
 
 
 try:
-    # Allow for using custom mode maps by importing a dict named
-    # AP_MAV_TYPE_MODE_MAP_CUSTOM from "~/.pymavlink/ap_custom_mode_map.py"
-    # and using it to extend the hard-coded AP_MAV_TYPE_MODE_MAP_DEFAULT dict.
-    import sys
+    # Allow for using custom mode maps by importing a JSON dict from
+    # "~/.pymavlink/custom_mode_map.json" and using it to extend the hard-coded
+    # AP_MAV_TYPE_MODE_MAP_DEFAULT dict.
     from os.path import expanduser
 
-    sys.path.append(expanduser('~') + '/.pymavlink')
-    from ap_custom_mode_map import AP_MAV_TYPE_MODE_MAP_CUSTOM
+    _custom_mode_map_path = expanduser('~/.pymavlink/custom_mode_map.json')
+    with open(_custom_mode_map_path) as f:
+        _json_mode_map = json.load(f)
+
+    try:
+        _custom_mode_map = {}
+        for mav_type, mode_map in _json_mode_map.items():
+            # make sure the custom map has the right datatypes
+            _custom_mode_map[int(mav_type)] = { int(mode_num): str(mode_name) for mode_num, mode_name in mode_map.items() }
+    except:
+        print("Error: invalid pymavlink custom mode map dict in " + _custom_mode_map_path)
+        raise
 
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT.copy()
-    AP_MAV_TYPE_MODE_MAP.update(AP_MAV_TYPE_MODE_MAP_CUSTOM)
-    print("Using custom MAV_TYPE mode map:")
-    print(repr(AP_MAV_TYPE_MODE_MAP_CUSTOM))
+    AP_MAV_TYPE_MODE_MAP.update(_custom_mode_map)
+    print("Using pymavlink custom MAV_TYPE mode map:")
+    print(repr(_custom_mode_map))
 except:
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -2030,8 +2030,6 @@ try:
 
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT.copy()
     AP_MAV_TYPE_MODE_MAP.update(_custom_mode_map)
-    print("Using pymavlink custom MAV_TYPE mode map:")
-    print(repr(_custom_mode_map))
 except:
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -2016,8 +2016,12 @@ try:
 
     _custom_mode_map_path = os.path.join("~", ".pymavlink", "custom_mode_map.json")
     _custom_mode_map_path = expanduser(_custom_mode_map_path)
-    with open(_custom_mode_map_path) as f:
-        _json_mode_map = json.load(f)
+    try:
+        with open(_custom_mode_map_path) as f:
+            _json_mode_map = json.load(f)
+    except:
+        print("Error: pymavlink custom mode file ('" + _custom_mode_map_path + "') is not valid JSON.")
+        raise
 
     try:
         _custom_mode_map = {}

--- a/mavutil.py
+++ b/mavutil.py
@@ -1985,7 +1985,7 @@ mode_mapping_sub = {
     19: 'MANUAL',
 }
 
-AP_MAV_TYPE_MODE_MAP = {
+AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     # copter
     mavlink.MAV_TYPE_HELICOPTER:  mode_mapping_acm,
     mavlink.MAV_TYPE_TRICOPTER:   mode_mapping_acm,
@@ -2006,6 +2006,25 @@ AP_MAV_TYPE_MODE_MAP = {
     # sub
     mavlink.MAV_TYPE_SUBMARINE: mode_mapping_sub,
 }
+
+
+try:
+    # Allow for using custom mode maps by importing a dict named
+    # AP_MAV_TYPE_MODE_MAP_CUSTOM from "~/.pymavlink/ap_custom_mode_map.py"
+    # and using it to extend the hard-coded AP_MAV_TYPE_MODE_MAP_DEFAULT dict.
+    import sys
+    from os.path import expanduser
+
+    sys.path.append(expanduser('~') + '/.pymavlink')
+    from ap_custom_mode_map import AP_MAV_TYPE_MODE_MAP_CUSTOM
+
+    AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT.copy()
+    AP_MAV_TYPE_MODE_MAP.update(AP_MAV_TYPE_MODE_MAP_CUSTOM)
+    print("Using custom MAV_TYPE mode map:")
+    print(repr(AP_MAV_TYPE_MODE_MAP_CUSTOM))
+except:
+    AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT
+
 
 # map from a PX4 "main_state" to a string; see msg/commander_state.msg
 # This allows us to map sdlog STAT.MainState to a simple "mode"

--- a/mavutil.py
+++ b/mavutil.py
@@ -1919,7 +1919,8 @@ mode_mapping_apm = {
     22 : 'QAUTOTUNE',
     23 : 'QACRO',
     24 : 'THERMAL',
-    }
+}
+
 mode_mapping_acm = {
     0 : 'STABILIZE',
     1 : 'ACRO',
@@ -1946,6 +1947,7 @@ mode_mapping_acm = {
     23 : 'FOLLOW',
     24 : 'ZIGZAG',
 }
+
 mode_mapping_rover = {
     0 : 'MANUAL',
     1 : 'ACRO',
@@ -1960,7 +1962,7 @@ mode_mapping_rover = {
     12 : 'SMART_RTL',
     15 : 'GUIDED',
     16 : 'INITIALISING'
-    }
+}
 
 mode_mapping_tracker = {
     0 : 'MANUAL',
@@ -1969,7 +1971,7 @@ mode_mapping_tracker = {
     4 : 'GUIDED',
     10 : 'AUTO',
     16 : 'INITIALISING'
-    }
+}
 
 mode_mapping_sub = {
     0: 'STABILIZE',
@@ -1981,7 +1983,29 @@ mode_mapping_sub = {
     9: 'SURFACE',
     16: 'POSHOLD',
     19: 'MANUAL',
-    }
+}
+
+AP_MAV_TYPE_MODE_MAP = {
+    # copter
+    mavlink.MAV_TYPE_HELICOPTER:  mode_mapping_acm,
+    mavlink.MAV_TYPE_TRICOPTER:   mode_mapping_acm,
+    mavlink.MAV_TYPE_QUADROTOR:   mode_mapping_acm,
+    mavlink.MAV_TYPE_HEXAROTOR:   mode_mapping_acm,
+    mavlink.MAV_TYPE_OCTOROTOR:   mode_mapping_acm,
+    mavlink.MAV_TYPE_DECAROTOR:   mode_mapping_acm,
+    mavlink.MAV_TYPE_DODECAROTOR: mode_mapping_acm,
+    mavlink.MAV_TYPE_COAXIAL:     mode_mapping_acm,
+    # plane
+    mavlink.MAV_TYPE_FIXED_WING: mode_mapping_apm,
+    # rover
+    mavlink.MAV_TYPE_GROUND_ROVER: mode_mapping_rover,
+    # boat
+    mavlink.MAV_TYPE_SURFACE_BOAT: mode_mapping_rover, # for the time being
+    # tracker
+    mavlink.MAV_TYPE_ANTENNA_TRACKER: mode_mapping_tracker,
+    # sub
+    mavlink.MAV_TYPE_SUBMARINE: mode_mapping_sub,
+}
 
 # map from a PX4 "main_state" to a string; see msg/commander_state.msg
 # This allows us to map sdlog STAT.MainState to a simple "mode"
@@ -2095,27 +2119,7 @@ def mode_mapping_byname(mav_type):
 
 def mode_mapping_bynumber(mav_type):
     '''return dictionary mapping mode numbers to name, or None if unknown'''
-    map = None
-    if mav_type in [mavlink.MAV_TYPE_QUADROTOR,
-                    mavlink.MAV_TYPE_HELICOPTER,
-                    mavlink.MAV_TYPE_HEXAROTOR,
-                    mavlink.MAV_TYPE_DECAROTOR,
-                    mavlink.MAV_TYPE_OCTOROTOR,
-                    mavlink.MAV_TYPE_DODECAROTOR,
-                    mavlink.MAV_TYPE_COAXIAL,
-                    mavlink.MAV_TYPE_TRICOPTER]:
-        map = mode_mapping_acm
-    if mav_type == mavlink.MAV_TYPE_FIXED_WING:
-        map = mode_mapping_apm
-    if mav_type == mavlink.MAV_TYPE_GROUND_ROVER:
-        map = mode_mapping_rover
-    if mav_type == mavlink.MAV_TYPE_SURFACE_BOAT:
-        map = mode_mapping_rover # for the time being
-    if mav_type == mavlink.MAV_TYPE_ANTENNA_TRACKER:
-        map = mode_mapping_tracker
-    if mav_type == mavlink.MAV_TYPE_SUBMARINE:
-        map = mode_mapping_sub
-    return map
+    return AP_MAV_TYPE_MODE_MAP[mav_type] if mav_type in AP_MAV_TYPE_MODE_MAP else None
 
 
 def mode_string_v10(msg):

--- a/mavutil.py
+++ b/mavutil.py
@@ -2019,8 +2019,12 @@ try:
     try:
         with open(_custom_mode_map_path) as f:
             _json_mode_map = json.load(f)
-    except:
+    except json.decoder.JSONDecodeError as ex:
+        # inform the user of a malformed custom_mode_map.json
         print("Error: pymavlink custom mode file ('" + _custom_mode_map_path + "') is not valid JSON.")
+        raise
+    except Exception:
+        # file is not present, fall back to using default map
         raise
 
     try:
@@ -2028,13 +2032,15 @@ try:
         for mav_type, mode_map in _json_mode_map.items():
             # make sure the custom map has the right datatypes
             _custom_mode_map[int(mav_type)] = { int(mode_num): str(mode_name) for mode_num, mode_name in mode_map.items() }
-    except:
+    except Exception:
+        # inform the user of invalid custom mode map
         print("Error: invalid pymavlink custom mode map dict in " + _custom_mode_map_path)
         raise
 
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT.copy()
     AP_MAV_TYPE_MODE_MAP.update(_custom_mode_map)
-except:
+except Exception:
+    # revert to using default mode map
     AP_MAV_TYPE_MODE_MAP = AP_MAV_TYPE_MODE_MAP_DEFAULT
 
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -2014,7 +2014,8 @@ try:
     # AP_MAV_TYPE_MODE_MAP_DEFAULT dict.
     from os.path import expanduser
 
-    _custom_mode_map_path = expanduser('~/.pymavlink/custom_mode_map.json')
+    _custom_mode_map_path = os.path.join("~", ".pymavlink", "custom_mode_map.json")
+    _custom_mode_map_path = expanduser(_custom_mode_map_path)
     with open(_custom_mode_map_path) as f:
         _json_mode_map = json.load(f)
 


### PR DESCRIPTION
We're doing some experimentation on vehicle types and vehicle modes. However, the hard-coded map of vehicle type to mode name makes this difficult, as it prevents us from easily using MAVProxy for testing.

This PR allows the user to create a `ap_custom_mode_map.py` file that contains a custom mode mapping and have it loaded when `pymavlink` is initialised.