### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1019,7 +1019,7 @@ class DFReader_text(DFReader):
         else:
             self.data_map = mmap.mmap(self.filehandle.fileno(), self.data_len, mmap.MAP_PRIVATE, mmap.PROT_READ)
         self.offset = 0
-        self.delimeter = ", "
+        self.delimiter = ", "
 
         self.formats = {
             'FMT': DFFormat(0x80,
@@ -1043,7 +1043,7 @@ class DFReader_text(DFReader):
         if self.offset == -1:
             self.offset = self.data_map.find(b'FMT,')
             if self.offset != -1:
-                self.delimeter = ","
+                self.delimiter = ","
         self.type_list = None
 
     def rewind(self):
@@ -1132,7 +1132,7 @@ class DFReader_text(DFReader):
             s = self.data_map[self.offset:endline].rstrip()
             if sys.version_info.major >= 3:
                 s = s.decode('utf-8')
-            elements = s.split(self.delimeter)
+            elements = s.split(self.delimiter)
             self.offset = endline+1
             if len(elements) >= 2:
                 # this_line is good
@@ -1167,7 +1167,7 @@ class DFReader_text(DFReader):
             # name, len, format, headings
             ftype = int(elements[0])
             fname = elements[2]
-            if self.delimeter == ",":
+            if self.delimiter == ",":
                 elements = elements[0:4] + [",".join(elements[4:])]
             columns = elements[4]
             if fname == 'FMT' and columns == 'Type,Length,Name,Format':

--- a/generator/CS/MavlinkUtil.cs
+++ b/generator/CS/MavlinkUtil.cs
@@ -191,7 +191,7 @@ public static class MavlinkUtil
     }
 
     /// <summary>
-    /// Convert a struct to an array of bytes, struct fields being reperesented in 
+    /// Convert a struct to an array of bytes, struct fields being represented in 
     /// little endian (LSB first)
     /// </summary>
     /// <remarks>Note - assumes little endian host order</remarks>
@@ -235,7 +235,7 @@ public static class MavlinkUtil
     }
 
     /// <summary>
-    /// Convert a struct to an array of bytes, struct fields being reperesented in 
+    /// Convert a struct to an array of bytes, struct fields being represented in 
     /// big endian (MSB first)
     /// </summary>
     public static byte[] StructureToByteArrayBigEndian(params object[] list)

