### PR TITLE
XSD: WIP tags in enums

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -208,6 +208,7 @@
         <xs:sequence>
             <xs:element ref="description" minOccurs="0"/>
         </xs:sequence>
+        <xs:attribute ref="since" />
     </xs:complexType>
 </xs:element>
 

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -254,7 +254,10 @@
 <xs:element name="enum">
     <xs:complexType>
         <xs:sequence>
-            <xs:element ref="deprecated" minOccurs="0" maxOccurs="1"/>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element ref="deprecated"/>
+                <xs:element ref="wip"/>
+            </xs:choice>
             <xs:element ref="description" minOccurs="0"/>
             <xs:element ref="entry" maxOccurs="unbounded"/>
         </xs:sequence>


### PR DESCRIPTION
Enums can also be work in progress. This enables them to be marked as such.

Further, this allows a "since" attribute to be added to the wip tag (but does not mandate it). The idea is that since allows you to easily see when the WIP tag was created, and thereby more easily assess whether the tag should be removed (or the whole element if implementation did not end up happening)

FYI @amilcarlucas - as per discussion in  https://github.com/mavlink/mavlink/issues/1732#issuecomment-960388791