### PR TITLE
add units required to align EFI_Status mavlink message with UAVCAN v0

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -149,6 +149,9 @@
     <xs:enumeration value="dpix"/>     <!-- decipixels -->
     <!-- flow -->
     <xs:enumeration value="g/min"/>    <!-- grams/minute -->
+    <xs:enumeration value="cm^3/min"/>    <!-- cubic centimetres/minute -->
+    <!-- volume -->
+    <xs:enumeration value="cm^3"/>    <!-- cubic centimetres -->
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
UAVCAN and ArduPilot AP_EFI use cubic centimetres per minute.  The mavlink message is defined as grams/minute, however is packed by AP_EFI as cm^3/min.  This adds necessary units to the schema so I can fix the mavlink message.
Ref: 
https://github.com/ArduPilot/ardupilot/blob/8561f5239d4bc10424e4bfe69ad69dfbdd7c5cc9/libraries/AP_EFI/AP_EFI.cpp#L128
https://github.com/UAVCAN/public_regulated_data_types/blob/c043498eacfe90a56e3246d4c2e4ae81aad13082/uavcan/equipment/ice/reciprocating/1120.Status.uavcan#L165
https://github.com/ArduPilot/mavlink/blob/ed340a4646dfdd873db1430db0b30a0c2ac9b6e3/message_definitions/v1.0/common.xml#L4932
Thanks to Maarrk in the ardupilot discord for identifying this.