### PR TITLE
Allow for arbitary location of message definitions

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -301,7 +301,10 @@ class Opts(object):
 def mavgen_python_dialect(dialect, wire_protocol):
     '''generate the python code on the fly for a MAVLink dialect'''
     dialects = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'dialects')
-    mdef = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'message_definitions')
+    if 'MDEF' in os.environ:
+        mdef = os.environ['MDEF']
+    else:
+        mdef = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'message_definitions')
     if wire_protocol == mavparse.PROTOCOL_0_9:
         py = os.path.join(dialects, 'v09', dialect + '.py')
         xml = os.path.join(dialects, 'v09', dialect + '.xml')


### PR DESCRIPTION
Message definition location for mavgen_python_dialect can be set using MDEF environment variable.
This fixes #596