### PR TITLE
Drop support for end of life versions of Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@v2

--- a/CSVReader.py
+++ b/CSVReader.py
@@ -20,9 +20,6 @@ MAV> graph CSV.GYRO_X
 in this case the GPS time was in seconds-since-week-start, so a conversion to ms is required
 
 '''
-from __future__ import print_function
-from builtins import range
-from builtins import object
 
 import csv
 import struct
@@ -31,7 +28,7 @@ from . import mavutil
 from . import mavextra
 from . import mavexpression
 
-class CSVMessage(object):
+class CSVMessage:
     def __init__(self, message_type, fmt, line):
         self.fmt = fmt
         self.message_type = message_type
@@ -49,7 +46,7 @@ class CSVMessage(object):
     def __str__(self):
         ret = "%s {" % self.message_type
         for (c, val) in zip(self.fmt.headings, self.line):
-            ret += "%s : %s, " % (c, str(val))
+            ret += f"{c} : {str(val)}, "
         return ret + '}'
 
     # methods for MAVExplorer:
@@ -65,7 +62,7 @@ class CSVMessage(object):
             return int(self.line[0])
         return self.line[self.fmt.field_offset[field]]
 
-class CSVFormat(object):
+class CSVFormat:
     def __init__(self, headings, messages, timestamp_expression=None):
         self.headings = headings
         self.messages = messages
@@ -78,7 +75,7 @@ class CSVFormat(object):
             self.field_offset[heading] = count
             count += 1
 
-class CSVReader(object):
+class CSVReader:
     '''parse a CSV file'''
     def __init__(self,
                  filename,
@@ -150,7 +147,7 @@ class CSVReader(object):
         if self.f is not None:
             self.f.close()
 
-        self.f = open(self.filename, mode='r')
+        self.f = open(self.filename)
 
         self.reader = csv.reader(self.f, delimiter=self.separator)
 

--- a/DFReader.py
+++ b/DFReader.py
@@ -7,9 +7,6 @@ Released under GNU GPL version 3 or later
 
 Partly based on SDLog2Parser by Anton Babushkin
 '''
-from __future__ import print_function
-from builtins import range
-from builtins import object
 
 import array
 import math
