### PR TITLE
Cross-platform include of endian.h

### DIFF
--- a/generator/CPP11/include_v2.0/msgmap.hpp
+++ b/generator/CPP11/include_v2.0/msgmap.hpp
@@ -2,7 +2,13 @@
 #pragma once
 
 #include <algorithm>
+#ifdef FREEBSD
+#include <sys/endian.h>
+#elif __APPLE__
+#include <machine/endian.h>
+#else
 #include <endian.h>
+#endif
 #include <type_traits>
 
 namespace mavlink {


### PR DESCRIPTION
This should fix compilation on osx (see https://github.com/mavlink/mavros/issues/851)