### PR TITLE
Close the mmap object

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1429,7 +1429,11 @@ class mavmmaplog(mavlogfile):
     def rewind(self):
         '''rewind to start of log'''
         self._rewind()
-        
+
+    def close(self):
+        super(mavmmaplog, self).close()
+        self.data_map.close()
+
     def init_arrays(self, progress_callback=None):
         '''initialise arrays for fast recv_match()'''
 


### PR DESCRIPTION
The inherited close() method from the mavlogfile class only closes the file object. However, the mmap object also keeps a handle on the file, which prevents it from being deleted or opened in read mode even after we call close() This commit closes both the file object (by calling the super method) and the mmap object (directly), ensuring that all handles are freed.