### PR TITLE
Add Blimp modes

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -620,6 +620,8 @@ class DFReader(object):
                 self.mav_type = mavutil.mavlink.MAV_TYPE_ANTENNA_TRACKER
             elif m.Message.find("ArduSub") != -1:
                 self.mav_type = mavutil.mavlink.MAV_TYPE_SUBMARINE
+            elif m.Message.find("Blimp") != -1:
+                self.mav_type = mavutil.mavlink.MAV_TYPE_AIRSHIP
         if type == 'MODE':
             if hasattr(m,'Mode') and isinstance(m.Mode, str):
                 self.flightmode = m.Mode.upper()

--- a/mavutil.py
+++ b/mavutil.py
@@ -1996,6 +1996,13 @@ mode_mapping_sub = {
     19: 'MANUAL',
 }
 
+mode_mapping_blimp = {
+    0 : 'LAND',
+    1 : 'MANUAL',
+    2 : 'VELOCITY',
+    3 : 'LOITER',
+}
+
 AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     # copter
     mavlink.MAV_TYPE_HELICOPTER:  mode_mapping_acm,
@@ -2016,6 +2023,8 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     mavlink.MAV_TYPE_ANTENNA_TRACKER: mode_mapping_tracker,
     # sub
     mavlink.MAV_TYPE_SUBMARINE: mode_mapping_sub,
+    # blimp
+    mavlink.MAV_TYPE_AIRSHIP: mode_mapping_blimp,
 }
 
 


### PR DESCRIPTION
Adds blimp vehicle and its mode list to pymavlink so that MAVProxy can show the correct modes. 

Also needs the vehicle to be added in MAVProxy, see MAVProxy PR #925.