### PR TITLE
Update mavlink_signature_check code to be compiler agnostic

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -133,7 +133,8 @@ MAVLINK_HELPER bool mavlink_signature_check(mavlink_signing_t *signing,
         
 	mavlink_sha256_init(&ctx);
 	mavlink_sha256_update(&ctx, signing->secret_key, sizeof(signing->secret_key));
-	mavlink_sha256_update(&ctx, p, MAVLINK_CORE_HEADER_LEN+1+msg->len);
+	mavlink_sha256_update(&ctx, p, MAVLINK_NUM_HEADER_BYTES);
+	mavlink_sha256_update(&ctx, _MAV_PAYLOAD(msg), msg->len);
 	mavlink_sha256_update(&ctx, msg->ck, 2);
 	mavlink_sha256_update(&ctx, psig, 1+6);
 	mavlink_sha256_final_48(&ctx, signature);


### PR DESCRIPTION
The bitfield packing in mavlink_message_t behaves differently on gcc and windows compilers such as VS2019. This difference caused the mavlink_signature_check function unable to verify signature when built with VS2019. Update the mavlink_signature_check code to not depend on the bitfield packing behavior.