### PR TITLE
XSD Validate - name attributes must not have whitespace

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -10,6 +10,12 @@
 
 <!-- definition of attributes -->
 <xs:attribute name="name"> <!-- used in enum,entry,message,field elements -->
+  <xs:simpleType>
+    <xs:restriction base="xs:string">
+        <xs:pattern value="[\w_]+"/> <!-- Force only word characters in names (a-zA-Z0-9_ and many unicode). No whitespace -->
+    </xs:restriction>
+  </xs:simpleType>
+
 </xs:attribute>
 <xs:attribute name="id" type="mavlinkMsgId"/> <!-- used in message elements -->
 <xs:attribute name="print_format" type="xs:string"/> <!-- used in field elements -->


### PR DESCRIPTION
Name attributes must not contain whitespace - that's required because they are used as ids for generated items.

This adds XSD validation to ensure that only word characters are used in name attributes or the `_` character. 

Note that the pattern check of `"\w+"` should have been fine because my understanding is that in normal RE this includes the underscore. However running the validator failed on underscores so I was forced to explicitly support them: `"[\w_]+"`

@peterbarker This follows on from https://github.com/mavlink/mavlink/pull/1824.

Note: 
- leading and trailing whitespace would actually be OK, because you could reasonably strip this in the parser. This does not allow it though, and it is never "needed".
- I think the parser should also strip leading/trailing spaces.
- running this on all.xml spots two more fails in AVSSUAS.xml : MODE_M300_HOTPOINT_MODE  and MODE_M300_NAVI_SDK_CTRL