### PR TITLE
Fixed message definitions directory for Mavlink2.0 messages

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -316,7 +316,7 @@ def mavgen_python_dialect(dialect, wire_protocol):
         py = os.path.join(dialects, 'v20', dialect + '.py')
         xml = os.path.join(dialects, 'v20', dialect + '.xml')
         if not os.path.exists(xml):
-            xml = os.path.join(mdef, 'v1.0', dialect + '.xml')
+            xml = os.path.join(mdef, 'v2.0', dialect + '.xml')
     opts = Opts(py, wire_protocol)
 
     # Python 2 to 3 compatibility

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,7 @@ def generate_content():
     dialects_path = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'dialects')
 
     v10_dialects = glob.glob(os.path.join(mdef_path, 'v1.0', '*.xml'))
-
-    # for now v2.0 uses same XML files as v1.0
-    v20_dialects = glob.glob(os.path.join(mdef_path, 'v1.0', '*.xml'))
+    v20_dialects = glob.glob(os.path.join(mdef_path, 'v2.0', '*.xml'))
 
     should_generate = not "NOGEN" in os.environ
     if should_generate:


### PR DESCRIPTION
Message definitions folder for Mavlink2.0 messages was previously called v1.0
This fixes #598