### PR TITLE
Correct magfit_WMM.py to account for AHRS_TRIM

### DIFF
--- a/tools/magfit_WMM.py
+++ b/tools/magfit_WMM.py
@@ -295,6 +295,10 @@ def magfit(logfile):
             print("Earth field: %s  strength %.0f declination %.1f degrees" % (earth_field, earth_field.length(), declination))
         if msg.get_type() == ATT_NAME:
             ATT = msg
+            # remove IMU sensor to body frame trim offsets to get back to the IMU sensor frame used by the EKFs
+            ATT.Roll  = ATT.Roll  + math.degrees(parameters['AHRS_TRIM_X'])
+            ATT.Pitch = ATT.Pitch + math.degrees(parameters['AHRS_TRIM_Y'])
+            ATT.Yaw   = ATT.Yaw   + math.degrees(parameters['AHRS_TRIM_Z'])
         if msg.get_type() == 'BAT':
             BAT = msg
         if msg.get_type() == mag_msg and ATT is not None:


### PR DESCRIPTION
The fitting should be done in the autopilot sensor frame of reference, not the body frame. Otherwise when operating close to +-90 pitch the pitch angle in the message will exceed +-90 deg which results in the sign of the predicted Z filed being flipped. Below are comparison fit results  from a tailsitter log with 

AHRS_TRIM_X      0.008438
AHRS_TRIM_Y      -0.042119
AHRS_TRIM_Z      0.000000

Before:

Current function value: 41.3713362683
Iterations: 50
Function evaluations: 456
Gradient evaluations: 50

![image](https://user-images.githubusercontent.com/3596952/116332400-05cc8080-a815-11eb-97ad-b6cc72e9fd88.png)

After:

Current function value: 6.82827669857
Iterations: 53
Function evaluations: 488
Gradient evaluations: 53

![image](https://user-images.githubusercontent.com/3596952/116332089-6909e300-a814-11eb-8aac-a9b92d70784c.png)
