### PR TITLE
mavgen_python: DRY, move to_string to module scope

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -78,6 +78,32 @@ MAVLINK_TYPE_FLOAT    = 9
 MAVLINK_TYPE_DOUBLE   = 10
 
 
+# swiped from DFReader.py
+def to_string(s):
+    '''desperate attempt to convert a string regardless of what garbage we get'''
+    try:
+        return s.decode("utf-8")
+    except Exception as e:
+        pass
+    try:
+        s2 = s.encode('utf-8', 'ignore')
+        x = u"%s" % s2
+        return s2
+    except Exception:
+        pass
+    # so its a nasty one. Let's grab as many characters as we can
+    r = ''
+    try:
+        for c in s:
+            r2 = r + c
+            r2 = r2.encode('ascii', 'ignore')
+            x = u"%s" % r2
+            r = r2
+    except Exception:
+        pass
+    return r + '_XXX'
+
+
 class MAVLink_header(object):
     '''MAVLink message header'''
     def __init__(self, msgId, incompat_flags=0, compat_flags=0, mlen=0, seq=0, srcSystem=0, srcComponent=0):
@@ -112,37 +138,11 @@ class MAVLink_message(object):
         self._instances  = None
         self._instance_field = None
 
-    # swiped from DFReader.py
-    def to_string(self, s):
-        '''desperate attempt to convert a string regardless of what garbage we get'''
-        try:
-            return s.decode("utf-8")
-        except Exception as e:
-            pass
-        try:
-            s2 = s.encode('utf-8', 'ignore')
-            x = u"%s" % s2
-            return s2
-        except Exception:
-            pass
-        # so its a nasty one. Let's grab as many characters as we can
-        r = ''
-        while s != '':
-            try:
-                r2 = r + s[0]
-                s = s[1:]
-                r2 = r2.encode('ascii', 'ignore')
-                x = u"%s" % r2
-                r = r2
-            except Exception:
-                break
-        return r + '_XXX'
-
     def format_attr(self, field):
         '''override field getter'''
         raw_attr = getattr(self,field)
         if isinstance(raw_attr, bytes):
-            raw_attr = self.to_string(raw_attr).rstrip("\\00")
+            raw_attr = to_string(raw_attr).rstrip("\\00")
         return raw_attr
 
     def get_msgbuf(self):
@@ -750,32 +750,6 @@ class MAVLink(object):
             self.signing.timestamp = max(self.signing.timestamp, timestamp)
             return True
 
-        # swiped from DFReader.py
-        def to_string(self, s):
-            '''desperate attempt to convert a string regardless of what garbage we get'''
-            try:
-                return s.decode("utf-8")
-            except Exception as e:
-                pass
-            try:
-                s2 = s.encode('utf-8', 'ignore')
-                x = u"%s" % s2
-                return s2
-            except Exception:
-                pass
-            # so its a nasty one. Let's grab as many characters as we can
-            r = ''
-            while s != '':
-                try:
-                    r2 = r + s[0]
-                    s = s[1:]
-                    r2 = r2.encode('ascii', 'ignore')
-                    x = u"%s" % r2
-                    r = r2
-                except Exception:
-                    break
-            return r + '_XXX'
-
         def decode(self, msgbuf):
                 '''decode a buffer as a MAVLink message'''
                 # decode the header
@@ -895,7 +869,7 @@ class MAVLink(object):
                 for i in range(0, len(tlist)):
                     if type.fieldtypes[i] == 'char':
                         if sys.version_info.major >= 3:
-                            tlist[i] = self.to_string(tlist[i])
+                            tlist[i] = to_string(tlist[i])
                         tlist[i] = str(MAVString(tlist[i]))
                 t = tuple(tlist)
                 # construct the message object


### PR DESCRIPTION
The helper function `to_string` appeared in two generated classes, and it doesn't even operate on the object. So I moved it to module scope. While at it, I changed the final loop cutting one character at a time to instead iterate over the sequence; shouldn't change the outcome.
