### PR TITLE
XSD validation requires messages have at least one field

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -272,7 +272,7 @@
                     <xs:element ref="wip"/>
                 </xs:choice>
                 <xs:element ref="description" minOccurs="1" maxOccurs="1"/>
-                <xs:element ref="field" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="field" minOccurs="1" maxOccurs="unbounded"/>
             </xs:sequence>
             <!-- MavLink 2.0 extensions are optional hence minOccurs="0" -->
             <xs:sequence minOccurs="0" maxOccurs="1">


### PR DESCRIPTION
This enforces in the XSD/validator that every message must have at least one field.

@tridge @julianoes @auturgy Are you OK with this restriction? 
The cases I can think of where you might want to send an empty message are all commands - in almost every case you will want an ACK so you probably want to use a MAV_CMD. Also it is pragmatic.

This originates from #615, which demonstrates that mavgen_c generated code is broken if no field is specified. More generally, @peterbarker notes that:
- many of the generators might be broken
- empty messages may be a problem in some languages as zero-length objects can't have memory addresses.
