### PR TITLE
Tools: mavlogdump: do not rearrange .mat before exporting

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -347,22 +347,7 @@ while True:
 
 # Export the .mat file
 if args.format == 'mat':
-    # Rearrange the dictionary so it exports correctly
-    MAT2 = {}
-    for packet_type in MAT:
-        vars = list(MAT[packet_type].keys())
-        data = []   # 2D list
-        i = 0
-        MAT2[packet_type+'_label'] = np.zeros((len(vars), 1), dtype=object)
-        for var in vars:
-            data.append(MAT[packet_type][var])
-            MAT2[packet_type+'_label'][i] = var
-            i += 1
-        # Transpose the list of lists
-        MAT2[packet_type] = list(map(list, zip(*data)))
-
-    # Save file
-    scipy.io.savemat(args.mat_file, MAT2, do_compression=args.compress)
+    scipy.io.savemat(args.mat_file, MAT, do_compression=args.compress)
 
 if args.show_types:
     for msgType in available_types:


### PR DESCRIPTION
This is a change to directly output .mat files rather than rearranging first. 

Currently you get lots of cells and labels:
![Capture](https://user-images.githubusercontent.com/33176108/112037119-4f042300-8b39-11eb-90c0-0cf096389918.PNG)

![Capture1](https://user-images.githubusercontent.com/33176108/112037131-51ff1380-8b39-11eb-99ae-27a20d4f6424.PNG)

With this change you get friendly structures with correctly named values:
![Capture2](https://user-images.githubusercontent.com/33176108/112037196-65aa7a00-8b39-11eb-8fad-577cd5ed387b.PNG)

![Capture3](https://user-images.githubusercontent.com/33176108/112037214-69d69780-8b39-11eb-8e1f-dd40700cb335.PNG)

This results in a format that is different to what you get with MP, but it is also much nicer. 

I guess we might want to make it optional if anyone is particularly attached to the old format.