--- a/generator/javascript/test/mavlink10.js
+++ b/generator/javascript/test/mavlink10.js
@@ -159,7 +159,7 @@ describe("Generated MAVLink 1.0 protocol handler object", function() {
         // TODO: there is a option in python: robust_parsing. Maybe we should port this as well.
         // If robust_parsing is off, the following should be tested:
         // - (maybe) not returning subsequent errors for prefix errors
-        // - errors are thrown instead of catched inside
+        // - errors are thrown instead of caught inside
 
         // TODO: add tests for "try hard" parsing when implemented
 

--- a/generator/javascript/test/mavlink20.js
+++ b/generator/javascript/test/mavlink20.js
@@ -163,7 +163,7 @@ describe("Generated MAVLink 2.0 protocol handler object", function() {
         // TODO: there is a option in python: robust_parsing. Maybe we should port this as well.
         // If robust_parsing is off, the following should be tested:
         // - (maybe) not returning subsequent errors for prefix errors
-        // - errors are thrown instead of catched inside
+        // - errors are thrown instead of caught inside
 
         // TODO: add tests for "try hard" parsing when implemented
 

--- a/generator/javascript_stable/test/mavlink10.js
+++ b/generator/javascript_stable/test/mavlink10.js
@@ -159,7 +159,7 @@ describe("Generated MAVLink 1.0 protocol handler object", function() {
         // TODO: there is a option in python: robust_parsing. Maybe we should port this as well.
         // If robust_parsing is off, the following should be tested:
         // - (maybe) not returning subsequent errors for prefix errors
-        // - errors are thrown instead of catched inside
+        // - errors are thrown instead of caught inside
 
         // TODO: add tests for "try hard" parsing when implemented
 

--- a/generator/javascript_stable/test/mavlink20.js
+++ b/generator/javascript_stable/test/mavlink20.js
@@ -159,7 +159,7 @@ describe("Generated MAVLink 2.0 protocol handler object", function() {
         // TODO: there is a option in python: robust_parsing. Maybe we should port this as well.
         // If robust_parsing is off, the following should be tested:
         // - (maybe) not returning subsequent errors for prefix errors
-        // - errors are thrown instead of catched inside
+        // - errors are thrown instead of caught inside
 
         // TODO: add tests for "try hard" parsing when implemented
 

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -36,8 +36,8 @@ TYPE_MAX = {
     'uint64_t' : tmax(64),
 }
 
-# macroses stopwords. Used to replace bad enum entry name.
-MACROSES = {
+# macros stopwords. Used to replace bad enum entry name.
+MACROS = {
     'MIN': 'MIN_',
     'MAX': 'MAX_',
     'NO_DATA': 'NO_DATA_',  # fix uAvionix enum bug
@@ -308,7 +308,7 @@ def enum_remove_prefix(prefix, s):
         sl.insert(0, pl[-1])
 
     ret = '_'.join(sl)
-    return MACROSES.get(ret, ret)
+    return MACROS.get(ret, ret)
 
 
 def fix_int8_t(v):

--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -29,7 +29,7 @@ map = {
     }
     
 def generate_message_header(f, xml_list):
-    dedup = {}
+    dedupe = {}
     for xml in xml_list:
         print("generate_message_header " + xml.basename)
         if xml.little_endian:
@@ -68,8 +68,8 @@ def generate_message_header(f, xml_list):
             # we sort with primary key msgid, secondary key dialect
             for msgid in sorted(xml.message_names.keys()):
                 name = xml.message_names[msgid]
-                if name not in dedup:
-                    dedup[name] = 1
+                if name not in dedupe:
+                    dedupe[name] = 1
                     xml_list[0].message_infos_array += '        new message_info(%u, "%s", %u, %u, %u, typeof( mavlink_%s_t )),\n' % (msgid,
                                                                         name,
                                                                         xml.message_crcs[msgid],
@@ -82,8 +82,8 @@ def generate_message_header(f, xml_list):
                 crc = xml.message_crcs.get(msgid, None)
                 name = xml.message_names.get(msgid, None)
                 length = xml.message_lengths.get(msgid, None)
-                if name is not None and name not in dedup:
-                    dedup[name] = 1
+                if name is not None and name not in dedupe:
+                    dedupe[name] = 1
                     xml_list[0].message_infos_array += '        new message_info(%u, "%s", %u, %u, %u, typeof( mavlink_%s_t )), // none 24 bit\n' % (msgid, 
                                                                         name,
                                                                         crc,

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -850,7 +850,7 @@ unpacked = jspack.Unpack('cBBBBB', msgbuf.slice(0, 6));
         this.signing.sig_count += 1  
     } 
 
-    // it's a Buffer, zero-length means unsed 
+    // it's a Buffer, zero-length means unused 
     if (this.signing.secret_key.length != 0 ){ 
         var accept_signature = false; 
         if (signature_len == ${MAVHEAD}.MAVLINK_SIGNATURE_BLOCK_LEN){  

--- a/generator/swift/Tests/MAVLinkTests/DataExtensionsTests.swift
+++ b/generator/swift/Tests/MAVLinkTests/DataExtensionsTests.swift
@@ -132,14 +132,14 @@ class DataExtensionsTests: XCTestCase {
         let data = Data(bytes: [0x60, 0x61, 0x62, 0x0, 0x64, 0x65]) // "`ab\0de"
         let string = try! data.string(at: 1, length: 4)
         
-        XCTAssert(string == "ab", "Expect cutted off by null-termination string")
+        XCTAssert(string == "ab", "Expect cut off by null-termination string")
     }
     
     func testGetStringDidReadExactlyLengthSizedASCIIEncodedStringWithoutNullTermination() {
         let data = Data(bytes: [0x60, 0x61, 0x62, 0x63, 0x64, 0x65]) // "`abcde"
         let string = try! data.string(at: 1, length: 3)
         
-        XCTAssert(string == "abc", "Expect cutted off by length limit string")
+        XCTAssert(string == "abc", "Expect cut off by length limit string")
     }
     
     // MARK: Test enumeration<T: Enumeration>(at offset: Data.Index) throws -> T where T.RawValue: MAVLinkNumber


### PR DESCRIPTION
Split from https://github.com/ArduPilot/pymavlink/pull/559/commits
