### PR TITLE
Don't hardcode sysid and compid when packing

### DIFF
--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -175,8 +175,8 @@ public class msg_${name_lower} extends MAVLinkMessage {
     @Override
     public MAVLinkPacket pack() {
         MAVLinkPacket packet = new MAVLinkPacket(MAVLINK_MSG_LENGTH,isMavlink2);
-        packet.sysid = 255;
-        packet.compid = 190;
+        packet.sysid = sysid;
+        packet.compid = compid;
         packet.msgid = MAVLINK_MSG_ID_${name};
         
         ${{base_fields:${packField}


### PR DESCRIPTION
Maybe I am missing something, but that surprised me. Typically this means that doing `message.unpack(); message.pack()` changes the sysid/compid, and I don't really see a reason for it :thinking: 