### PR TITLE
Use tobytes instead of tostring on arrays in Python3

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -242,11 +242,13 @@ class DFMessage(object):
             if is_py2:
                 if isinstance(v,unicode): # NOQA
                     v = str(v)
+                elif isinstance(v, array.array):
+                    v = v.tostring()
             else:
                 if isinstance(v,str):
                     v = bytes(v,'ascii')
-            if isinstance(v, array.array):
-                v = v.tostring()
+                elif isinstance(v, array.array):
+                    v = v.tobytes()
             if mul is not None:
                 v /= mul
                 v = int(round(v))

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -709,7 +709,10 @@ class MAVLink(object):
         def check_signature(self, msgbuf, srcSystem, srcComponent):
             '''check signature on incoming message'''
             if isinstance(msgbuf, array.array):
-                msgbuf = msgbuf.tostring()
+                try:
+                    msgbuf = msgbuf.tostring()
+                except:
+                    msgbuf = msgbuf.tobytes()
             timestamp_buf = msgbuf[-12:-6]
             link_id = msgbuf[-13]
             (tlow, thigh) = self.mav_sign_unpacker.unpack(timestamp_buf)


### PR DESCRIPTION
Closes https://github.com/ArduPilot/pymavlink/issues/587

Tested DFReader.py using mavlogdump

Tested signing using mavproxy and SITL.

Tracker's autotest sute also passes with these changes
