### PR TITLE
DFReader: provide __MAV__ message for log metadata

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -483,7 +483,11 @@ class DFReader(object):
         self.verbose = False
         self.params = {}
         self._flightmodes = None
-        self.messages = {}
+        self.messages = {
+            'MAV': self,
+            '__MAV__': self,  # avoids conflicts with messages actually called "MAV"
+        }
+        self.percent = 0
 
     def _rewind(self):
         '''reset state on rewind'''
@@ -492,7 +496,10 @@ class DFReader(object):
         # need their messages to disappear to.  If they want their own
         # copy they can copy.copy it!
         self.messages.clear()
-        self.messages['MAV'] = self
+        self.messages = {
+            'MAV': self,
+            '__MAV__': self,  # avoids conflicts with messages actually called "MAV"
+        }
         if self._flightmodes is not None and len(self._flightmodes) > 0:
             self.flightmode = self._flightmodes[0][0]
         else:


### PR DESCRIPTION
Logs now have messages called "MAV" in them, so you end up with a
keyerror if you look for MAV.percent in a condition.

Provide a very unlikely key for the log metadata

.... I wonder if we should choose a different magic key here?  This is DFReader which doesn't have anything to do with mavlink...
