### PR TITLE
Mavfft add option to choose axis and add file name to legend 

### DIFF
--- a/tools/mavfft_isb.py
+++ b/tools/mavfft_isb.py
@@ -30,7 +30,7 @@ args = parser.parse_args()
 
 from pymavlink import mavutil
 
-def mavfft_fttd(logfile):
+def mavfft_fttd(logfile, multi_log):
     '''display fft for raw ACC data in logfile'''
 
     '''object to store data about a single FFT plot'''
@@ -254,7 +254,15 @@ def mavfft_fttd(logfile):
             # convert to db if requested
             if args.fft_scale == 'db':
                 psd = 10 * numpy.log10 (psd)
-            pylab.plot(freqmap[sensor], psd, label=axis)
+            # add file name to axis if doing multi-file plot
+            if multi_log:
+                # remove extension and path
+                (log_name, _, _) = logfile.rpartition('.')
+                (_, _, log_name) = log_name.rpartition('/')
+                legend_label = '%s (%s)' % (axis, log_name)
+            else:
+                legend_label = axis
+            pylab.plot(freqmap[sensor], psd, label=legend_label)
         pylab.legend(loc='upper right')
         pylab.xlabel('Hz')
         scale_label=''
@@ -283,7 +291,12 @@ def mavfft_fttd(logfile):
             pylab.text(0.5, 0.95, textstr, fontsize=12,
                 verticalalignment='top', bbox=props, transform=pylab.gca().transAxes)
 
+# auto set option for adding log names to legend label
+multi_log = False
+if len(args.logs) > 1:
+    multi_log = True
+
 for filename in args.logs:
-    mavfft_fttd(filename)
+    mavfft_fttd(filename, multi_log)
 
 pylab.show()

--- a/tools/mavfft_isb.py
+++ b/tools/mavfft_isb.py
@@ -24,6 +24,7 @@ parser.add_argument("--overlap", dest='fft_overlap', default=False, action='stor
 parser.add_argument("--output", dest='fft_output', default='psd', action='store', help="whether to output frequency spectrum information as power or linear spectral density: 'psd' or 'lsd'")
 parser.add_argument("--notch-params", default=False, action='store_true', help="whether to output estimated harmonic notch parameters")
 parser.add_argument("--notch-peak", dest='fft_peak', default=0, action='store', help="peak to select when setting notch parameters")
+parser.add_argument("--axis", dest='axis', default='XYZ', action='store', help="Select which axis to plot default: XYZ")
 
 args = parser.parse_args()
 
@@ -192,6 +193,9 @@ def mavfft_fttd(logfile):
             S2[thing_to_plot.tag()] = numpy.inner(window[thing_to_plot.tag()], window[thing_to_plot.tag()])
 
         for axis in [ "X","Y","Z" ]:
+            # only plot the selected axis
+            if axis not in args.axis:
+                continue
             # normalize data and convert to dps in order to produce more meaningful magnitudes
             if thing_to_plot.sensor_type == 1:
                 d = numpy.array(numpy.degrees(thing_to_plot.data[axis])) / float(thing_to_plot.multiplier)
@@ -226,6 +230,10 @@ def mavfft_fttd(logfile):
         print("Sensor: %s" % str(sensor))
         fig = pylab.figure(str(sensor))
         for axis in [ "X","Y","Z" ]:
+            # only plot the selected axis
+            if axis not in args.axis:
+                continue
+
             # normalize output to averaged PSD
             psd = 2 * (sum_fft[sensor][axis] / counts[sensor]) / (sample_rates[sensor] * S2[sensor])
 


### PR DESCRIPTION
Two features being added to mavfft_isb.py in two seperate commits.
1) Add option to be able to choose which axis to be able to plot (defaults to all).  Example:
![image](https://user-images.githubusercontent.com/34512430/132858278-914becf1-cb97-4303-b608-b1f279e6253a.png)


2) When doing multi file analysis, add the file name to the legend.  Example:
![image](https://user-images.githubusercontent.com/34512430/132857892-085a0318-8d62-42d5-8d27-8c4fa5b89d56.png)