@@ -53,7 +50,7 @@ FORMAT_TO_STRUCT = {
 def u_ord(c):
 	return ord(c) if sys.version_info.major < 3 else c
 
-class DFFormat(object):
+class DFFormat:
     def __init__(self, type, name, flen, format, columns, oldfmt=None):
         self.type = type
         self.name = null_term(name)
@@ -131,7 +128,7 @@ def to_string(s):
         pass
     try:
         s2 = s.encode('utf-8', 'ignore')
-        x = u"%s" % s2
+        x = "%s" % s2
         return s2
     except Exception:
         pass
@@ -142,7 +139,7 @@ def to_string(s):
             r2 = r + s[0]
             s = s[1:]
             r2 = r2.encode('ascii', 'ignore')
-            x = u"%s" % r2
+            x = "%s" % r2
             r = r2
         except Exception:
             break
@@ -158,7 +155,7 @@ def null_term(str):
     return str
 
 
-class DFMessage(object):
+class DFMessage:
     def __init__(self, fmt, elements, apply_multiplier, parent):
         self.fmt = fmt
         self._elements = elements
@@ -197,7 +194,7 @@ class DFMessage(object):
     def __setattr__(self, field, value):
         '''override field setter'''
         if not field[0].isupper() or not field in self.fmt.colhash:
-            super(DFMessage,self).__setattr__(field, value)
+            super().__setattr__(field, value)
         else:
             i = self.fmt.colhash[field]
             if self.fmt.msg_mults[i] is not None and self._apply_multiplier:
@@ -221,7 +218,7 @@ class DFMessage(object):
                     noisy_nan = "\x7f\xf8\x00\x00\x00\x00\x00\x00"
                 if struct.pack(">d", val) != noisy_nan:
                     val = "qnan"
-            ret += "%s : %s, " % (c, val)
+            ret += f"{c} : {val}, "
             col_count += 1
         if col_count != 0:
             ret = ret[:-2]
@@ -266,13 +263,13 @@ class DFMessage(object):
         '''support indexing, allowing for multi-instance sensors in one message'''
         if self.fmt.instance_field is None:
             raise IndexError()
-        k = '%s[%s]' % (self.fmt.name, str(key))
+        k = f'{self.fmt.name}[{str(key)}]'
         if not k in self._parent.messages:
             raise IndexError()
         return self._parent.messages[k]
 
 
-class DFReaderClock(object):
+class DFReaderClock:
     '''base class for all the different ways we count time in logs'''
 
     def __init__(self):
@@ -454,7 +451,7 @@ class DFReaderClock_gps_interpolated(DFReaderClock):
         m._timestamp = self.timebase + count/rate
 
 
-class DFReader(object):
+class DFReader:
     '''parse a generic dataflash file'''
     def __init__(self):
         # read the whole file into memory for simplicity
@@ -604,7 +601,7 @@ class DFReader(object):
         self.messages[type] = m
         if m.fmt.instance_field is not None:
             i = m.__getattr__(m.fmt.instance_field)
-            self.messages["%s[%s]" % (type, str(i))] = m
+            self.messages[f"{type}[{str(i)}]"] = m
 
         if self.clock:
             self.clock.message_arrived(m)
@@ -642,7 +639,7 @@ class DFReader(object):
         type can be a string or a list of strings'''
         if type is not None:
             if isinstance(type, str):
-                type = set([type])
+                type = {type}
             elif isinstance(type, list):
                 type = set(type)
         while True:
@@ -675,7 +672,7 @@ class DFReader(object):
         if self._flightmodes is None:
             self._rewind()
             self._flightmodes = []
-            types = set(['MODE'])
+            types = {'MODE'}
             while True:
                 m = self.recv_match(type=types)
                 if m is None:
@@ -700,7 +697,7 @@ class DFReader_binary(DFReader):
     def __init__(self, filename, zero_time_base=False, progress_callback=None):
         DFReader.__init__(self)
         # read the whole file into memory for simplicity
-        self.filehandle = open(filename, 'r')
+        self.filehandle = open(filename)
         self.filehandle.seek(0, 2)
         self.data_len = self.filehandle.tell()
         self.filehandle.seek(0)
@@ -860,7 +857,7 @@ class DFReader_binary(DFReader):
         if self.type_nums is None:
             # always add some key msg types so we can track flightmode, params etc
             type = type.copy()
-            type.update(set(['MODE','MSG','PARM','STAT']))
+            type.update({'MODE','MSG','PARM','STAT'})
             self.indexes = []
             self.type_nums = []
             for t in type:
@@ -999,7 +996,7 @@ class DFReader_binary(DFReader):
 
 def DFReader_is_text_log(filename):
     '''return True if a file appears to be a valid text log'''
-    with open(filename, 'r') as f:
+    with open(filename) as f:
         ret = (f.read(8000).find('FMT,') != -1)
 
     return ret
@@ -1010,7 +1007,7 @@ class DFReader_text(DFReader):
     def __init__(self, filename, zero_time_base=False, progress_callback=None):
         DFReader.__init__(self)
         # read the whole file into memory for simplicity
-        self.filehandle = open(filename, 'r')
+        self.filehandle = open(filename)
         self.filehandle.seek(0, 2)
         self.data_len = self.filehandle.tell()
         self.filehandle.seek(0, 0)
@@ -1098,7 +1095,7 @@ class DFReader_text(DFReader):
         if self.type_list is None:
             # always add some key msg types so we can track flightmode, params etc
             self.type_list = type.copy()
-            self.type_list.update(set(['MODE','MSG','PARM','STAT']))
+            self.type_list.update({'MODE','MSG','PARM','STAT'})
             self.type_list = list(self.type_list)
             self.indexes = []
             self.type_nums = []

--- a/README.md
+++ b/README.md
@@ -15,21 +15,21 @@ Examples can be found [in the repository](examples/) or in the [ArduSub book](ht
 
 # Installation 
 
-Pymavlink supports both Python 2 and Python 3.
+Pymavlink supports Python 3.6 and later.
 
 The following instructions assume you are using Python 3 and a Debian-based (like Ubuntu) installation.
 
 .. note::
 
-   pymavlink assumes the command "python" is in your path.  Your distribution may provide a package such as "python-is-python3" to ensure that "python" is in your path.
+   pymavlink assumes the command "python3" is in your path.
 
 ## Dependencies
 
 Pymavlink has several dependencies :
 
-    - [future](http://python-future.org/) : for Python 2 and Python 3 interoperability
+    - [future](http://python-future.org/) : for legacy Python 2 interoperability
     - [lxml](http://lxml.de/installation.html) : for checking and parsing xml file 
-    - python3-dev : for mavnative (or python-dev for Python 2)
+    - python3-dev : for mavnative
     - a C compiler : for mavnative
 
 Optional :
@@ -39,10 +39,6 @@ Optional :
 ### On Linux
 
 lxml has some additional dependencies that can be installed with your package manager (here with `apt-get`) :
-
-.. note::
-
-   If you continue to use Python 2 you may need to change package names here (e.g. python3-dev => python-dev)
 
 ```bash
 sudo apt-get install gcc python3-dev libxml2-dev libxslt-dev
@@ -57,7 +53,7 @@ sudo apt-get install python3-numpy python3-pytest
 Using pip you can install the required dependencies for pymavlink :
 
 ```bash
-sudo python -m pip install --upgrade future lxml
+sudo python3 -m pip install --upgrade future lxml
 ```
 
 ### On Windows
@@ -70,19 +66,19 @@ Lxml can be installed with a Windows installer from here : https://pypi.org/proj
 
 ### For users
 
-It is recommended to install pymavlink from PyPI with pip, that way dependencies should be auto installed by pip.
+It is recommended to install pymavlink from PyPI with pip, that way dependencies should be auto installed by python3 -m pip.
 
 ```bash
-sudo python -m pip install --upgrade pymavlink
+sudo python3 -m pip install --upgrade pymavlink
 ```
 
 #### Mavnative
 
 By default, pymavlink will try to compile and install mavnative which is a C extension for parsing mavlink. Mavnative only supports mavlink1.
-To skip mavnative installation and reduce dependencies like `gcc` and `python-dev`, you can pass `DISABLE_MAVNATIVE=True` environment variable to the installation command:
+To skip mavnative installation and reduce dependencies like `gcc` and `python3-dev`, you can pass `DISABLE_MAVNATIVE=True` environment variable to the installation command:
 
 ```bash
-sudo DISABLE_MAVNATIVE=True python -m pip install --upgrade pymavlink
+sudo DISABLE_MAVNATIVE=True python3 -m pip install --upgrade pymavlink
 ```
 
 ### For developers
@@ -90,7 +86,7 @@ sudo DISABLE_MAVNATIVE=True python -m pip install --upgrade pymavlink
 From the pymavlink directory, you can use :
 
 ```bash
-sudo MDEF=PATH_TO_message_definitions python -m pip install . -v
+sudo MDEF=PATH_TO_message_definitions python3 -m pip install . -v
 ```
 
 Since pip installation is executed from /tmp, it is necessary to point to the directory containing message definitions with MDEF. MDEF should not be set to any particular message version directory but the parent folder instead. If you have cloned from mavlink/mavlink then this is ```/mavlink/message_definitions``` . Using pip should auto install dependencies and allow you to keep them up-to-date. 
@@ -98,7 +94,7 @@ Since pip installation is executed from /tmp, it is necessary to point to the di
 Or:
 
 ```bash
-sudo python setup.py install
+sudo python3 setup.py install
 ```
 
 ### Ardupilot Custom Modes

--- a/examples/apmsetrate.py
+++ b/examples/apmsetrate.py
@@ -3,8 +3,6 @@
 '''
 set stream rate on an APM
 '''
-from __future__ import print_function
-from builtins import range
 
 import sys
 

--- a/examples/bwtest.py
+++ b/examples/bwtest.py
@@ -3,7 +3,6 @@
 '''
 check bandwidth of link
 '''
-from __future__ import print_function
 import time
 
 from pymavlink import mavutil

--- a/examples/magtest.py
+++ b/examples/magtest.py
@@ -4,7 +4,6 @@
 rotate APMs on bench to test magnetometers
 
 '''
-from __future__ import print_function
 
 import time
 from math import radians

--- a/examples/mav2pcap.py
+++ b/examples/mav2pcap.py
@@ -14,11 +14,8 @@
 # dependency: Python construct library (python-construct on Debian/Ubuntu), "easy_install construct" elsewhere
 
 
-from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
-from builtins import open
 import sys
 import os
 
@@ -39,7 +36,7 @@ MAVLINK_MESSAGE_CRCS  = (50, 124, 137, 0, 237, 217, 104, 119, 0, 0, 0, 89, 0, 0,
 import struct
 
 # Helper class for writing pcap files
-class pcap(object):
+class pcap:
     """
        Used under the terms of GNU GPL v3.
        Original author: Neale Pickett
@@ -54,7 +51,7 @@ class pcap(object):
         try:
             # Try reading
             hdr = self.stream.read(24)
-        except IOError:
+        except OSError:
             hdr = None
 
         if hdr:
@@ -66,12 +63,12 @@ class pcap(object):
                     self._endian = endian
                     break
             if not self._endian:
-                raise IOError('Not a pcap file')
+                raise OSError('Not a pcap file')
             (self.magic, version_major, version_minor,
              self.thiszone, self.sigfigs,
              self.snaplen, self.linktype) = struct.unpack(self._endian + 'IHHIIII', hdr)
             if (version_major, version_minor) != (2, 4):
-                raise IOError('Cannot handle file version %d.%d' % (version_major,
+                raise OSError('Cannot handle file version %d.%d' % (version_major,
                                                                     version_minor))
         else:
             # We're in write mode

--- a/examples/mav_accel.py
+++ b/examples/mav_accel.py
@@ -3,7 +3,6 @@
 '''
 show accel calibration for a set of logs
 '''
-from __future__ import print_function
 
 from argparse import ArgumentParser
 parser = ArgumentParser()

--- a/examples/mav_replay_estimator.py
+++ b/examples/mav_replay_estimator.py
@@ -3,8 +3,6 @@
 '''
 estimate attitude from an ArduPilot replay log using a python state estimator
 '''
-from __future__ import print_function
-from builtins import range
 
 import os
 
@@ -21,7 +19,7 @@ from math import degrees
 
 GRAVITY_MSS = 9.80665
 
-class Estimator(object):
+class Estimator:
     '''state estimator'''
     def __init__(self):
         self.r = Matrix3()

--- a/examples/mavgps.py
+++ b/examples/mavgps.py
@@ -8,7 +8,6 @@ via a local TCP connection.
 
 @author: Matthew Lloyd (github@matthewlloyd.net)
 """
-from __future__ import print_function
 
 from pymavlink import mavutil
 from argparse import ArgumentParser
@@ -69,7 +68,7 @@ def main():
                 if args.debug >= 1:
                     print('>', len(data))
                 mav_serialport.write(data)
-        except socket.error:
+        except OSError:
             pass
 
         data = mav_serialport.read(args.buffsize)

--- a/examples/mavtcpsniff.py
+++ b/examples/mavtcpsniff.py
@@ -13,7 +13,6 @@ hint:
 Copyright Sept 2012 David "Buzz" Bussenschutt
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
 import time
 
@@ -27,11 +26,11 @@ parser.add_argument("dstport", type=int)
 
 args = parser.parse_args()
 
-msrc = mavutil.mavlink_connection('tcp:localhost:{}'.format(args.srcport), planner_format=False,
+msrc = mavutil.mavlink_connection(f'tcp:localhost:{args.srcport}', planner_format=False,
                                   notimestamps=True,
                                   robust_parsing=True)
 
-mdst = mavutil.mavlink_connection('tcp:localhost:{}'.format(args.dstport), planner_format=False,
+mdst = mavutil.mavlink_connection(f'tcp:localhost:{args.dstport}', planner_format=False,
                                   notimestamps=True,
                                   robust_parsing=True)
 

--- a/examples/mavtest.py
+++ b/examples/mavtest.py
@@ -4,13 +4,11 @@
 Generate a message using different MAVLink versions, put in a buffer and then read from it.
 """
 
-from __future__ import print_function
-from builtins import object
 
 from pymavlink.dialects.v10 import ardupilotmega as mavlink1
 from pymavlink.dialects.v20 import ardupilotmega as mavlink2
 
-class fifo(object):
+class fifo:
     def __init__(self):
         self.buf = []
     def write(self, data):

--- a/examples/mavtester.py
+++ b/examples/mavtester.py
@@ -3,7 +3,6 @@
 '''
 test mavlink messages
 '''
-from __future__ import print_function
 
 from pymavlink import mavtest, mavutil
 

--- a/examples/wptogpx.py
+++ b/examples/wptogpx.py
@@ -4,8 +4,6 @@
 example program to extract GPS data from a waypoint file, and create a GPX
 file, for loading into google earth
 '''
-from __future__ import print_function
-from builtins import range
 
 import time
 

--- a/fgFDM.py
+++ b/fgFDM.py
@@ -1,11 +1,8 @@
-
 #!/usr/bin/env python
 # parse and construct FlightGear NET FDM packets
 # Andrew Tridgell, November 2011
 # released under GNU GPL version 2 or later
 
-from builtins import range
-from builtins import object
 import struct, math
 
 class fgFDMError(Exception):
@@ -14,14 +11,14 @@ class fgFDMError(Exception):
         Exception.__init__(self, msg)
         self.message = 'fgFDMError: ' + msg
 
-class fgFDMVariable(object):
+class fgFDMVariable:
     '''represent a single fgFDM variable'''
     def __init__(self, index, arraylength, units):
         self.index   = index
         self.arraylength = arraylength
         self.units = units
 
-class fgFDMVariableList(object):
+class fgFDMVariableList:
     '''represent a list of fgFDM variable'''
     def __init__(self):
         self.vars = {}
@@ -31,7 +28,7 @@ class fgFDMVariableList(object):
         self.vars[varname] = fgFDMVariable(self._nextidx, arraylength, units=units)
         self._nextidx += arraylength
 
-class fgFDM(object):
+class fgFDM:
     '''a flightgear native FDM parser/generator'''
     def __init__(self):
         '''init a fgFDM object'''
@@ -157,7 +154,7 @@ class fgFDM(object):
             return value * self.unitmap[(fromunits,tounits)]
         if (tounits,fromunits) in self.unitmap:
             return value / self.unitmap[(tounits,fromunits)]
-        raise fgFDMError("unknown unit mapping (%s,%s)" % (fromunits, tounits))
+        raise fgFDMError(f"unknown unit mapping ({fromunits},{tounits})")
 
 
     def units(self, varname):

--- a/generator/C/test/posix/sha256_test.py
+++ b/generator/C/test/posix/sha256_test.py
@@ -1,4 +1,3 @@
-from builtins import range
 #!/usr/bin/env python
 
 import hashlib, sys

--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -4,10 +4,9 @@ MAVLink CRC-16/MCRF4XX code
 Copyright Andrew Tridgell
 Released under GNU LGPL version 3 or later
 '''
-from builtins import object
 
 
-class x25crc(object):
+class x25crc:
     '''CRC-16/MCRF4XX - based on checksum.h from mavlink library'''
     def __init__(self, buf=None):
         self.crc = 0xffff

--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -22,10 +22,8 @@ General process:
 
 '''
 
-from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
-from builtins import object
 import os
 import re
 import sys
@@ -61,7 +59,7 @@ def mavgen(opts, args):
     if opts.validate:
         try:
             from lxml import etree
-            with open(schemaFile, 'r') as f:
+            with open(schemaFile) as f:
                 xmlschema_root = etree.parse(f)
                 if not opts.strict_units:
                     # replace the strict "SI_Unit" list of known unit strings with a more generic "xs:string" type
@@ -197,7 +195,7 @@ def mavgen(opts, args):
            here because it relies on the XML libs that were loaded in mavgen(), so it can't be called standalone"""
         xmlvalid = True
         try:
-            with open(xmlfile, 'r') as f:
+            with open(xmlfile) as f:
                 xmldocument = etree.parse(f)
                 xmlschema.assertValid(xmldocument)
                 forbidden_names_re = re.compile("^(break$|case$|class$|catch$|const$|continue$|debugger$|default$|delete$|do$|else$|\
@@ -209,7 +207,7 @@ def mavgen(opts, args):
                 for element in xmldocument.iter('enum', 'entry', 'message', 'field'):
                     if forbidden_names_re.search(element.get('name')):
                         print("Validation error:", file=sys.stderr)
-                        print("Element : %s at line : %s contains forbidden word" % (element.tag, element.sourceline), file=sys.stderr)
+                        print(f"Element : {element.tag} at line : {element.sourceline} contains forbidden word", file=sys.stderr)
                         xmlvalid = False
 
             return xmlvalid
@@ -288,7 +286,7 @@ def mavgen(opts, args):
 
 
 # build all the dialects in the dialects subpackage
-class Opts(object):
+class Opts:
     def __init__(self, output, wire_protocol=DEFAULT_WIRE_PROTOCOL, language=DEFAULT_LANGUAGE, validate=DEFAULT_VALIDATE, error_limit=DEFAULT_ERROR_LIMIT, strict_units=DEFAULT_STRICT_UNITS):
         self.wire_protocol = wire_protocol
         self.error_limit = error_limit

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -5,11 +5,8 @@ parse a MAVLink protocol XML file and generate a C implementation
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 from future.utils import iteritems
 
-from builtins import range
-from builtins import object
 
 import os
 from . import mavparse, mavtemplate
@@ -527,7 +524,7 @@ def copy_fixed_headers(directory, xml):
         }
     basepath = os.path.dirname(os.path.realpath(__file__))
     srcpath = os.path.join(basepath, 'C/include_v%s' % xml.wire_protocol_version)
-    print("Copying fixed headers for protocol %s to %s" % (xml.wire_protocol_version, directory))
+    print(f"Copying fixed headers for protocol {xml.wire_protocol_version} to {directory}")
     for h in hlist[xml.wire_protocol_version]:
         src = os.path.realpath(os.path.join(srcpath, h))
         dest = os.path.realpath(os.path.join(directory, h))
@@ -535,7 +532,7 @@ def copy_fixed_headers(directory, xml):
             continue
         shutil.copy(src, dest)
 
-class mav_include(object):
+class mav_include:
     def __init__(self, base):
         self.base = base
 
@@ -645,9 +642,9 @@ def generate_one(basename, xml):
                 f.array_return_arg = '%s, %u, ' % (f.name, f.array_length)
                 f.array_const = 'const '
                 f.decode_left = ''
-                f.decode_right = ', %s->%s' % (m.name_lower, f.name)
+                f.decode_right = f', {m.name_lower}->{f.name}'
                 f.return_type = 'uint16_t'
-                f.get_arg = ', %s *%s' % (f.type, f.name)
+                f.get_arg = f', {f.type} *{f.name}'
                 if f.type == 'char':
                     f.c_test_value = '"%s"' % f.test_value
                 else:
@@ -662,7 +659,7 @@ def generate_one(basename, xml):
                 f.array_arg = ''
                 f.array_return_arg = ''
                 f.array_const = ''
-                f.decode_left = "%s->%s = " % (m.name_lower, f.name)
+                f.decode_left = f"{m.name_lower}->{f.name} = "
                 f.decode_right = ''
                 f.get_arg = ''
                 f.return_type = f.type

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -8,7 +8,6 @@ Copyright Andrew Tridgell 2011
 Copyright Vladimir Ermakov 2016
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
 import sys, textwrap, os, time
 from . import mavparse, mavtemplate
@@ -279,7 +278,7 @@ def copy_fixed_headers(directory, xml):
         }
     basepath = os.path.dirname(os.path.realpath(__file__))
     srcpath = os.path.join(basepath, 'CPP11/include_v%s' % xml.wire_protocol_version)
-    print("Copying fixed C++ headers for protocol %s to %s" % (xml.wire_protocol_version, directory))
+    print(f"Copying fixed C++ headers for protocol {xml.wire_protocol_version} to {directory}")
     for h in hlist[xml.wire_protocol_version]:
         src = os.path.realpath(os.path.join(srcpath, h))
         dest = os.path.realpath(os.path.join(directory, h))
@@ -288,7 +287,7 @@ def copy_fixed_headers(directory, xml):
         shutil.copy(src, dest)
 
 
-class mav_include(object):
+class mav_include:
     def __init__(self, base):
         self.base = base
 
@@ -374,25 +373,25 @@ def generate_one(basename, xml):
             #    f.test_value[5] = 0
 
             if f.array_length != 0:
-                f.cxx_type = 'std::array<%s, %s>' % (f.type, f.array_length)
+                f.cxx_type = f'std::array<{f.type}, {f.array_length}>'
 
                 # XXX sometime test_value is > 127 for int8_t, monkeypatch
                 if f.type == 'int8_t':
                     f.test_value = [fix_int8_t(v) for v in f.test_value]
 
                 if f.type == 'char':
-                    f.to_yaml_code = """ss << "  %s: \\"" << to_string(%s) << "\\"" << std::endl;""" % (f.name, f.name)
+                    f.to_yaml_code = f"""ss << "  {f.name}: \\"" << to_string({f.name}) << "\\"" << std::endl;"""
 
                     f.cxx_test_value = 'to_char_array("%s")' % (f.test_value)
                     f.c_test_value = '"%s"' % f.test_value
                 else:
-                    f.to_yaml_code = """ss << "  %s: [" << to_string(%s) << "]" << std::endl;""" % (f.name, f.name)
+                    f.to_yaml_code = f"""ss << "  {f.name}: [" << to_string({f.name}) << "]" << std::endl;"""
 
                     f.cxx_test_value = '{{ %s }}' % ', '.join([str(v) for v in f.test_value])
                     f.c_test_value = '{ %s }' % ', '.join([str(v) for v in f.test_value])
             else:
                 f.cxx_type = f.type
-                f.to_yaml_code = """ss << "  %s: " << %s%s << std::endl;""" % (f.name, to_yaml_cast, f.name)
+                f.to_yaml_code = f"""ss << "  {f.name}: " << {to_yaml_cast}{f.name} << std::endl;"""
 
                 # XXX sometime test_value is > 127 for int8_t, monkeypatch
                 if f.type == 'int8_t':
@@ -412,7 +411,7 @@ def generate_one(basename, xml):
 
             # cope with uint8_t_mavlink_version
             if f.omit_arg:
-                f.ser_name = "%s(%s)" % (f.type, f.const_value)
+                f.ser_name = f"{f.type}({f.const_value})"
 
     # add trimmed filed name to enums
     for e in xml.enum:
@@ -431,7 +430,7 @@ def generate_one(basename, xml):
                 e.entry_flt.append(f)
                 # XXX check all values in acceptable range
                 if underlying_type and f.value > underlying_type.max:
-                    raise ValueError("Enum %s::%s = %s > MAX(%s)" % (e.name, f.name_trim, f.value, underlying_type.max))
+                    raise ValueError(f"Enum {e.name}::{f.name_trim} = {f.value} > MAX({underlying_type.max})")
                 elif not underlying_type and f.value > TYPE_MAX['int32_t']:
                     # default underlying type is int, usual 32-bit
                     underlying_type = EType('int64_t', TYPE_MAX['int64_t'])

--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -265,7 +265,7 @@ ${{ordered_fields:        /// <summary>${description} ${enum} ${units} ${display
 ''', m)
 
 
-class mav_include(object):
+class mav_include:
     def __init__(self, base):
         self.base = base
 
@@ -295,11 +295,11 @@ def generate_one(fh, basename, xml):
                 f.array_return_arg = '%u, ' % (f.array_length)
                 f.array_tag = ''
                 f.array_const = 'const '
-                f.decode_left = "%s.%s = " % (m.name_lower, f.name)
+                f.decode_left = f"{m.name_lower}.{f.name} = "
                 f.decode_right = ''
                 f.return_type = 'void'
                 f.return_value = 'void'
-                f.type = "%s%s" % (map[f.type], '[]')
+                f.type = "{}{}".format(map[f.type], '[]')
             else:
                 if f.enum != "":
                     f.type = "/*" +f.enum + "*/" + f.type;
@@ -314,7 +314,7 @@ def generate_one(fh, basename, xml):
                 f.array_arg = ''
                 f.array_return_arg = ''
                 f.array_const = ''
-                f.decode_left = "%s.%s = " % (m.name_lower, f.name)
+                f.decode_left = f"{m.name_lower}.{f.name} = "
                 f.decode_right = ''
                 f.get_arg = ''
                 f.c_test_value = f.test_value
@@ -349,7 +349,7 @@ def copy_fixed_headers(directory, xml):
         }
     basepath = os.path.dirname(os.path.realpath(__file__))
     srcpath = os.path.join(basepath, 'CS')
-    print("Copying fixed headers for protocol %s to %s" % (xml.wire_protocol_version, directory))
+    print(f"Copying fixed headers for protocol {xml.wire_protocol_version} to {directory}")
     for h in hlist[xml.wire_protocol_version]:
         src = os.path.realpath(os.path.join(srcpath, h))
         dest = os.path.realpath(os.path.join(directory, h))
@@ -360,7 +360,7 @@ def copy_fixed_headers(directory, xml):
 
 def generate(basename, xml_list):
     '''generate complete MAVLink CSharp implemenation'''
-    print("generate for protocol %s to %s" % (xml_list[0].wire_protocol_version, basename))
+    print(f"generate for protocol {xml_list[0].wire_protocol_version} to {basename}")
     
     directory = basename
 

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -5,10 +5,7 @@ Parse a MAVLink protocol XML file and generate a Java implementation
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
-from builtins import range
-from builtins import object
 
 import os
 from . import mavparse, mavtemplate
@@ -276,7 +273,7 @@ def generate_MAVLinkMessage(directory, xml_list):
     imports = []
 
     for xml in xml_list:
-        importString = "import com.MAVLink.{}.*;".format(xml.basename)
+        importString = f"import com.MAVLink.{xml.basename}.*;"
         imports.append(importString)
 
     xml_list[0].importString = os.linesep.join(imports)
@@ -589,7 +586,7 @@ def copy_fixed_headers(directory, xml):
             print("Not re-creating Messages directory")
         shutil.copy(src, dest)
 
-class mav_include(object):
+class mav_include:
     def __init__(self, base):
         self.base = base
 
@@ -687,17 +684,17 @@ def generate_one(basename, xml):
                 f.decode_right = 'm.%s' % (f.name)
                 
                 f.unpackField = ''' 
-        for (int i = 0; i < this.%s.length; i++) {
-            this.%s[i] = payload.get%s();
-        }
-                ''' % (f.name, f.name, mavfmt(f, 1) )
+        for (int i = 0; i < this.{}.length; i++) {{
+            this.{}[i] = payload.get{}();
+        }}
+                '''.format(f.name, f.name, mavfmt(f, 1) )
                 f.packField = '''
-        for (int i = 0; i < %s.length; i++) {
-            packet.payload.put%s(%s[i]);
-        }
-                    ''' % (f.name, mavfmt(f, 1),f.name)
+        for (int i = 0; i < {}.length; i++) {{
+            packet.payload.put{}({}[i]);
+        }}
+                    '''.format(f.name, mavfmt(f, 1),f.name)
                 f.return_type = 'uint16_t'
-                f.get_arg = ', %s *%s' % (f.type, f.name)
+                f.get_arg = f', {f.type} *{f.name}'
                 if f.type == 'char':
 
                     f.c_test_value = '"%s"' % f.test_value
@@ -746,8 +743,8 @@ def generate_one(basename, xml):
                 f.array_const = ''
                 f.decode_left =  '%s' % (f.name)
                 f.decode_right = ''
-                f.unpackField = 'this.%s = payload.get%s();' % (f.name, mavfmt(f, 1))
-                f.packField = 'packet.payload.put%s(%s);' % (mavfmt(f, 1),f.name)
+                f.unpackField = f'this.{f.name} = payload.get{mavfmt(f, 1)}();'
+                f.packField = f'packet.payload.put{mavfmt(f, 1)}({f.name});'
 
                 f.get_arg = ''
                 f.return_type = f.type

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -5,9 +5,7 @@ parse a MAVLink protocol XML file and generate a Node.js javascript module imple
 Based on original work Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
-from builtins import range
 
 import os
 import textwrap
@@ -257,14 +255,14 @@ def generate_classes(outf, msgs, xml):
     def field_descriptions(fields):
         ret = ""
         for f in fields:
-            ret += "                %-18s        : %s (%s)\n" % (f.name, f.description.strip(), f.type)
+            ret += f"                {f.name:<18}        : {f.description.strip()} ({f.type})\n"
         return ret
 
     # now do all the messages
     for m in msgs:
 
         # assemble some strings we'll use later in outputting ..
-        comment = "%s\n\n%s" % (wrapper.fill(m.description.strip()), field_descriptions(m.fields))
+        comment = f"{wrapper.fill(m.description.strip())}\n\n{field_descriptions(m.fields)}"
         selffieldnames = 'self, '
         for f in m.fields:
             selffieldnames += '%s, ' % f.name
@@ -286,7 +284,7 @@ def generate_classes(outf, msgs, xml):
 """ % (comment))
 
         # function signature + declaration
-        outf.write("    %s.messages.%s = function(" % ( get_mavhead(xml), m.name.lower() ) )
+        outf.write(f"    {get_mavhead(xml)}.messages.{m.name.lower()} = function(" )
         outf.write(" ...moreargs ) {\n")
         # passing the dynamic args into the correct attributes, we can call the constructor with or without the 'moreargs'
         outf.write("     [ this.%s ] = moreargs;\n" % " , this.".join(m.fieldnames))
@@ -325,7 +323,7 @@ def generate_classes(outf, msgs, xml):
         outf.write("\n}\n")
 
         # inherit methods from the base message class
-        outf.write("\n%s.messages.%s.prototype = new %s.message;\n" % ( get_mavhead(xml), m.name.lower() ,get_mavhead(xml) ) )
+        outf.write(f"\n{get_mavhead(xml)}.messages.{m.name.lower()}.prototype = new {get_mavhead(xml)}.message;\n" )
 
         orderedfields =    "var orderedfields = [ this." + ", this.".join(m.ordered_fieldnames) + "];";
 
@@ -1062,7 +1060,7 @@ def generate_tests_mavlink_class(outf, msgs, xml):
         #var bs = new mavlink20.messages.battery_status(
         outf.write("   if ( verbose == 2 ) console.log('test creating and packing:%s'); \n" % (  m.name.lower() ) )
         outf.write("   if ( verbose == 1) { process.stdout.write('test creating and packing:"+m.name.lower()+"          \\r'); }\n")
-        outf.write("   var test_%s = new %s.messages.%s(); \n" % (  m.name.lower(),get_mavhead(xml), m.name.lower()))
+        outf.write(f"   var test_{m.name.lower()} = new {get_mavhead(xml)}.messages.{m.name.lower()}(); \n")
  
         idx = 0; # test data is in same order as ordered_fieldnames
         for f in m.ordered_fieldnames:
@@ -1120,7 +1118,7 @@ def generate_tests_mavlink_class(outf, msgs, xml):
                  #string
                  tdata = '"'+m.test_data[idx]+'"';
 
-            outf.write( "      test_%s.%s = %s;" % ( m.name.lower(),f, tdata) );
+            outf.write( f"      test_{m.name.lower()}.{f} = {tdata};" );
             outf.write(" // fieldtype: %s "%(fieldtype));
             outf.write(" isarray: %s \n"%(_isarray));
             idx=idx+1;

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -5,9 +5,7 @@ parse a MAVLink protocol XML file and generate a Node.js javascript module imple
 Based on original work Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
-from builtins import range
 
 import os
 import textwrap
@@ -194,12 +192,12 @@ def generate_classes(outf, msgs, xml):
     def field_descriptions(fields):
         ret = ""
         for f in fields:
-            ret += "                %-18s        : %s (%s)\n" % (f.name, f.description.strip(), f.type)
+            ret += f"                {f.name:<18}        : {f.description.strip()} ({f.type})\n"
         return ret
 
     for m in msgs:
 
-        comment = "%s\n\n%s" % (wrapper.fill(m.description.strip()), field_descriptions(m.fields))
+        comment = f"{wrapper.fill(m.description.strip())}\n\n{field_descriptions(m.fields)}"
 
         selffieldnames = 'self, '
         for f in m.fields:

--- a/generator/mavgen_lua.py
+++ b/generator/mavgen_lua.py
@@ -2,9 +2,7 @@
 '''
 parse a MAVLink protocol XML file and generate a Wireshark LUA dissector
 '''
-from __future__ import print_function
 
-from builtins import range
 
 import os
 
@@ -129,13 +127,13 @@ end
     # dump the actual symbol table
     outf.write("messages = {}\n")
     for m in msgs:
-        outf.write("messages[%s] = { -- %s\n" % (m.id, m.name))
+        outf.write(f"messages[{m.id}] = {{ -- {m.name}\n")
         for i in range(0, len(m.ordered_fields)):
             field = m.ordered_fields[i]
             if (field.array_length > 0):
-                outf.write("             { \"%s\", \"<%s\", %s },\n" % (field.name, unpack_types.get(field.type), field.array_length))
+                outf.write(f"             {{ \"{field.name}\", \"<{unpack_types.get(field.type)}\", {field.array_length} }},\n")
             else:
-                outf.write("             { \"%s\", \"<%s\" },\n" % (field.name, unpack_types.get(field.type)))
+                outf.write(f"             {{ \"{field.name}\", \"<{unpack_types.get(field.type)}\" }},\n")
         outf.write("             }\n")
 
     outf.close()

--- a/generator/mavgen_objc.py
+++ b/generator/mavgen_objc.py
@@ -5,7 +5,6 @@ parse a MAVLink protocol XML file and generate an Objective-C implementation
 Copyright John Boiles 2013
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
 
 import os
 from . import mavparse, mavtemplate
@@ -403,7 +402,7 @@ def generate_message_definitions(basename, xml):
                 f.array_return_arg = '%s, %u, ' % (f.name, f.array_length)
                 f.return_type = 'uint16_t'
                 f.get_arg = ', %s' % (f.name)
-                f.get_arg_objc = ':(%s *)%s' % (f.type, f.name)
+                f.get_arg_objc = f':({f.type} *){f.name}'
                 if f.type == 'char':
                     # Special handling for strings (assumes all char arrays are strings)
                     f.return_type = 'NSString *'
@@ -416,7 +415,7 @@ def generate_message_definitions(basename, xml):
 
             if not f.return_method_implementation:
                 f.return_method_implementation = \
-"""return mavlink_msg_%(message_name_lower)s_get_%(name)s(&(self->_message)%(get_arg)s);""" % {'message_name_lower': m.name_lower, 'name': f.name, 'get_arg': f.get_arg}
+f"""return mavlink_msg_{m.name_lower}_get_{f.name}(&(self->_message){f.get_arg});"""
 
     for m in xml.message:
         m.arg_fields = []

--- a/generator/mavgen_swift.py
+++ b/generator/mavgen_swift.py
@@ -5,7 +5,6 @@ Parse a MAVLink protocol XML file and generate Swift implementation
 Copyright Max Odnovolyk 2015
 Released under GNU GPL version 3 or later
 """
-from __future__ import print_function
 
 import os
 from . import mavparse, mavtemplate
@@ -67,7 +66,7 @@ def generate_enums(directory, filelist, xml_list, enums):
     for enum in enums:
         if enum.is_a_bitmask:
             continue
-        filename = "%s%sEnum.swift" % (enum.swift_name, enum.basename)
+        filename = f"{enum.swift_name}{enum.basename}Enum.swift"
         filepath = os.path.join(directory, filename)
         outf = open(filepath, "w")
         generate_header(outf, filelist, xml_list, filename)
@@ -96,7 +95,7 @@ def generate_optionsets(directory, filelist, xml_list, enums):
             continue
         for entry in enum.entry:
             entry.parent_swift_name = enum.swift_name
-        filename = "%s%sOptionSet.swift" % (enum.swift_name, enum.basename)
+        filename = f"{enum.swift_name}{enum.basename}OptionSet.swift"
         filepath = os.path.join(directory, filename)
         outf = open(filepath, "w")
         generate_header(outf, filelist, xml_list, filename)
@@ -135,7 +134,7 @@ def generate_messages(directory, filelist, xml_list, msgs):
     print("Generating Messages")
 
     for msg in msgs:
-        filename = "%s%sMsg.swift" % (msg.swift_name, msg.basename)
+        filename = f"{msg.swift_name}{msg.basename}Msg.swift"
         filepath = os.path.join(directory, filename)
         outf = open(filepath, "w")
         generate_header(outf, filelist, xml_list, filename)
@@ -294,7 +293,7 @@ def generate_enums_type_info(enums, msgs):
                 entry.formatted_description = "\n\t/// " + entry.description + "\n"
 
             all_entities.append(entry.swift_name)
-            entities_info.append('("%s", "%s")' % (entry.name, entry.description.replace('"','\\"')))
+            entities_info.append('("{}", "{}")'.format(entry.name, entry.description.replace('"','\\"')))
 
         enum.all_entities = ", ".join(all_entities)
         enum.entities_info = ", ".join(entities_info)

--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -10,9 +10,7 @@ Instructions for use:
 2. convert binary stream int .pcap file format (see ../examples/mav2pcap.py)
 3. open the pcap file in Wireshark
 '''
-from __future__ import print_function
 
-from builtins import range
 
 import os
 import re

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -5,9 +5,6 @@ mavlink python parse functions
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
-from builtins import range
-from builtins import object
 
 import errno
 import operator
@@ -32,7 +29,7 @@ class MAVParseError(Exception):
     def __str__(self):
         return self.message
 
-class MAVField(object):
+class MAVField:
     def __init__(self, name, type, print_format, xml, description='', enum='', display='', units='', instance=False):
         self.name = name
         self.name_upper = name.upper()
@@ -122,7 +119,7 @@ class MAVField(object):
             self.test_value = v[:-1]
 
 
-class MAVType(object):
+class MAVType:
     def __init__(self, name, id, linenumber, description=''):
         self.name = name
         self.name_lower = name.lower()
@@ -140,7 +137,7 @@ class MAVType(object):
             return len(self.fields)
         return len(self.fields[:self.extensions_start])
 
-class MAVEnumParam(object):
+class MAVEnumParam:
     def __init__(self, index, description='', label='', units='', enum='', increment='', minValue='', maxValue='', reserved=False, default=''):
         self.index = index
         self.description = description
@@ -162,7 +159,7 @@ class MAVEnumParam(object):
         else:
             self.description = description
 
-class MAVEnumEntry(object):
+class MAVEnumEntry:
     def __init__(self, name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0):
         self.name = name
         self.value = value
@@ -173,7 +170,7 @@ class MAVEnumEntry(object):
         self.origin_file = origin_file
         self.origin_line = origin_line
 
-class MAVEnum(object):
+class MAVEnum:
     def __init__(self, name, linenumber, description='', bitmask=False):
         self.name = name
         self.description = description
@@ -183,7 +180,7 @@ class MAVEnum(object):
         self.linenumber = linenumber
         self.bitmask = bitmask
 
-class MAVXML(object):
+class MAVXML:
     '''parse a mavlink XML file'''
     def __init__(self, filename, wire_protocol_version=PROTOCOL_0_9):
         self.filename = filename
@@ -227,7 +224,7 @@ class MAVXML(object):
             self.allow_extensions = True
         else:
             print("Unknown wire protocol version")
-            print("Available versions are: %s %s" % (PROTOCOL_0_9, PROTOCOL_1_0, PROTOCOL_2_0))
+            print(f"Available versions are: {PROTOCOL_0_9} {PROTOCOL_1_0}")
             raise MAVParseError('Unknown MAVLink wire protocol version %s' % wire_protocol_version)
 
         in_element_list = []
@@ -537,8 +534,8 @@ def check_duplicates(xml):
             for entry in enum.entry:
                 if entry.autovalue is True and "common.xml" not in entry.origin_file:
                     print("Note: An enum value was auto-generated: %s = %u" % (entry.name, entry.value))
-                s1 = "%s.%s" % (enum.name, entry.name)
-                s2 = "%s.%s" % (enum.name, entry.value)
+                s1 = f"{enum.name}.{entry.name}"
+                s2 = f"{enum.name}.{entry.value}"
                 if s1 in enummap or s2 in enummap:
                     print("ERROR: Duplicate enum %s:\n\t%s = %s @ %s:%u\n\t%s" % (
                         "names" if s1 in enummap else "values",

--- a/generator/mavtemplate.py
+++ b/generator/mavtemplate.py
@@ -6,11 +6,10 @@ Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
 
-from builtins import object
 
 from .mavparse import MAVParseError
 
-class MAVTemplate(object):
+class MAVTemplate:
     '''simple templating system'''
     def __init__(self,
                  start_var_token="${", 
@@ -112,7 +111,7 @@ class MAVTemplate(object):
             if isinstance(subvars, dict):
                 if not varname in subvars:
                     if checkmissing:
-                        raise MAVParseError("unknown variable in '%s%s%s'" % (
+                        raise MAVParseError("unknown variable in '{}{}{}'".format(
                             self.start_var_token, varname, self.end_var_token))
                     return text[0:idx+endidx] + self.substitute(text[idx+endidx:], subvars,
                                                                 trim_leading_lf=False, checkmissing=False)
@@ -121,11 +120,11 @@ class MAVTemplate(object):
                 value = getattr(subvars, varname, None)
                 if value is None:
                     if checkmissing:
-                        raise MAVParseError("unknown variable in '%s%s%s'" % (
+                        raise MAVParseError("unknown variable in '{}{}{}'".format(
                             self.start_var_token, varname, self.end_var_token))
                     return text[0:idx+endidx] + self.substitute(text[idx+endidx:], subvars,
                                                                 trim_leading_lf=False, checkmissing=False)
-            text = text.replace("%s%s%s" % (self.start_var_token, varname, self.end_var_token), str(value))
+            text = text.replace(f"{self.start_var_token}{varname}{self.end_var_token}", str(value))
         return text
 
     def write(self, file, text, subvars={}, trim_leading_lf=True):

--- a/generator/mavtestgen.py
+++ b/generator/mavtestgen.py
@@ -5,8 +5,6 @@ generate a MAVLink test suite
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
-from builtins import range
 
 import sys
 from argparse import ArgumentParser
@@ -73,7 +71,7 @@ def generate_outputs(mav):
         outf.write("\tmav.%s_send(" % m.name.lower())
         for i in range(0, len(m.fields)):
             f = m.fields[i]
-            outf.write("%s=%s" % (f.name, gen_value(f, i, 'py')))
+            outf.write("{}={}".format(f.name, gen_value(f, i, 'py')))
             if i != len(m.fields)-1:
                 outf.write(",")
         outf.write(")\n")

--- a/mavextra.py
+++ b/mavextra.py
@@ -5,9 +5,6 @@ useful extra functions for use by mavlink clients
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import print_function
-from __future__ import absolute_import
-from builtins import object
 
 from math import *
 
@@ -795,7 +792,7 @@ def wrap_360(angle):
         angle += 360.0
     return angle
 
-class DCM_State(object):
+class DCM_State:
     '''DCM state object'''
     def __init__(self, roll, pitch, yaw):
         self.dcm = Matrix3()
@@ -854,7 +851,7 @@ def DCM_update(IMU, ATT, MAG, GPS):
     dcm_state.update(gyro, accel, mag, GPS)
     return dcm_state
 
-class PX4_State(object):
+class PX4_State:
     '''PX4 DCM state object'''
     def __init__(self, roll, pitch, yaw, timestamp):
         self.dcm = Matrix3()

--- a/mavparm.py
+++ b/mavparm.py
@@ -1,7 +1,6 @@
 '''
 module for loading/saving sets of mavlink parameters
 '''
-from __future__ import print_function
 
 
 import fnmatch, math, time, struct
@@ -66,7 +65,7 @@ class MAVParmDict(dict):
                     self.__setitem__(name, float(value))
                     break
         if not got_ack:
-            print("timeout setting %s to %f" % (name, vfloat))
+            print(f"timeout setting {name} to {vfloat:f}")
             return False
         return True
 
@@ -81,9 +80,9 @@ class MAVParmDict(dict):
             if p and fnmatch.fnmatch(str(p).upper(), wildcard.upper()):
                 value = self.__getitem__(p)
                 if isinstance(value, float):
-                    f.write("%-16.16s %f\n" % (p, value))
+                    f.write(f"{p:<16.16} {value:f}\n")
                 else:
-                    f.write("%-16.16s %s\n" % (p, str(value)))
+                    f.write(f"{p:<16.16} {str(value)}\n")
                 count += 1
         f.close()
         if verbose:
@@ -93,9 +92,9 @@ class MAVParmDict(dict):
     def load(self, filename, wildcard='*', mav=None, check=True, use_excludes=True):
         '''load parameters from a file'''
         try:
-            f = open(filename, mode='r')
+            f = open(filename)
         except Exception as e:
-            print("Failed to open file '%s': %s" % (filename, str(e)))
+            print(f"Failed to open file '{filename}': {str(e)}")
             return False
         count = 0
         changed = 0
@@ -123,9 +122,9 @@ class MAVParmDict(dict):
                         count += 1
                         continue
                     if self.mavset(mav, a[0], a[1]):
-                        print("changed %s from %f to %f" % (a[0], old_value, float(a[1])))
+                        print(f"changed {a[0]} from {old_value:f} to {float(a[1]):f}")
                 else:
-                    print("set %s to %f" % (a[0], float(a[1])))
+                    print(f"set {a[0]} to {float(a[1]):f}")
                     self.mavset(mav, a[0], a[1])
                 changed += 1
             else:
@@ -139,7 +138,7 @@ class MAVParmDict(dict):
         return True
 
     def show_param_value(self, name, value):
-        print("%-16.16s %s" % (name, value))
+        print(f"{name:<16.16} {value}")
 
     def show(self, wildcard='*'):
         '''show parameters'''
@@ -160,13 +159,13 @@ class MAVParmDict(dict):
             if not k in other:
                 value = float(self[k])
                 if show_only2:
-                    print("%-16.16s              %12.4f" % (k, value))
+                    print(f"{k:<16.16}              {value:12.4f}")
             elif not k in self:
                 if show_only1:
-                    print("%-16.16s %12.4f" % (k, float(other[k])))
+                    print(f"{k:<16.16} {float(other[k]):12.4f}")
             elif abs(self[k] - other[k]) > self.mindelta:
                 value = float(self[k])
                 if use_tabs:
-                    print("%s\t%.4f\t%.4f" % (k, other[k], value))
+                    print(f"{k}\t{other[k]:.4f}\t{value:.4f}")
                 else:
-                    print("%-16.16s %12.4f %12.4f" % (k, other[k], value))
+                    print(f"{k:<16.16} {other[k]:12.4f} {value:12.4f}")

--- a/mavwp.py
+++ b/mavwp.py
@@ -4,9 +4,6 @@ module for loading/saving waypoints
 Copyright the ArduPilot Project
 Released under GNU LGPL version 3 or later
 '''
-from __future__ import print_function
-from builtins import range
-from builtins import object
 
 import time, copy
 import logging
@@ -26,7 +23,7 @@ class MAVWPError(Exception):
         self.message = msg
 
 
-class MAVWPLoader(object):
+class MAVWPLoader:
     '''MAVLink waypoint loader'''
     def __init__(self, target_system=0, target_component=0):
         self.wpoints = []
@@ -273,7 +270,7 @@ class MAVWPLoader(object):
     def load(self, filename):
         '''load waypoints from a file.
         returns number of waypoints loaded'''
-        f = open(filename, mode='r')
+        f = open(filename)
         version_line = f.readline().strip()
         if version_line == "QGC WPL 100":
             readfn = self._read_waypoints_v100
@@ -433,7 +430,7 @@ class MAVRallyError(Exception):
         Exception.__init__(self, msg)
         self.message = msg
 
-class MAVRallyLoader(object):
+class MAVRallyLoader:
     '''MAVLink Rally points and Rally Land points loader'''
     def __init__(self, target_system=0, target_component=0):
         self.rally_points = []
@@ -506,7 +503,7 @@ class MAVRallyLoader(object):
     def load(self, filename):
         '''load rally and rally_land points from a file.
          returns number of points loaded'''
-        f = open(filename, mode='r')
+        f = open(filename)
         self.clear()
         for line in f:
             if line.startswith('#'):
@@ -538,7 +535,7 @@ class MAVFenceError(Exception):
             Exception.__init__(self, msg)
             self.message = msg
 
-class MAVFenceLoader(object):
+class MAVFenceLoader:
     '''MAVLink geo-fence loader'''
     def __init__(self, target_system=0, target_component=0):
         self.points = []
@@ -583,7 +580,7 @@ class MAVFenceLoader(object):
     def load(self, filename):
         '''load points from a file.
         returns number of points loaded'''
-        f = open(filename, mode='r')
+        f = open(filename)
         self.clear()
         for line in f:
             if line.startswith('#'):
@@ -602,7 +599,7 @@ class MAVFenceLoader(object):
         '''save fence points to a file'''
         f = open(filename, mode='w')
         for p in self.points:
-            f.write("%f\t%f\n" % (p.lat, p.lng))
+            f.write(f"{p.lat:f}\t{p.lng:f}\n")
         f.close()
 
     def move(self, i, lat, lng, change_time=True):

--- a/quaternion.py
+++ b/quaternion.py
@@ -5,9 +5,7 @@
 Quaternion implementation for use in pymavlink
 """
 
-from __future__ import absolute_import, division, print_function
 
-from builtins import object
 import numpy as np
 from .rotmat import Vector3, Matrix3
 
@@ -17,7 +15,7 @@ __license__ = "GNU Lesser General Public License v3"
 __email__ = "thomasgubler@gmail.com"
 
 
-class QuaternionBase(object):
+class QuaternionBase:
 
     """
     Quaternion class, this is the version which supports numpy arrays
@@ -492,9 +490,9 @@ class Quaternion(QuaternionBase):
         elif isinstance(attitude, Vector3):
             # provided euler angles
             euler = [attitude.x, attitude.y, attitude.z]
-            super(Quaternion, self).__init__(euler)
+            super().__init__(euler)
         else:
-            super(Quaternion, self).__init__(attitude)
+            super().__init__(attitude)
 
     @property
     def dcm(self):
@@ -534,7 +532,7 @@ class Quaternion(QuaternionBase):
 
         :returns: inversed quaternion
         """
-        return Quaternion(super(Quaternion, self).inversed)
+        return Quaternion(super().inversed)
 
     def transform(self, v3):
         """
@@ -543,10 +541,10 @@ class Quaternion(QuaternionBase):
         :returns: transformed vector
         """
         if isinstance(v3, Vector3):
-            t = super(Quaternion, self).transform([v3.x, v3.y, v3.z])
+            t = super().transform([v3.x, v3.y, v3.z])
             return Vector3(t[0], t[1], t[2])
         elif len(v3) == 3:
-            return super(Quaternion, self).transform(v3)
+            return super().transform(v3)
         else:
             raise TypeError("param v3 is not a vector type")
 
@@ -580,7 +578,7 @@ class Quaternion(QuaternionBase):
         :returns: Matrix3
         """
         assert(len(q) == 4)
-        arr = super(Quaternion, self)._q_to_dcm(q)
+        arr = super()._q_to_dcm(q)
         return self._dcm_array_to_matrix3(arr)
 
     def _dcm_to_q(self, dcm):
@@ -591,7 +589,7 @@ class Quaternion(QuaternionBase):
         """
         assert(isinstance(dcm, Matrix3))
         arr = self._matrix3_to_dcm_array(dcm)
-        return super(Quaternion, self)._dcm_to_q(arr)
+        return super()._dcm_to_q(arr)
 
     def _euler_to_dcm(self, euler):
         """
@@ -618,14 +616,14 @@ class Quaternion(QuaternionBase):
         :param other: Quaternion
         :returns: multiplaction of this Quaternion with other
         """
-        return Quaternion(super(Quaternion, self).__mul__(other))
+        return Quaternion(super().__mul__(other))
 
     def __truediv__(self, other):
         """
         :param other: Quaternion
         :returns: division of this Quaternion with other
         """
-        return Quaternion(super(Quaternion, self).__truediv__(other))
+        return Quaternion(super().__truediv__(other))
 
 if __name__ == "__main__":
     import doctest

--- a/rotmat.py
+++ b/rotmat.py
@@ -22,12 +22,11 @@
 
 '''rotation matrix class
 '''
-from __future__ import print_function
 
 from math import sin, cos, sqrt, asin, atan2, pi, acos
 
 
-class Vector3(object):
+class Vector3:
     '''a vector'''
     def __init__(self, x=None, y=None, z=None):
         if x is not None and y is not None and z is not None:
@@ -46,7 +45,7 @@ class Vector3(object):
             self.z = float(0)
 
     def __repr__(self):
-        return 'Vector3(%.2f, %.2f, %.2f)' % (self.x,
+        return 'Vector3({:.2f}, {:.2f}, {:.2f})'.format(self.x,
                                               self.y,
                                               self.z)
 
@@ -151,7 +150,7 @@ class Vector3(object):
         return rotations[rot_id].rt * self
 
 
-class Matrix3(object):
+class Matrix3:
     '''a 3x3 matrix, intended as a rotation matrix'''
     def __init__(self, a=None, b=None, c=None):
         if a is not None and b is not None and c is not None:
@@ -162,7 +161,7 @@ class Matrix3(object):
             self.identity()
 
     def __repr__(self):
-        return 'Matrix3((%.2f, %.2f, %.2f), (%.2f, %.2f, %.2f), (%.2f, %.2f, %.2f))' % (
+        return 'Matrix3(({:.2f}, {:.2f}, {:.2f}), ({:.2f}, {:.2f}, {:.2f}), ({:.2f}, {:.2f}, {:.2f}))'.format(
             self.a.x, self.a.y, self.a.z,
             self.b.x, self.b.y, self.b.z,
             self.c.x, self.c.y, self.c.z)
@@ -385,7 +384,7 @@ class Matrix3(object):
     def close(self, m, tol=1e-7):
         return self.a.close(m.a, tol) and self.b.close(m.b, tol) and self.c.close(m.c, tol)
 
-class Plane(object):
+class Plane:
     '''a plane in 3 space, defined by a point and a vector normal'''
     def __init__(self, point=None, normal=None):
         if point is None:
@@ -395,7 +394,7 @@ class Plane(object):
         self.point = point
         self.normal = normal
 
-class Line(object):
+class Line:
     '''a line in 3 space, defined by a point and a vector'''
     def __init__(self, point=None, vector=None):
         if point is None:
@@ -416,7 +415,7 @@ class Line(object):
             return None
         return (self.vector * d) + self.point
 
-class Rotation(object):
+class Rotation:
     def __init__(self, name, roll, pitch, yaw):
         self.name = name
         self.roll = roll

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, print_function
 from setuptools.command.build_py import build_py
 # Work around mbcs bug in distutils.
 # http://bugs.python.org/issue10945

--- a/tests/test_fgFDM.py
+++ b/tests/test_fgFDM.py
@@ -5,7 +5,6 @@
 Unit tests for the fgFDM library
 """
 
-from __future__ import print_function
 import unittest
 
 from pymavlink.fgFDM import fgFDMError, fgFDMVariable, fgFDMVariableList, fgFDM
@@ -17,10 +16,10 @@ class fgFDMErrorTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(fgFDMErrorTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         
     def test_constructor(self):
-        ex = fgFDMError("Test Exception {0}".format(1))
+        ex = fgFDMError(f"Test Exception {1}")
         
         assert ex.message == "fgFDMError: Test Exception 1"
 
@@ -30,7 +29,7 @@ class fgFDMVariableTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(fgFDMVariableTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         
     def test_constructor(self):
         """Test the constructor"""
@@ -47,7 +46,7 @@ class fgFDMVariableListTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(fgFDMVariableListTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         
     def test_constructor(self):
         """Test the constructor and adding variables"""
@@ -69,7 +68,7 @@ class fgFDMTest(unittest.TestCase):
     """
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(fgFDMTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         
     def test_constructor(self):
         """Test the constructor"""

--- a/tests/test_mavexpression.py
+++ b/tests/test_mavexpression.py
@@ -5,7 +5,6 @@
 Unit tests for the mavexpression library
 """
 
-from __future__ import print_function
 import unittest
 import random
 
@@ -22,7 +21,7 @@ class ExpressionTest(unittest.TestCase):
         self.varsDict = {}
         self.varsDict['lat'] = 5.67
         self.varsDict['speed'] = 8
-        super(ExpressionTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
     def test_novars(self):

--- a/tests/test_mavlogdump.py
+++ b/tests/test_mavlogdump.py
@@ -5,7 +5,6 @@
 regression tests for mavlogdump.py
 """
 
-from __future__ import absolute_import, print_function
 import unittest
 import os
 import pkg_resources
@@ -19,7 +18,7 @@ class MAVLogDumpTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(MAVLogDumpTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_dump_same(self):
         """Test dump of file is what we expect"""
@@ -27,7 +26,7 @@ class MAVLogDumpTest(unittest.TestCase):
         test_filepath = pkg_resources.resource_filename(__name__,
                                                         test_filename)
         dump_filename = "tmp.dump"
-        os.system("mavlogdump.py %s >%s" % (test_filepath, dump_filename))
+        os.system(f"mavlogdump.py {test_filepath} >{dump_filename}")
         with open(dump_filename) as f:
             got = f.read()
 

--- a/tests/test_mavparm.py
+++ b/tests/test_mavparm.py
@@ -5,7 +5,6 @@
 Unit tests for the mavparm library
 """
 
-from __future__ import print_function
 import unittest
 import os
 
@@ -24,7 +23,7 @@ class MAVParmDictTest(unittest.TestCase):
         self.parms['PARAM1'] = 34.45
         self.parms['PARAM2'] = 0
         self.parms['PARAM3'] = -13.4
-        super(MAVParmDictTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
     def test_dict(self):

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -5,7 +5,6 @@
 Unit tests for the quaternion library
 """
 
-from __future__ import absolute_import, division, print_function
 import unittest
 import numpy as np
 from pymavlink.quaternion import QuaternionBase, Quaternion
@@ -25,7 +24,7 @@ class QuaternionBaseTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(QuaternionBaseTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.quaternions = self._all_quaternions()
 
     def test_constructor(self):
@@ -208,7 +207,7 @@ class QuaternionTest(QuaternionBaseTest):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(QuaternionTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.quaternions = self._all_quaternions()
 
     def _all_quaternions(self):

--- a/tests/test_rotmat.py
+++ b/tests/test_rotmat.py
@@ -5,7 +5,6 @@
 Unit tests for the rotmat library
 """
 
-from __future__ import absolute_import, print_function
 from math import radians, degrees
 import unittest
 import random
@@ -21,7 +20,7 @@ class VectorTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(VectorTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
 
     def test_constructor(self):
@@ -63,7 +62,7 @@ class MatrixTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(MatrixTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_constructor(self):
         """Test the constructor functionality"""
@@ -154,7 +153,7 @@ class LinePlaneTest(unittest.TestCase):
 
     def __init__(self, *args, **kwargs):
         """Constructor, set up some data that is reused in many tests"""
-        super(LinePlaneTest, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
     def test_plane(self):
         '''testing line/plane intersection'''

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -5,7 +5,6 @@
 test for trimming under Python 3
 """
 
-from __future__ import absolute_import, print_function
 import unittest
 import os
 import pkg_resources

--- a/tools/AccelSearch.py
+++ b/tools/AccelSearch.py
@@ -3,9 +3,6 @@
 '''
 search a set of log files for bad accel values
 '''
-from __future__ import print_function
-from builtins import input
-from builtins import range
 
 import sys, os
 import zipfile
@@ -16,10 +13,10 @@ from pymavlink import mavutil
 import json
 from pymavlink.dialects.v10 import ardupilotmega
 
-search_dirs = ['c:\Program Files\APM Planner',
-               'c:\Program Files\Mission Planner',
-               'c:\Program Files (x86)\APM Planner',
-               'c:\Program Files (x86)\Mission Planner']
+search_dirs = [r'c:\Program Files\APM Planner',
+               r'c:\Program Files\Mission Planner',
+               r'c:\Program Files (x86)\APM Planner',
+               r'c:\Program Files (x86)\Mission Planner']
 results = 'SearchResults.zip'
 email = 'Craig Elder <craig@3drobotics.com>'
 

--- a/tools/MPU6KSearch.py
+++ b/tools/MPU6KSearch.py
@@ -3,9 +3,6 @@
 '''
 search a set of log files for signs of inconsistent IMU data
 '''
-from __future__ import print_function
-from builtins import input
-from builtins import range
 
 import sys, time, os
 import zipfile
@@ -17,10 +14,10 @@ from math import degrees
 import json
 from pymavlink.dialects.v10 import ardupilotmega
 
-search_dirs = ['c:\Program Files\APM Planner',
-               'c:\Program Files\Mission Planner',
-               'c:\Program Files (x86)\APM Planner',
-               'c:\Program Files (x86)\Mission Planner']
+search_dirs = [r'c:\Program Files\APM Planner',
+               r'c:\Program Files\Mission Planner',
+               r'c:\Program Files (x86)\APM Planner',
+               r'c:\Program Files (x86)\Mission Planner']
 results = 'SearchResults.zip'
 email = 'Craig Elder <craig@3drobotics.com>'
 
@@ -124,7 +121,7 @@ def IMUCheckFail(filename):
                     print(m)
                     return True
                 if abs(ecount_gyro[i]) > count_threshold:
-                    print("gyrodiff[i] %.1f" % (i, adiff))
+                    print(f"gyrodiff[i] {i:.1f}")
                     print(m)
                     return True
         
@@ -189,7 +186,7 @@ for f in found:
     arcname=os.path.basename(f)
     if not arcname.startswith('201'):
         mtime = os.path.getmtime(f)
-        arcname = "%s-%s" % (time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime(mtime)), arcname)
+        arcname = "{}-{}".format(time.strftime("%Y-%m-%d-%H-%M-%S", time.localtime(mtime)), arcname)
     zip.write(f, arcname=arcname)
 zip.close()
 

--- a/tools/find_aliasing.py
+++ b/tools/find_aliasing.py
@@ -34,7 +34,7 @@ def process_log(fname):
         last_err[a] = 0.0
 
     alpha = 0.9
-    msg_types = set(['IMU', 'IMU3'])
+    msg_types = {'IMU', 'IMU3'}
 
     while True:
         m = mlog.recv_match(type=msg_types)
@@ -77,9 +77,9 @@ def process_log(fname):
             break
 
     if max_err_axis is not None:
-        print("%s aliasing on %s %.1f" % (fname, max_err_axis, max_err))
+        print(f"{fname} aliasing on {max_err_axis} {max_err:.1f}")
         try:
-            open(fname + ".aliasing", "w").write("aliasing on %s %.1f : %s\n" % (max_err_axis, max_err, fname))
+            open(fname + ".aliasing", "w").write(f"aliasing on {max_err_axis} {max_err:.1f} : {fname}\n")
         except Exception:
             pass
 

--- a/tools/isb_extract.py
+++ b/tools/isb_extract.py
@@ -3,7 +3,6 @@
 '''
 extract ISBH and ISBD messages from AP_Logging files into a csv file
 '''
-from __future__ import print_function
 
 import numpy
 import os
@@ -23,7 +22,7 @@ def mavfft_fttd(logfile):
     '''display fft for raw ACC data in logfile'''
 
     '''object to store data about a single FFT plot'''
-    class PlotData(object):
+    class PlotData:
         def __init__(self, ffth):
             self.seqno = -1
             self.fftnum = ffth.N

--- a/tools/magfit.py
+++ b/tools/magfit.py
@@ -3,8 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from __future__ import print_function
-from builtins import range
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
@@ -142,7 +140,7 @@ def magfit(logfile):
         # fit again
         (offsets, field_strength) = fit_data(data)
 
-    print("Final    : %s  field_strength=%6.1f to %6.1f" % (
+    print("Final    : {}  field_strength={:6.1f} to {:6.1f}".format(
         offsets,
         radius(data[0], offsets), radius(data[-1], offsets)))
 

--- a/tools/magfit_WMM.py
+++ b/tools/magfit_WMM.py
@@ -60,16 +60,16 @@ class Correction:
         print("COMPASS_OFS%s_X %d" % (mag_idx, int(self.offsets.x)))
         print("COMPASS_OFS%s_Y %d" % (mag_idx, int(self.offsets.y)))
         print("COMPASS_OFS%s_Z %d" % (mag_idx, int(self.offsets.z)))
-        print("COMPASS_DIA%s_X %.3f" % (mag_idx, self.diag.x))
-        print("COMPASS_DIA%s_Y %.3f" % (mag_idx, self.diag.y))
-        print("COMPASS_DIA%s_Z %.3f" % (mag_idx, self.diag.z))
-        print("COMPASS_ODI%s_X %.3f" % (mag_idx, self.offdiag.x))
-        print("COMPASS_ODI%s_Y %.3f" % (mag_idx, self.offdiag.y))
-        print("COMPASS_ODI%s_Z %.3f" % (mag_idx, self.offdiag.z))
-        print("COMPASS_MOT%s_X %.3f" % (mag_idx, self.cmot.x))
-        print("COMPASS_MOT%s_Y %.3f" % (mag_idx, self.cmot.y))
-        print("COMPASS_MOT%s_Z %.3f" % (mag_idx, self.cmot.z))
-        print("COMPASS_SCALE%s %.2f" % (mag_idx, self.scaling))
+        print(f"COMPASS_DIA{mag_idx}_X {self.diag.x:.3f}")
+        print(f"COMPASS_DIA{mag_idx}_Y {self.diag.y:.3f}")
+        print(f"COMPASS_DIA{mag_idx}_Z {self.diag.z:.3f}")
+        print(f"COMPASS_ODI{mag_idx}_X {self.offdiag.x:.3f}")
+        print(f"COMPASS_ODI{mag_idx}_Y {self.offdiag.y:.3f}")
+        print(f"COMPASS_ODI{mag_idx}_Z {self.offdiag.z:.3f}")
+        print(f"COMPASS_MOT{mag_idx}_X {self.cmot.x:.3f}")
+        print(f"COMPASS_MOT{mag_idx}_Y {self.cmot.y:.3f}")
+        print(f"COMPASS_MOT{mag_idx}_Z {self.cmot.z:.3f}")
+        print(f"COMPASS_SCALE{mag_idx} {self.scaling:.2f}")
         if args.cmot:
             print("COMPASS_MOTCT 2")
 
@@ -272,7 +272,7 @@ def magfit(logfile):
     if args.lat != 0 and args.lon != 0:
         earth_field = mavextra.expected_earth_field_lat_lon(args.lat, args.lon)
         (declination,inclination,intensity) = mavextra.get_mag_field_ef(args.lat, args.lon)
-        print("Earth field: %s  strength %.0f declination %.1f degrees" % (earth_field, earth_field.length(), declination))
+        print(f"Earth field: {earth_field}  strength {earth_field.length():.0f} declination {declination:.1f} degrees")
 
     if args.att_source is not None:
         ATT_NAME = args.att_source
@@ -292,7 +292,7 @@ def magfit(logfile):
         if msg.get_type() == 'GPS' and msg.Status >= 3 and earth_field is None:
             earth_field = mavextra.expected_earth_field(msg)
             (declination,inclination,intensity) = mavextra.get_mag_field_ef(msg.Lat, msg.Lng)
-            print("Earth field: %s  strength %.0f declination %.1f degrees" % (earth_field, earth_field.length(), declination))
+            print(f"Earth field: {earth_field}  strength {earth_field.length():.0f} declination {declination:.1f} degrees")
         if msg.get_type() == ATT_NAME:
             ATT = msg
             # remove IMU sensor to body frame trim offsets to get back to the IMU sensor frame used by the EKFs
@@ -337,7 +337,7 @@ def magfit(logfile):
     data = data2
 
     print("Extracted %u points" % len(data))
-    print("Current: %s diag: %s offdiag: %s cmot: %s scale: %.2f" % (
+    print("Current: {} diag: {} offdiag: {} cmot: {} scale: {:.2f}".format(
         old_corrections.offsets, old_corrections.diag, old_corrections.offdiag, old_corrections.cmot, old_corrections.scaling))
     if len(data) == 0:
         return
@@ -358,7 +358,7 @@ def magfit(logfile):
         c.diag *= 1.0/scale_change
         c.offdiag *= 1.0/scale_change
 
-    print("New: %s diag: %s offdiag: %s cmot: %s scale: %.2f" % (
+    print("New: {} diag: {} offdiag: {} cmot: {} scale: {:.2f}".format(
         c.offsets, c.diag, c.offdiag, c.cmot, c.scaling))
 
     x = []

--- a/tools/magfit_compassmot.py
+++ b/tools/magfit_compassmot.py
@@ -3,8 +3,6 @@
 '''
 estimate COMPASS_MOT_* parameters for throttle based compensation
 '''
-from __future__ import print_function
-from builtins import range
 import math
 
 from argparse import ArgumentParser
@@ -72,7 +70,7 @@ def magfit(logfile):
     print("Extracted %u data points" % len(data))
 
     (cmot,r) = fit_data(data)
-    print("Fit    : %s  r: %s" % (cmot,r))
+    print(f"Fit    : {cmot}  r: {r}")
 
     x = range(len(data))
     errors = mag_error((cmot.x,cmot.y,cmot.z,r), data)

--- a/tools/magfit_delta.py
+++ b/tools/magfit_delta.py
@@ -4,8 +4,6 @@
 fit best estimate of magnetometer offsets using the algorithm from
 Bill Premerlani
 '''
-from __future__ import print_function
-from builtins import range
 
 import sys
 

--- a/tools/magfit_elliptical.py
+++ b/tools/magfit_elliptical.py
@@ -3,7 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from __future__ import print_function
 
 import sys, time, os, math
 
@@ -195,7 +194,7 @@ def magfit(logfile):
         # fit again
         (offsets, field_strength, diag, offdiag) = fit_data(data)
 
-    print("Final    : %s %s %s field_strength=%6.1f to %6.1f" % (
+    print("Final    : {} {} {} field_strength={:6.1f} to {:6.1f}".format(
         offsets, diag, offdiag,
         radius(data[0], offsets, diag, offdiag), radius(data[-1], offsets, diag, offdiag)))
 

--- a/tools/magfit_gps.py
+++ b/tools/magfit_gps.py
@@ -3,8 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from __future__ import print_function
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
@@ -19,13 +17,13 @@ args = parser.parse_args()
 from pymavlink import mavutil
 
 
-class vec3(object):
+class vec3:
     def __init__(self, x, y, z):
         self.x = x
         self.y = y
         self.z = z
     def __str__(self):
-        return "%.1f %.1f %.1f" % (self.x, self.y, self.z)
+        return f"{self.x:.1f} {self.y:.1f} {self.z:.1f}"
 
 def heading_error1(parm, data):
     from math import sin, cos, atan2, degrees

--- a/tools/magfit_motors.py
+++ b/tools/magfit_motors.py
@@ -3,8 +3,6 @@
 '''
 fit best estimate of magnetometer offsets, trying to take into account motor interference
 '''
-from __future__ import print_function
-from builtins import range
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
@@ -135,10 +133,10 @@ def magfit(logfile):
         # fit again
         (offsets, motor_ofs, field_strength) = fit_data(data)
 
-    print("Final    : %s  %s field_strength=%6.1f to %6.1f" % (
+    print("Final    : {}  {} field_strength={:6.1f} to {:6.1f}".format(
         offsets, motor_ofs,
         radius(data[0], offsets, motor_ofs), radius(data[-1], offsets, motor_ofs)))
-    print("mavgraph.py '%s' 'mag_field(RAW_IMU)' 'mag_field_motors(RAW_IMU,SENSOR_OFFSETS,(%f,%f,%f),SERVO_OUTPUT_RAW,(%f,%f,%f))'" % (
+    print("mavgraph.py '{}' 'mag_field(RAW_IMU)' 'mag_field_motors(RAW_IMU,SENSOR_OFFSETS,({:f},{:f},{:f}),SERVO_OUTPUT_RAW,({:f},{:f},{:f}))'".format(
         filename,
         offsets.x,offsets.y,offsets.z,
         motor_ofs.x, motor_ofs.y, motor_ofs.z))

--- a/tools/magfit_rotation_gps.py
+++ b/tools/magfit_rotation_gps.py
@@ -3,9 +3,6 @@
 '''
 fit best estimate of magnetometer rotation to GPS data
 '''
-from __future__ import print_function
-from builtins import range
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
@@ -21,7 +18,7 @@ from pymavlink.rotmat import Vector3, Matrix3
 from math import radians, degrees, sin, cos, atan2
 
 
-class Rotation(object):
+class Rotation:
     def __init__(self, roll, pitch, yaw, r):
         self.roll = roll
         self.pitch = pitch

--- a/tools/magfit_rotation_gyro.py
+++ b/tools/magfit_rotation_gyro.py
@@ -3,10 +3,7 @@
 '''
 fit best estimate of magnetometer rotation to gyro data
 '''
-from __future__ import print_function
 
-from builtins import range
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)
@@ -22,7 +19,7 @@ from pymavlink.rotmat import Vector3, Matrix3
 from math import radians
 
 
-class Rotation(object):
+class Rotation:
     def __init__(self, name, roll, pitch, yaw):
         self.name = name
         self.roll = roll
@@ -163,7 +160,7 @@ def magfit(logfile):
         if not r.is_90_degrees():
             continue
         if args.verbose:
-            print("%s err=%.2f" % (r, total_error[i]/count))
+            print(f"{r} err={total_error[i]/count:.2f}")
         if total_error[i] < best_err:
             best_i = i
             best_err = total_error[i]
@@ -173,7 +170,7 @@ def magfit(logfile):
         rotations[COMPASS_ORIENT],
         COMPASS_EXTERNAL))
     print("Best rotation is %s err=%.2f from %u points" % (r, best_err/count, count))
-    print("Please set AHRS_ORIENTATION=%s COMPASS_ORIENT=%s COMPASS_EXTERNAL=1" % (
+    print("Please set AHRS_ORIENTATION={} COMPASS_ORIENT={} COMPASS_EXTERNAL=1".format(
         rotations[AHRS_ORIENTATION],
         r))
 

--- a/tools/mavextract.py
+++ b/tools/mavextract.py
@@ -3,7 +3,6 @@
 '''
 extract one mode type from a log
 '''
-from __future__ import print_function
 
 import os
 import struct

--- a/tools/mavfft.py
+++ b/tools/mavfft.py
@@ -3,7 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from __future__ import print_function
 
 import numpy
 import pylab

--- a/tools/mavfft_int.py
+++ b/tools/mavfft_int.py
@@ -3,7 +3,6 @@
 '''
 interactively select accel and gyro data for FFT analysis
 '''
-from __future__ import print_function
 
 import numpy
 import pylab
@@ -44,16 +43,16 @@ def check_drops(data, msg, start, end):
     deltas = numpy.diff(seqcnt[start:end])
 #     print('ndeltas: ', len(deltas))
     duration = ts[end] - ts[start]
-    print(msg + ' duration: {0:.3f} seconds'.format(duration))
+    print(msg + f' duration: {duration:.3f} seconds')
     avg_rate = float(end - start - 1) / duration
-    print('average logging rate: {0:.0f} Hz'.format(avg_rate))
+    print(f'average logging rate: {avg_rate:.0f} Hz')
     ts_mean = numpy.mean(deltas) 
     dmin = numpy.min(deltas)
     dmax = numpy.max(deltas)
-    print('sample count delta min: {0}, max: {1}'.format(dmin, dmax))
+    print(f'sample count delta min: {dmin}, max: {dmax}')
     if (dmin != dmax):
         print('sample count delta mean: ', '{0:.2f}, std: {0:.2f}'.format(ts_mean, numpy.std(deltas)))
-    print('sensor sample rate: {0:.0f} Hz'.format(ts_mean * avg_rate))
+    print(f'sensor sample rate: {ts_mean * avg_rate:.0f} Hz')
 
     drop_lens = []
     drop_times = []
@@ -62,9 +61,9 @@ def check_drops(data, msg, start, end):
         if (deltas[i] > 1.5 * ts_mean):
             drop_lens.append(deltas[i])
             drop_times.append(ts[start+i])
-            print('dropout at sample {0}: length {1}'.format(start+i, deltas[i]))
+            print(f'dropout at sample {start+i}: length {deltas[i]}')
     
-    print('{0:d} sample intervals > {1:.3f}'.format(len(drop_lens), 1.5 * ts_mean))
+    print(f'{len(drop_lens):d} sample intervals > {1.5 * ts_mean:.3f}')
     return avg_rate
     
 def fft(logfile):
@@ -152,18 +151,18 @@ def fft(logfile):
         # check for dropouts: (delta > 1)
         avg_rate = check_drops(data, 'ACC1', s_start, s_end)
         
-        title = 'FFT input: {0:s} ACC1[{1:d}:{2:d}], {3:d} samples'.format(logfile, s_start, s_end, n_samp)
-        currentAxes.set_xlabel('sample index : nsamples: {0:d}, avg rate: {1:.0f} Hz'.format(n_samp, avg_rate))
+        title = f'FFT input: {logfile:s} ACC1[{s_start:d}:{s_end:d}], {n_samp:d} samples'
+        currentAxes.set_xlabel(f'sample index : nsamples: {n_samp:d}, avg rate: {avg_rate:.0f} Hz')
         preview.canvas.set_window_title(title)
         preview.savefig('acc1z.png')
             
         for msg in ['ACC1', 'GYR1', 'ACC2', 'GYR2']:
             if msg.startswith('ACC'):
                 prefix = 'Acc'
-                title = '{2} FFT [{0:d}:{1:d}]'.format(s_start, s_end, msg)
+                title = f'{msg} FFT [{s_start:d}:{s_end:d}]'
             else:
                 prefix = 'Gyr'
-                title = '{2} FFT [{0:d}:{1:d}]'.format(s_start, s_end, msg)
+                title = f'{msg} FFT [{s_start:d}:{s_end:d}]'
             
             # check for dropouts    
             data[msg+'.rate'] = check_drops(data, msg, s_start, s_end)
@@ -188,7 +187,7 @@ def fft(logfile):
                 # remove mean
                 avg[axis] = numpy.mean(d)
                 d -= avg[axis]
-                print('{1} DC component: {0:.3f}'.format(avg[axis], field))
+                print(f'{field} DC component: {avg[axis]:.3f}')
                 # transform
                 d_fft = numpy.fft.rfft(d)
                 abs_fft[axis] = numpy.abs(d_fft)
@@ -207,8 +206,8 @@ def fft(logfile):
             fftwin.canvas.set_window_title(title)
             fftwin.gca().set_ylim(-90, 0)
             pylab.legend(loc='upper right')
-            pylab.xlabel('Hz : res: ' + '{0:.3f}'.format(f_res))
-            pylab.ylabel('dB X {0:.3f} Y {1:.3f} Z {2:.3f}\n'.format(avg['X'], avg['Y'], avg['Z']))
+            pylab.xlabel('Hz : res: ' + f'{f_res:.3f}')
+            pylab.ylabel('dB X {:.3f} Y {:.3f} Z {:.3f}\n'.format(avg['X'], avg['Y'], avg['Z']))
             pylab.subplots_adjust(left=0.1, right=0.95, top=0.95, bottom=0.16)
             fftwin.savefig(msg + '_fft.png')
         

--- a/tools/mavfft_isb.py
+++ b/tools/mavfft_isb.py
@@ -3,7 +3,6 @@
 '''
 extract ISBH and ISBD messages from AP_Logging files and produce FFT plots
 '''
-from __future__ import print_function
 
 import numpy
 import os
@@ -33,7 +32,7 @@ def mavfft_fttd(logfile):
     '''display fft for raw ACC data in logfile'''
 
     '''object to store data about a single FFT plot'''
-    class PlotData(object):
+    class PlotData:
         def __init__(self, ffth):
             self.seqno = -1
             self.fftnum = ffth.N
@@ -67,7 +66,7 @@ def mavfft_fttd(logfile):
         def overlap_windows(self, plotdata):
             newplotdata = copy.deepcopy(self)
             if plotdata.tag() != self.tag():
-                print("Invalid FFT data tag (%s vs %s) for window overlap" % (plotdata.tag(), self.tag()))
+                print(f"Invalid FFT data tag ({plotdata.tag()} vs {self.tag()}) for window overlap")
                 return self
             if plotdata.fftnum <= self.fftnum:
                 print("Invalid FFT sequence (%u vs %u) for window overlap" % (plotdata.fftnum, self.fftnum))
@@ -255,9 +254,9 @@ def mavfft_fttd(logfile):
             scale_label="dB "
         if args.fft_output == 'lsd':
             if str(sensor).startswith("Gyro"):
-                pylab.ylabel('LSD $' + scale_label + 'd/s/\sqrt{Hz}$')
+                pylab.ylabel('LSD $' + scale_label + r'd/s/\sqrt{Hz}$')
             else:
-                pylab.ylabel('LSD $' + scale_label + 'm/s^2/\sqrt{Hz}$')
+                pylab.ylabel('LSD $' + scale_label + r'm/s^2/\sqrt{Hz}$')
         else:
             if str(sensor).startswith("Gyro"):
                 pylab.ylabel('PSD $' + scale_label + 'd^2/s^2/Hz$')
@@ -266,9 +265,9 @@ def mavfft_fttd(logfile):
 
         if hntch_mode is not None and hntch_option is not None and batch_mode is not None:
             textstr = '\n'.join((
-                r'%s tracking' % (hntch_mode_names[hntch_mode], ),
-                r'%s notch' % (hntch_option_names[hntch_option], ),
-                r'%s sampling' % (batch_mode_names[batch_mode], )))
+                fr'{hntch_mode_names[hntch_mode]} tracking',
+                fr'{hntch_option_names[hntch_option]} notch',
+                fr'{batch_mode_names[batch_mode]} sampling'))
 
             props = dict(boxstyle='round', facecolor='wheat', alpha=0.5)
 

--- a/tools/mavfft_pid.py
+++ b/tools/mavfft_pid.py
@@ -3,7 +3,6 @@
 '''
 fit estimate of PID oscillations
 '''
-from __future__ import print_function
 
 import numpy
 import pylab

--- a/tools/mavflightmodes.py
+++ b/tools/mavflightmodes.py
@@ -3,7 +3,6 @@
 '''
 show changes in flight modes
 '''
-from __future__ import print_function
 
 import datetime
 import os
@@ -77,7 +76,7 @@ def flight_modes(logfile):
             total_flight_time = total_flight_time + value
 
         for key, value in time_in_mode.items():
-            print('%-12s %s %.2f%%' % (key, str(datetime.timedelta(seconds=int(value))), (value / total_flight_time) * 100.0))
+            print(f'{key:<12} {str(datetime.timedelta(seconds=int(value)))} {(value / total_flight_time) * 100.0:.2f}%')
     else:
         #can't print time in mode if only one mode during flight
         print(previous_mode, " 100% of flight time")

--- a/tools/mavflighttime.py
+++ b/tools/mavflighttime.py
@@ -3,7 +3,6 @@
 '''
 work out total flight time for a mavlink log
 '''
-from __future__ import print_function
 
 import time
 import glob
@@ -53,11 +52,11 @@ def flight_time(logfile):
             continue
         t = time.localtime(m._timestamp)
         if groundspeed > args.groundspeed and not in_air:
-            print("In air at %s (percent %.0f%% groundspeed %.1f)" % (time.asctime(t), mlog.percent, groundspeed))
+            print(f"In air at {time.asctime(t)} (percent {mlog.percent:.0f}% groundspeed {groundspeed:.1f})")
             in_air = True
             start_time = time.mktime(t)
         elif groundspeed < args.groundspeed and in_air:
-            print("On ground at %s (percent %.1f%% groundspeed %.1f  time=%.1f seconds)" % (
+            print("On ground at {} (percent {:.1f}% groundspeed {:.1f}  time={:.1f} seconds)".format(
                 time.asctime(t), mlog.percent, groundspeed, time.mktime(t) - start_time))
             in_air = False
             total_time += time.mktime(t) - start_time

--- a/tools/mavgps_CEP.py
+++ b/tools/mavgps_CEP.py
@@ -5,7 +5,6 @@ calculate GPS CEP from DF or mavlink log for all present GPS modules
 
 This assumes the GPS modules were not moving during the test
 '''
-from builtins import range
 
 import os
 

--- a/tools/mavgpslag.py
+++ b/tools/mavgpslag.py
@@ -14,8 +14,6 @@ The code really only works when there is significant acceleration as well.
 You'll need to fly quite aggressively on a copter to get a result.
 
 '''
-from __future__ import print_function
-from builtins import range
 
 import os
 

--- a/tools/mavgpslock.py
+++ b/tools/mavgpslock.py
@@ -3,7 +3,6 @@
 '''
 show GPS lock events in a MAVLink log
 '''
-from __future__ import print_function
 
 import time
 

--- a/tools/mavgraph.py
+++ b/tools/mavgraph.py
@@ -3,9 +3,6 @@
 graph a MAVLink log file
 Andrew Tridgell August 2011
 '''
-from __future__ import print_function
-from builtins import input
-from builtins import range
 
 import datetime
 import matplotlib
@@ -210,7 +207,7 @@ if args.flightmode is not None and args.xaxis:
     sys.exit(1)
 
 if args.flightmode is not None and args.flightmode not in colourmap:
-    print("Unknown flight controller '%s' in specification of --flightmode (choose from %s)" % (args.flightmode, ",".join(colourmap.keys())))
+    print("Unknown flight controller '{}' in specification of --flightmode (choose from {})".format(args.flightmode, ",".join(colourmap.keys())))
     sys.exit(1)
 
 

--- a/tools/mavkml.py
+++ b/tools/mavkml.py
@@ -4,9 +4,7 @@
 simple kml export for logfiles
 Thomas Gubler <thomasgubler@gmail.com>
 '''
-from __future__ import print_function
 
-from builtins import range
 
 from argparse import ArgumentParser
 import simplekml

--- a/tools/mavlink_bitmask_decoder.py
+++ b/tools/mavlink_bitmask_decoder.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 
 from pymavlink import mavutil
 
@@ -17,7 +16,7 @@ def print_decode(messagetype, field, value):
             svalue = "!"
         if name is None:
             name = "[UNKNOWN]"
-        print("%s %s" % (svalue, name))
+        print(f"{svalue} {name}")
 
 
 parser = argparse.ArgumentParser(description=__doc__)

--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -6,7 +6,6 @@ assumed to be in the format that qgroundcontrol uses, which consists
 of a series of MAVLink packets, each with a 64 bit timestamp
 header. The timestamp is in microseconds since 1970 (unix epoch)
 '''
-from __future__ import print_function
 
 import array
 import fnmatch
@@ -141,7 +140,7 @@ if istlog and args.format == 'csv': # we know our fields from the get-go
         currentOffset = 1 # Store how many fields in we are for each message.
         for type in types:
             try:
-                typeClass = "MAVLink_{0}_message".format(type.lower())
+                typeClass = f"MAVLink_{type.lower()}_message"
                 fields += [type + '.' + x for x in inspect.getargspec(getattr(mavutil.mavlink, typeClass).__init__).args[1:]]
                 offsets[type] = currentOffset
                 currentOffset += len(fields)
@@ -188,7 +187,7 @@ while True:
     if m is None:
         # write the final csv line before exiting
         if args.format == 'csv' and csv_out:
-          csv_out[0] = "{:.8f}".format(last_timestamp)
+          csv_out[0] = f"{last_timestamp:.8f}"
           print(args.csv_sep.join(csv_out))
         break
     available_types.add(m.get_type())
@@ -244,7 +243,7 @@ while True:
         try:
             output.write(m.get_msgbuf())
         except Exception as ex:
-            print("Failed to write msg %s: %s" % (m.get_type(), str(ex)))
+            print(f"Failed to write msg {m.get_type()}: {str(ex)}")
 
     # If quiet is specified, don't display output to the terminal.
     if args.quiet:
@@ -296,7 +295,7 @@ while True:
 
         # Otherwise if this is a new timestamp, print out the old output data, and store the current message for later output.
         else:
-            csv_out[0] = "{:.8f}".format(last_timestamp)
+            csv_out[0] = f"{last_timestamp:.8f}"
             print(args.csv_sep.join(csv_out))
             if isbin:
                 csv_out = [str(data[y]) if y != "timestamp" else "" for y in fields]

--- a/tools/mavloss.py
+++ b/tools/mavloss.py
@@ -3,7 +3,6 @@
 '''
 show MAVLink packet loss
 '''
-from __future__ import print_function
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/mavmission.py
+++ b/tools/mavmission.py
@@ -3,7 +3,6 @@
 '''
 extract mavlink mission from log
 '''
-from __future__ import print_function
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/mavmsgstats.py
+++ b/tools/mavmsgstats.py
@@ -53,7 +53,7 @@ def show_stats(logfile):
     print("Total size: %u" % total_size)
     for (name,size) in pairs:
         if size > 0:
-            print("%-4s %.2f%%" % (name, 100.0 * size / total_size))
+            print(f"{name:<4} {100.0 * size / total_size:.2f}%")
 
     print("")
     category_total = 0
@@ -66,7 +66,7 @@ def show_stats(logfile):
                     break
         category_total += total
         if total > 0:
-            print("@%s %.2f%%" % (c, 100.0 * total / total_size))
+            print(f"@{c} {100.0 * total / total_size:.2f}%")
     print("@OTHER %.2f%%" % (100.0 * (total_size-category_total) / total_size))
 
 for filename in args.logs:

--- a/tools/mavparms.py
+++ b/tools/mavparms.py
@@ -3,7 +3,6 @@
 '''
 extract mavlink parameter values
 '''
-from __future__ import print_function
 
 
 import time
@@ -38,7 +37,7 @@ def mavparms(logfile):
             value = m.Value
         if len(pname) > 0:
             if args.changesOnly is True and pname in parms and parms[pname] != value:
-                print("%s %-15s %.6f -> %.6f" % (time.asctime(time.localtime(m._timestamp)), pname, parms[pname], value))
+                print(f"{time.asctime(time.localtime(m._timestamp))} {pname:<15} {parms[pname]:.6f} -> {value:.6f}")
 
             parms[pname] = value
 
@@ -50,4 +49,4 @@ if (args.changesOnly is False):
     keys = list(parms.keys())
     keys.sort()
     for p in keys:
-        print("%-15s %.6f" % (p, parms[p]))
+        print(f"{p:<15} {parms[p]:.6f}")

--- a/tools/mavplayback.py
+++ b/tools/mavplayback.py
@@ -6,11 +6,9 @@ realtime mavlink stream
 
 Useful for visualising flights
 '''
-from __future__ import print_function
 from future import standard_library
 standard_library.install_aliases()
 
-from builtins import object
 
 import os
 import sys
@@ -48,7 +46,7 @@ def LoadImage(filename):
     return tkinter.PhotoImage(file=path)
 
 
-class App(object):
+class App:
     def __init__(self, filename):
         self.root = tkinter.Tk()
 

--- a/tools/mavsearch.py
+++ b/tools/mavsearch.py
@@ -3,7 +3,6 @@
 '''
 search a set of log files for a condition
 '''
-from __future__ import print_function
 
 from pymavlink import mavutil
 

--- a/tools/mavsigloss.py
+++ b/tools/mavsigloss.py
@@ -3,7 +3,6 @@
 '''
 show times when signal is lost
 '''
-from __future__ import print_function
 
 import time
 
@@ -50,7 +49,7 @@ def sigloss(logfile):
             t = m._timestamp
         if last_t != 0:
             if t - last_t > args.deltat:
-                print("Sig lost for %.1fs at %s" % (t-last_t, time.asctime(time.localtime(t))))
+                print(f"Sig lost for {t-last_t:.1f}s at {time.asctime(time.localtime(t))}")
         last_t = t
 
 total = 0.0

--- a/tools/mavsplit_sysid.py
+++ b/tools/mavsplit_sysid.py
@@ -3,7 +3,6 @@
 '''
 split log by system ID
 '''
-from __future__ import print_function
 
 import os
 import struct

--- a/tools/mavsummarize.py
+++ b/tools/mavsummarize.py
@@ -3,8 +3,6 @@
 '''
 Summarize MAVLink logs. Useful for identifying which log is of interest in a large set.
 '''
-from __future__ import print_function
-from builtins import object
 
 import glob
 import time
@@ -22,7 +20,7 @@ from pymavlink import mavutil
 from pymavlink.mavextra import distance_two
 
 
-class Totals(object):
+class Totals:
     def __init__(self):
         self.time = 0
         self.distance = 0
@@ -31,8 +29,8 @@ class Totals(object):
     def print_summary(self):
         print("===============================")
         print("Num Flights : %u" % self.flights)
-        print("Total distance : {:0.2f}m".format(self.distance))
-        print("Total time (mm:ss): {:3.0f}:{:02.0f}".format(self.time / 60, self.time % 60))
+        print(f"Total distance : {self.distance:0.2f}m")
+        print(f"Total time (mm:ss): {self.time / 60:3.0f}:{self.time % 60:02.0f}")
 
 
 totals = Totals()
@@ -51,7 +49,7 @@ def PrintSummary(logfile):
     first_gps_msg = None # The last GPS message received
     true_time = None # Track the first timestamp found that corresponds to a UNIX timestamp
 
-    types = set(['HEARTBEAT', 'GPS_RAW_INT'])
+    types = {'HEARTBEAT', 'GPS_RAW_INT'}
 
     while True:
         m = mlog.recv_match(condition=args.condition, type=types)
@@ -129,7 +127,7 @@ def PrintSummary(logfile):
     # (MAVLink didn't exist until 2009)
     if true_time:
         start_time_str = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(true_time))
-        print("Log started at about {}".format(start_time_str))
+        print(f"Log started at about {start_time_str}")
     else:
         print("Warning: No absolute timestamp found in datastream. No starting time can be provided for this log.")
 
@@ -138,17 +136,17 @@ def PrintSummary(logfile):
         first_gps_position = (first_gps_msg.lat / 1e7, first_gps_msg.lon / 1e7)
         last_gps_position = (last_gps_msg.lat / 1e7, last_gps_msg.lon / 1e7)
         print("Travelled from ({0[0]}, {0[1]}) to ({1[0]}, {1[1]})".format(first_gps_position, last_gps_position))
-        print("Total distance : {:0.2f}m".format(total_dist))
+        print(f"Total distance : {total_dist:0.2f}m")
     else:
         print("Warning: No GPS data found, can't give position summary.")
 
     # Print out the rest of the results.
     total_time = timestamp - start_time
-    print("Total time (mm:ss): {:3.0f}:{:02.0f}".format(total_time / 60, total_time % 60))
+    print(f"Total time (mm:ss): {total_time / 60:3.0f}:{total_time % 60:02.0f}")
     # The autonomous time should be good, as a steady HEARTBEAT is required for MAVLink operation
-    print("Autonomous sections: {}".format(autonomous_sections))
+    print(f"Autonomous sections: {autonomous_sections}")
     if autonomous_sections > 0:
-        print("Autonomous time (mm:ss): {:3.0f}:{:02.0f}".format(auto_time / 60, auto_time % 60))
+        print(f"Autonomous time (mm:ss): {auto_time / 60:3.0f}:{auto_time % 60:02.0f}")
 
     totals.time += total_time
     totals.distance += total_dist

--- a/tools/mavtelemetry_datarates.py
+++ b/tools/mavtelemetry_datarates.py
@@ -11,7 +11,6 @@ Released under GNU GPL version 3 or later
 
 from future import standard_library
 standard_library.install_aliases()
-from builtins import str
 
 ## Generate window for calculating the datasize
 from tkinter import Tk, Text, TOP, BOTH, X, Y, N, LEFT,RIGHT, CENTER, RIDGE, VERTICAL, END, IntVar, IntVar, Scrollbar

--- a/tools/mavtogpx.py
+++ b/tools/mavtogpx.py
@@ -4,7 +4,6 @@
 example program to extract GPS data from a mavlink log, and create a GPX
 file, for loading into google earth
 '''
-from __future__ import print_function
 
 import time
 
@@ -26,14 +25,14 @@ def mav_to_gpx(infilename, outfilename):
 
     def process_packet(timestamp, lat, lon, alt, hdg, v):
         t = time.localtime(timestamp)
-        outf.write('''<trkpt lat="%s" lon="%s">
-  <ele>%s</ele>
-  <time>%s</time>
-  <course>%s</course>
-  <speed>%s</speed>
+        outf.write('''<trkpt lat="{}" lon="{}">
+  <ele>{}</ele>
+  <time>{}</time>
+  <course>{}</course>
+  <speed>{}</speed>
   <fix>3d</fix>
 </trkpt>
-''' % (lat, lon, alt,
+'''.format(lat, lon, alt,
        time.strftime("%Y-%m-%dT%H:%M:%SZ", t),
        hdg, v))
 

--- a/tools/mavtomfile.py
+++ b/tools/mavtomfile.py
@@ -3,8 +3,6 @@
 '''
 convert a MAVLink tlog file to a MATLab mfile
 '''
-from __future__ import print_function
-from builtins import range
 
 import os
 import re
@@ -32,7 +30,7 @@ def process_tlog(filename):
     # note that Octave doesn't like any extra '.', '*', '-', characters in the filename
     (head, tail) = os.path.split(filename)
     basename = '.'.join(tail.split('.')[:-1])
-    mfilename = re.sub('[\.\-\+\*]','_', basename) + '.m'
+    mfilename = re.sub(r'[\.\-\+\*]','_', basename) + '.m'
     # Octave also doesn't like files that don't start with a letter
     if re.match('^[a-zA-z]', mfilename) is None:
         mfilename = 'm_' + mfilename

--- a/tools/python_array_test_recv.py
+++ b/tools/python_array_test_recv.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
-from __future__ import print_function
 from pymavlink import mavutil
 
 master = mavutil.mavlink_connection("udp::14555", dialect="array_test")

--- a/tools/python_array_test_send.py
+++ b/tools/python_array_test_send.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 import time
 from pymavlink import mavutil

--- a/tools/serial_control_to_shell.py
+++ b/tools/serial_control_to_shell.py
@@ -15,7 +15,7 @@ import fcntl
 
 from pymavlink import mavutil
 
-class SerialControlToShell(object):
+class SerialControlToShell:
     '''reads SERIAL_CONTROL packets and passes them to a shell, returning textual  results'''
 
     def __init__(self, connection_string, system_id=1, component_id=10):
@@ -68,12 +68,12 @@ class SerialControlToShell(object):
             if select.select([self.shell.stderr, self.shell.stdout],[],[],0)[0] != []:
                 try:
                     self.mixed_output_from_shell += self.shell.stderr.read()
-                except IOError as e:
+                except OSError as e:
                     if e.errno != 11:
                         raise
                 try:
                     self.mixed_output_from_shell += self.shell.stdout.read()
-                except IOError as e:
+                except OSError as e:
                     if e.errno != 11:
                         raise
 

--- a/tools/sertotcp.py
+++ b/tools/sertotcp.py
@@ -4,7 +4,6 @@
 map a serial port to an outgoing TCP connection
 Released under GNU GPLv3 or later
 """
-from __future__ import print_function
 
 from argparse import ArgumentParser
 import errno
@@ -50,7 +49,7 @@ while True:
         if b:
             try:
                 tcpsock.send(b)
-            except socket.error:
+            except OSError:
                 tcpsock.close()
                 tcpsock = None
                 continue
@@ -58,7 +57,7 @@ while True:
 
     try:
         b = tcpsock.recv(1000)
-    except socket.error as e:
+    except OSError as e:
         if e.args[0] in [errno.EWOULDBLOCK, errno.EAGAIN]:
             time.sleep(0.02)
             continue


### PR DESCRIPTION
Fixes #556
Fixes #555

This PR was created by running[`pyupgrade --py36-plus **/*.py`](https://github.com/asottile/pyupgrade) to drop support for [end of life](https://devguide.python.org/devcycle/#end-of-life-branches) versions of Python.
This removes 136 lines of legacy compatibility code while simplifying many other lines and given that [f-strings are faster](https://www.scivision.dev/python-f-string-speed) should speed up execution.   Adds README.md changes to streamline installation instructions. 