### PR TITLE
Fix CRC algorithm documentation

### DIFF
--- a/generator/C/include_v0.9/checksum.h
+++ b/generator/C/include_v0.9/checksum.h
@@ -22,7 +22,7 @@ extern "C" {
 #define X25_VALIDATE_CRC 0xf0b8
 
 /**
- * @brief Accumulate the X.25 CRC by adding one char at a time.
+ * @brief Accumulate CRC16_MCRF4XX by adding one char at a time.
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).
@@ -41,9 +41,9 @@ static inline void crc_accumulate(uint8_t data, uint16_t *crcAccum)
 }
 
 /**
- * @brief Initiliaze the buffer for the X.25 CRC
+ * @brief Initiliaze the buffer for the MCRF4XX CRC16
  *
- * @param crcAccum the 16 bit X.25 CRC
+ * @param crcAccum the 16 bit MCRF4XX CRC16
  */
 static inline void crc_init(uint16_t* crcAccum)
 {
@@ -52,7 +52,7 @@ static inline void crc_init(uint16_t* crcAccum)
 
 
 /**
- * @brief Calculates the X.25 checksum on a byte buffer
+ * @brief Calculates the MCRF4XX CRC16 checksum on a byte buffer
  *
  * @param  pBuffer buffer containing the byte array to hash
  * @param  length  length of the byte array
@@ -69,7 +69,7 @@ static inline uint16_t crc_calculate(const uint8_t* pBuffer, uint16_t length)
 }
 
 /**
- * @brief Accumulate the X.25 CRC by adding an array of bytes
+ * @brief Accumulate the MCRF4XX CRC16 by adding an array of bytes
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).

--- a/generator/C/include_v1.0/checksum.h
+++ b/generator/C/include_v1.0/checksum.h
@@ -23,7 +23,7 @@ extern "C" {
 
 #ifndef HAVE_CRC_ACCUMULATE
 /**
- * @brief Accumulate the X.25 CRC by adding one char at a time.
+ * @brief Accumulate the MCRF4XX CRC16 by adding one char at a time.
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).
@@ -44,9 +44,9 @@ static inline void crc_accumulate(uint8_t data, uint16_t *crcAccum)
 
 
 /**
- * @brief Initiliaze the buffer for the X.25 CRC
+ * @brief Initiliaze the buffer for the MCRF4XX CRC16
  *
- * @param crcAccum the 16 bit X.25 CRC
+ * @param crcAccum the 16 bit MCRF4XX CRC16
  */
 static inline void crc_init(uint16_t* crcAccum)
 {
@@ -55,7 +55,7 @@ static inline void crc_init(uint16_t* crcAccum)
 
 
 /**
- * @brief Calculates the X.25 checksum on a byte buffer
+ * @brief Calculates the MCRF4XX CRC16 checksum on a byte buffer
  *
  * @param  pBuffer buffer containing the byte array to hash
  * @param  length  length of the byte array
@@ -73,7 +73,7 @@ static inline uint16_t crc_calculate(const uint8_t* pBuffer, uint16_t length)
 
 
 /**
- * @brief Accumulate the X.25 CRC by adding an array of bytes
+ * @brief Accumulate the MCRF4XX CRC16 CRC by adding an array of bytes
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).

--- a/generator/C/include_v2.0/checksum.h
+++ b/generator/C/include_v2.0/checksum.h
@@ -24,7 +24,7 @@ extern "C" {
 
 #ifndef HAVE_CRC_ACCUMULATE
 /**
- * @brief Accumulate the X.25 CRC by adding one char at a time.
+ * @brief Accumulate the CRC16_MCRF4XX checksum by adding one char at a time.
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).
@@ -45,9 +45,9 @@ static inline void crc_accumulate(uint8_t data, uint16_t *crcAccum)
 
 
 /**
- * @brief Initiliaze the buffer for the X.25 CRC
+ * @brief Initiliaze the buffer for the MCRF4XX CRC16
  *
- * @param crcAccum the 16 bit X.25 CRC
+ * @param crcAccum the 16 bit MCRF4XX CRC16
  */
 static inline void crc_init(uint16_t* crcAccum)
 {
@@ -56,7 +56,7 @@ static inline void crc_init(uint16_t* crcAccum)
 
 
 /**
- * @brief Calculates the X.25 checksum on a byte buffer
+ * @brief Calculates the CRC16_MCRF4XX checksum on a byte buffer
  *
  * @param  pBuffer buffer containing the byte array to hash
  * @param  length  length of the byte array
@@ -74,7 +74,7 @@ static inline uint16_t crc_calculate(const uint8_t* pBuffer, uint16_t length)
 
 
 /**
- * @brief Accumulate the X.25 CRC by adding an array of bytes
+ * @brief Accumulate the MCRF4XX CRC16 by adding an array of bytes
  *
  * The checksum function adds the hash of one char at a time to the
  * 16 bit checksum (uint16_t).

--- a/generator/CS/common/Mavlink.cs
+++ b/generator/CS/common/Mavlink.cs
@@ -423,7 +423,7 @@ namespace MavLink
 
 
         // For a "message" of length bytes contained in the byte array
-        // pointed to by buffer, calculate the CRC
+        // pointed to by buffer, calculate the CRC16_MCRF4XX
         public static UInt16 Calculate(byte[] buffer, UInt16 start, UInt16 length)
         {
             UInt16 crcTmp = X25_INIT_CRC;

--- a/generator/javascript/test/mavlink10.js
+++ b/generator/javascript/test/mavlink10.js
@@ -278,7 +278,7 @@ describe("Generated MAVLink 1.0 protocol handler object", function() {
 });
 
 
-describe("MAVLink X25CRC Decoder", function() {
+describe("MAVLink CRC-16/MCRF4XX Decoder", function() {
 
     beforeEach(function() {
         var {mavlink10, MAVLink10Processor} = require('../implementations/mavlink_common_v1.0/mavlink.js');
@@ -289,7 +289,7 @@ describe("MAVLink X25CRC Decoder", function() {
 
     // This test matches the output directly taken by inspecting what the Python implementation
     // generated for the above packet.
-    it('implements x25crc function', function() {
+    it('implements CRC-16/MCRF4XX function', function() {
             mavlink10.x25Crc(this.heartbeatMessage).should.equal(27276);
     });
 

--- a/generator/javascript/test/mavlink20.js
+++ b/generator/javascript/test/mavlink20.js
@@ -292,7 +292,7 @@ describe("Generated MAVLink 2.0 protocol handler object", function() {
 });
 
 
-describe("MAVLink 2.0 X25CRC Decoder", function() {
+describe("MAVLink 2.0 CRC-16/MCRF4XX Decoder", function() {
 
     beforeEach(function() {
         var {mavlink20, MAVLink20Processor} = require('../implementations/mavlink_ardupilotmega_v2.0/mavlink.js');
@@ -303,7 +303,7 @@ describe("MAVLink 2.0 X25CRC Decoder", function() {
 
     // This test matches the output directly taken by inspecting what the Python implementation
     // generated for the above packet.
-    it('implements x25crc function', function() {
+    it('implements CRC-16/MCRF4XX function', function() {
             mavlink20.x25Crc(this.heartbeatMessage).should.equal(27276);
     });
 

--- a/generator/javascript_stable/test/mavlink10.js
+++ b/generator/javascript_stable/test/mavlink10.js
@@ -278,7 +278,7 @@ describe("Generated MAVLink 1.0 protocol handler object", function() {
 });
 
 
-describe("MAVLink X25CRC Decoder", function() {
+describe("MAVLink CRC-16/MCRF4XX Decoder", function() {
 
     beforeEach(function() {
         // Message header + payload, lacks initial MAVLink flag (FE) and CRC.
@@ -288,7 +288,7 @@ describe("MAVLink X25CRC Decoder", function() {
 
     // This test matches the output directly taken by inspecting what the Python implementation
     // generated for the above packet.
-    it('implements x25crc function', function() {
+    it('implements CRC-16/MCRF4XX function', function() {
             mavlink10.x25Crc(this.heartbeatMessage).should.equal(27276);
     });
 

--- a/generator/javascript_stable/test/mavlink20.js
+++ b/generator/javascript_stable/test/mavlink20.js
@@ -278,7 +278,7 @@ describe("Generated MAVLink 2.0 protocol handler object", function() {
 });
 
 
-describe("MAVLink 2.0 X25CRC Decoder", function() {
+describe("MAVLink 2.0 CRC-16/MCRF4XX Decoder", function() {
 
     beforeEach(function() {
         // Message header + payload, lacks initial MAVLink flag (FE) and CRC.
@@ -288,7 +288,7 @@ describe("MAVLink 2.0 X25CRC Decoder", function() {
 
     // This test matches the output directly taken by inspecting what the Python implementation
     // generated for the above packet.
-    it('implements x25crc function', function() {
+    it('implements CRC-16/MCRF4XX function', function() {
             mavlink20.x25Crc(this.heartbeatMessage).should.equal(27276);
     });
 

--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -1,5 +1,5 @@
 '''
-MAVLink X25 CRC code
+MAVLink CRC-16/MCRF4XX code
 
 Copyright Andrew Tridgell
 Released under GNU LGPL version 3 or later
@@ -8,7 +8,7 @@ from builtins import object
 
 
 class x25crc(object):
-    '''x25 CRC - based on checksum.h from mavlink library'''
+    '''CRC-16/MCRF4XX - based on checksum.h from mavlink library'''
     def __init__(self, buf=None):
         self.crc = 0xffff
         if buf is not None:

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -61,9 +61,9 @@ def generate_CRC(directory, xml):
 package com.MAVLink.${basename};
 
 /**
-* X.25 CRC calculation for MAVlink messages. The checksum must be initialized,
-* updated with witch field of the message, and then finished with the message
-* id.
+* CRC-16/MCRF4XX calculation for MAVlink messages. The checksum must be
+* initialized, updated with witch field of the message, and then finished with
+* the message id.
 *
 */
 public class CRC {
@@ -72,7 +72,7 @@ public class CRC {
     private int crcValue;
 
     /**
-    * Accumulate the X.25 CRC by adding one char at a time.
+    * Accumulate the CRC16 by adding one char at a time.
     *
     * The checksum function adds the hash of one char at a time to the 16 bit
     * checksum (uint16_t).
@@ -99,7 +99,7 @@ public class CRC {
     }
 
     /**
-    * Initialize the buffer for the X.25 CRC
+    * Initialize the buffer for the CRC16/MCRF4XX
     *
     */
     public void start_checksum() {
@@ -259,9 +259,9 @@ ${importString}
 * 4            Component ID        0 - 255     ID of the SENDING component. Allows to differentiate different components of the same system, e.g. the IMU and the autopilot.
 * 5            Message ID          0 - 255     ID of the message - the id defines what the payload means and how it should be correctly decoded.
 * 6 to (n+6)   Payload             0 - 255     Data of the message, depends on the message id.
-* (n+7)to(n+8) Checksum (low byte, high byte)  ITU X.25/SAE AS-4 hash, excluding packet start sign, so bytes 1..(n+6) Note: The checksum also includes MAVLINK_CRC_EXTRA (Number computed from message fields. Protects the packet from decoding a different version of the same packet but with different variables).
+* (n+7)to(n+8) Checksum (low byte, high byte)  CRC16/MCRF4XX hash, excluding packet start sign, so bytes 1..(n+6) Note: The checksum also includes MAVLINK_CRC_EXTRA (Number computed from message fields. Protects the packet from decoding a different version of the same packet but with different variables).
 
-* The checksum is the same as used in ITU X.25 and SAE AS-4 standards (CRC-16-CCITT), documented in SAE AS5669A. Please see the MAVLink source code for a documented C-implementation of it. LINK TO CHECKSUM
+* The checksum is the CRC16/MCRF4XX. Please see the MAVLink source code for a documented C-implementation of it. LINK TO CHECKSUM
 * The minimum packet length is 8 bytes for acknowledgement packets without payload
 * The maximum packet length is 263 bytes for full payload
 *
@@ -305,7 +305,7 @@ public class MAVLinkPacket implements Serializable {
     public MAVLinkPayload payload;
 
     /**
-    * ITU X.25/SAE AS-4 hash, excluding packet start sign, so bytes 1..(n+6)
+    * CRC-16/MCRF4XX hash, excluding packet start sign, so bytes 1..(n+6)
     * Note: The checksum also includes MAVLINK_CRC_EXTRA (Number computed from
     * message fields. Protects the packet from decoding a different version of
     * the same packet but with different variables).

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -48,7 +48,7 @@ Buffer.prototype.toByteArray = function () {
 
 ${MAVHEAD} = function(){};
 
-// Implement the X25CRC function (present in the Python version through the mavutil.py package)
+// Implement the CRC-16/MCRF4XX function (present in the Python version through the mavutil.py package)
 ${MAVHEAD}.x25Crc = function(buffer, crcIN) {
 
     var bytes = buffer;

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -45,7 +45,7 @@ Buffer.prototype.toByteArray = function () {
 
 ${MAVHEAD} = function(){};
 
-// Implement the X25CRC function (present in the Python version through the mavutil.py package)
+// Implement the CRC-16/MCRF4XX function (present in the Python version through the mavutil.py package)
 ${MAVHEAD}.x25Crc = function(buffer, crcIN) {
 
     var bytes = buffer;

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -446,7 +446,7 @@ class MAVXML(object):
 
 
 def message_checksum(msg):
-    '''calculate a 8-bit checksum of the key fields of a message, so we
+    '''calculate CRC-16/MCRF4XX checksum of the key fields of a message, so we
        can detect incompatible XML changes'''
     from .mavcrc import x25crc
     crc = x25crc()

--- a/generator/swift/MAVLink.swift
+++ b/generator/swift/MAVLink.swift
@@ -854,12 +854,12 @@ public struct Checksum {
         start()
     }
     
-    /// Initialize the buffer for the X.25 CRC.
+    /// Initialize the buffer for the MCRF4XX CRC.
     mutating func start() {
         value = Constants.x25InitCRCValue
     }
     
-    /// Accumulate the X.25 CRC by adding one char at a time. The checksum
+    /// Accumulate the MCRF4XX CRC by adding one char at a time. The checksum
     /// function adds the hash of one char at a time to the 16 bit checksum
     /// `value` (`UInt16`).
     ///
@@ -870,7 +870,7 @@ public struct Checksum {
         value = (UInt16(value) >> 8) ^ (UInt16(tmp) << 8) ^ (UInt16(tmp) << 3) ^ (UInt16(tmp) >> 4)
     }
     
-    /// Accumulate the X.25 CRC by adding `buffer` bytes.
+    /// Accumulate the MCRF4XX CRC by adding `buffer` bytes.
     ///
     /// - parameter buffer: Sequence of bytes to hash
     mutating func accumulate<T: Sequence>(_ buffer: T) where T.Iterator.Element == UInt8 {

--- a/mavutil.py
+++ b/mavutil.py
@@ -2186,7 +2186,7 @@ def mode_string_acm(mode_number):
     return "Mode(%u)" % mode_number
 
 class x25crc(object):
-    '''x25 CRC - based on checksum.h from mavlink library'''
+    '''CRC-16/MCRF4XX - based on checksum.h from mavlink library'''
     def __init__(self, buf=''):
         self.crc = 0xffff
         self.accumulate(buf)


### PR DESCRIPTION
The description of the CRC does not seem to match the implementation.
The description specifies X.25, however, the code implementing the CRC check does not do the final xor out operation.
This means the result is actually the same as CRC-16/MCRF4XX.

I found this a while back trying to implement it using a table, and then stumbled on the same observation here:
https://discuss.px4.io/t/mavlink-crc-computation-standard-in-mavlink-1/5962

The difference between X.25 and MCRF4XX is just the last xor step:

X.25:
width=16 poly=0x1021 init=0xffff refin=true refout=true xorout=0xffff check=0x906e residue=0xf0b8 name="CRC-16/IBM-SDLC"

MCRF4XX:
width=16 poly=0x1021 init=0xffff refin=true refout=true xorout=0x0000 check=0x6f91 residue=0x0000 name="CRC-16/MCRF4XX"

This is based on:
https://reveng.sourceforge.io/crc-catalogue/16.htm

Here are two links to play around with it:
https://godbolt.org/z/brzPs3
https://crccalc.com/?crc=Loremipsumdolorsitametconsectetu&method=crc16&datatype=ascii&outtype=hex

This PR only changes comments but not variable names, so it should not break anything.

@tridge I would be interested to hear your take on this.