### PR TITLE
def/undef of MAVLINK_THIS_XML_HASH to MAVLINK_FILENAME_XML_…

### DIFF
--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -94,8 +94,7 @@ def generate_main_h(directory, xml):
     #error Wrong include order: MAVLINK_${basename_upper}.H MUST NOT BE DIRECTLY USED. Include mavlink.h from the same directory instead or set ALL AND EVERY defines from MAVLINK.H manually accordingly, including the #define MAVLINK_H call.
 #endif
 
-#undef MAVLINK_THIS_XML_HASH
-#define MAVLINK_THIS_XML_HASH ${xml_hash}
+#define MAVLINK_${basename_upper}_XML_HASH ${xml_hash}
 
 #ifdef __cplusplus
 extern "C" {
@@ -148,10 +147,8 @@ ${{message:#include "./mavlink_msg_${name_lower}.h"
 ${{include_list:#include "../${base}/${base}.h"
 }}
 
-#undef MAVLINK_THIS_XML_HASH
-#define MAVLINK_THIS_XML_HASH ${xml_hash}
 
-#if MAVLINK_THIS_XML_HASH == MAVLINK_PRIMARY_XML_HASH
+#if MAVLINK_${basename_upper}_XML_HASH == MAVLINK_PRIMARY_XML_HASH
 # define MAVLINK_MESSAGE_INFO {${message_info_array}}
 # define MAVLINK_MESSAGE_NAMES {${message_name_array}}
 # if MAVLINK_COMMAND_24BIT


### PR DESCRIPTION
Follows on from #537. As suggested by @peterbarker "Can you think of a reason we couldn't emit `MAVLINK_COMMON_XML_HASH` and `MAVLINK_MINIMAL_XML_HASH` instead of having to undef/redef MAVLINK_THIS_XML_HASH all the time?"

The aim of the def is to ensure that we load the primary and do some processing, then we process the include files but we DONT include the stuff at the end. We only include it when we come back to the primary file after doing all the includes. This is still what is happening.  I like it more because it is clear that we're asking "is common (say) the primary". I find it more readable.

Just FYI, the before and after zip is attached showing the file changes.

[compare-hash_variants.zip](https://github.com/ArduPilot/pymavlink/files/7859814/compare-hash_variants.zip)
 