### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 pytest pytest-mock numpy
+          pip install codespell flake8 pytest pytest-mock numpy
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           sudo apt update
           sudo apt install -y libgtest-dev g++
@@ -31,6 +31,8 @@ jobs:
         with:
           node-version: '12'
       - run: npm install
+      - name: Discover typos with codespell
+        run: codespell --ignore-words-list="inout,ned,od,parm,parms,pevent,upto" --quiet-level=2
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names


### PR DESCRIPTION
Like #557, use https://github.com/codespell-project/codespell to discover and fix common typos across the codebase.