### PR TITLE
Fixed messages classes field packing on JavaScript_NextGen

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -330,8 +330,10 @@ def generate_classes(outf, msgs, xml):
         # inherit methods from the base message class
         outf.write("\n%s.messages.%s.prototype = new %s.message;\n" % ( get_mavhead(xml), m.name.lower() ,get_mavhead(xml) ) )
 
-        orderedfields =    "var orderedfields = [ this." + ", this.".join(m.ordered_fieldnames) + "];";
-
+        import re
+        match = re.findall('(\d+)?([AxcbBhHsfdiIlLqQ])', m.fmtstr)
+        orderedfields = "var orderedfields = [" + ', '.join(['{}'.format('...' if reg[0].isnumeric() else '') +
+         f'this.{field}' for (field, reg) in zip(m.ordered_fieldnames, match)]) + "];"
 
         # Implement the pack() function for this message
         t.write(outf, """


### PR DESCRIPTION
JavasCript_NextGen's code generated was not passing the generated tests. Every message definition's fields containing an array was not correctly forwarded to jspack.Pack, hence the return value was 'false' instead of the message  buffer.
Code generated was as next example:
```
mavlink20.messages.vision_position_delta.prototype.pack = function(mav) {
    var orderedfields = [ this.time_usec, this.time_delta_usec, this.angle_delta, this.position_delta, this.confidence];
    var j = jspack.Pack(this._format, orderedfields);
    if (j === false ) throw new Error("jspack unable to handle this packet");
    return mavlink20.message.prototype.pack.call(this, mav, this.crc_extra, j );
}
```
Producing a test output like:

```
.
.
.
/home/acosuna/Proyectos/node_mav/mavlink.js:5831
    if (j === false ) throw new Error("jspack unable to handle this packet");
                      ^

Error: jspack unable to handle this packet
    at mavlink20.messages.vision_position_delta.pack (/home/acosuna/Proyectos/node_mav/mavlink.js:5831:29)
    at test_vision_position_delta (/home/acosuna/Proyectos/node_mav/mavlink.tests.js:957:53)
    at mavlink20Tests (/home/acosuna/Proyectos/node_mav/mavlink.tests.js:5667:1)
    at Object.<anonymous> (/home/acosuna/Proyectos/node_mav/mavlink.tests.js:5919:4)
```

Resulting code now unrolls fields that are array-like and allows a correct packing by `jspac.Pack`

```
var orderedfields = [this.time_usec, this.time_delta_usec, ...this.angle_delta, ...this.position_delta, this.confidence];
```