### PR TITLE
mavgen_javascript.py: small bugfixes

### DIFF
--- a/generator/gen_js.sh
+++ b/generator/gen_js.sh
@@ -8,15 +8,17 @@ for protocol in 1.0 2.0; do
      # Generate MAVLink implementation
      ../tools/mavgen.py --lang=JavaScript_NextGen --wire-protocol=$protocol --output=javascript/implementations/mavlink_${base}_v${protocol}/mavlink.js $xml || exit 1
 
+
+
      # Create package.json file
      cat >javascript/implementations/mavlink_${base}_v${protocol}/package.json <<EOF
  {
     "name" : "mavlink_${base}_v${protocol}",
-    "version" : "0.0.1",
+    "version" : "0.0.3",
     "description" : "NextGen Implementation of the MAVLink protocol",
-    "keywords" : ["mavlink", "arduino", "megapilot", "ros", "robot", "uav", "drone", "awesome"],
-    "homepage": "https://github.com/mavlink/mavlink",
-    "bugs" : "https://github.com/mavlink/mavlink/issues",
+    "keywords" : ["mavlink", "arduino", "ardupilot", "ros", "robot", "uav", "drone", "awesome"],
+    "homepage": "https://github.com/ardupilot/mavlink",
+    "bugs" : "https://github.com/ardupilot/mavlink/issues",
     "license" : {
         "type" : "LGPL-3.0",
         "url" : "http://opensource.org/licenses/LGPL-3.0"
@@ -25,12 +27,13 @@ for protocol in 1.0 2.0; do
     "main" : "mavlink.js",
     "repository" : {
       "type" : "git",
-      "url" : "https://github.com/mavlink/mavlink"
+      "url" : "https://github.com/ardupilot/mavlink"
       },
     "dependencies" : {
       "underscore" : "",
-      "jspack":"",
-      "winston": ""
+      "winston": "",
+      "jspack": "file:local_modules/jspack",
+      "long": "file:local_modules/long"
     },
     "devDependencies" : {
       "should" : "",
@@ -39,6 +42,10 @@ for protocol in 1.0 2.0; do
     }
 }
 EOF
+
+    #symlink our custom jspack and 'long' so the package.json above can find them without needing multiple copies
+    rm ./javascript/implementations/mavlink_${base}_v${protocol}/local_modules
+    ln -s ../../local_modules ./javascript/implementations/mavlink_${base}_v${protocol}/
 
  done
 done

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -988,8 +988,10 @@ unpacked = jspack.Unpack('cBBBBB', msgbuf.slice(0, 6));
 def generate_footer(outf, xml):
     t.write(outf, """
 
-// Expose this code as a module
-module.exports = {${MAVHEAD}, ${MAVPROCESSOR}};
+// allow loading as both common.js (Node), and/or vanilla javascript in-browser
+if(typeof module === "object" && module.exports) {
+    module.exports = {${MAVHEAD}, ${MAVPROCESSOR}};
+}
 
 """, {'MAVHEAD': get_mavhead(xml), 'MAVPROCESSOR': get_mavprocessor(xml)})
 


### PR DESCRIPTION
- allow loading as both common.js (Node), and/or vanilla javascript in-browser
 - include customised jspack and long  as part of node package.json - 'npm install' now works in generated output folder without further tweaks.
-  bump version no in generated output as its never happened before.
- fix package.json urls and keywords.