### PR TITLE
mavgen: protect for too deep inlcude trees

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -115,6 +115,9 @@ def mavgen(opts, args):
         for i in range(MAXIMUM_INCLUDE_FILE_NESTING):
             if not expand_oneiteration():
                 break
+        if i >= MAXIMUM_INCLUDE_FILE_NESTING:
+            print("\nERROR include tree is too deeply nested!")
+            exit(1)
 
         if mavparse.check_duplicates(xml):
             sys.exit(1)


### PR DESCRIPTION
protect against too deep include trees
useful for https://github.com/mavlink/mavlink/pull/1537 (the include trees tend to become deeper and deeper ...)