### PR TITLE
mavutil.py: mavtcp: recreate socket object in reconned for macosx

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1211,7 +1211,6 @@ class mavtcp(mavfile):
         mavfile.__init__(self, self.port.fileno(), "tcp:" + device, source_system=source_system, source_component=source_component, use_native=use_native)
 
     def do_connect(self):
-        self.port = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         retries = self.retries
         if retries <= 0:
             # try to connect at least once:
@@ -1219,6 +1218,7 @@ class mavtcp(mavfile):
         while retries >= 0:
             retries -= 1
             try:
+                self.port = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 self.port.connect(self.destination_addr)
                 break
             except Exception as e:


### PR DESCRIPTION
Invalid argument gets spewed otherwise

Closes https://github.com/ArduPilot/ardupilot/issues/20251

@andyp1per 