### PR TITLE
Replace iterative IDX with hash of dialect name to remove build order dependencies

### DIFF
--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -49,7 +49,7 @@ def generate_mavlink_h(directory, xml):
 #ifndef MAVLINK_H
 #define MAVLINK_H
 
-#define MAVLINK_PRIMARY_XML_IDX ${xml_idx}
+#define MAVLINK_PRIMARY_XML_HASH ${xml_hash}
 
 #ifndef MAVLINK_STX
 #define MAVLINK_STX ${protocol_marker}
@@ -94,8 +94,8 @@ def generate_main_h(directory, xml):
     #error Wrong include order: MAVLINK_${basename_upper}.H MUST NOT BE DIRECTLY USED. Include mavlink.h from the same directory instead or set ALL AND EVERY defines from MAVLINK.H manually accordingly, including the #define MAVLINK_H call.
 #endif
 
-#undef MAVLINK_THIS_XML_IDX
-#define MAVLINK_THIS_XML_IDX ${xml_idx}
+#undef MAVLINK_THIS_XML_HASH
+#define MAVLINK_THIS_XML_HASH ${xml_hash}
 
 #ifdef __cplusplus
 extern "C" {
@@ -148,10 +148,10 @@ ${{message:#include "./mavlink_msg_${name_lower}.h"
 ${{include_list:#include "../${base}/${base}.h"
 }}
 
-#undef MAVLINK_THIS_XML_IDX
-#define MAVLINK_THIS_XML_IDX ${xml_idx}
+#undef MAVLINK_THIS_XML_HASH
+#define MAVLINK_THIS_XML_HASH ${xml_hash}
 
-#if MAVLINK_THIS_XML_IDX == MAVLINK_PRIMARY_XML_IDX
+#if MAVLINK_THIS_XML_HASH == MAVLINK_PRIMARY_XML_HASH
 # define MAVLINK_MESSAGE_INFO {${message_info_array}}
 # define MAVLINK_MESSAGE_NAMES {${message_name_array}}
 # if MAVLINK_COMMAND_24BIT
@@ -716,6 +716,6 @@ def generate(basename, xml_list):
 
     for idx in range(len(xml_list)):
         xml = xml_list[idx]
-        xml.xml_idx = idx
+        xml.xml_hash = hash(xml.basename)        
         generate_one(basename, xml)
     copy_fixed_headers(basename, xml_list[0])


### PR DESCRIPTION
The C generator assigns to each nested dialect an increasing `MAVLINK_THIS_XML_IDX`. In the mavlink.h at each level it defines the same value of `MAVLINK_PRIMARY_XML_IDX` and uses the comparison to decide if it should define the arrays `MAVLINK_MESSAGE_INFO` and `MAVLINK_MESSAGE_NAMES`. 

So whichever dialect you import (e.g. common.xml) the `MAVLINK_THIS_XML_IDX==MAVLINK_PRIMARY_XML_IDX` and you pull in the info and names for the current dialect. However they don't get pulled in again, because the values ONLY match for the mavlink.h you pulled in first.

However this is fragile in that if you generate (say) ardupilotmega.xml and common.xml the libraries will be different, and depending on the order you can end up with two libraries with the same IDX value.  Consider building ardupilot first and you get these IDX values at each level.
ap primary 0
common 1
min 2

If you then build common at the same location you end up with:
ap primary 0
common 0
min 1

So if you import ap, when common is loaded it will try to reimport the definitions.

What this PR does is replace this complicated approach with an `#ifndef MAVLINK_MESSAGE_INFO`. That way the info is defined when only once, in the top level file you call first. 

