### PR TITLE
Fix Wireshark parsing logic

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -313,14 +313,7 @@ def generate_field_dissector(outf, msg, field, offset, cmd=None, param=None):
         t.write(outf,
 """
     field_offset = offset + ${foffset}
-    value = padded(field_offset, ${fbytes}):${ftvbfunc}()
-    if (field_offset + ${fbytes} <= limit) then
-        subtree = tree:add_le(f.${fvar}, buffer(field_offset, ${fbytes}), value)
-    elseif (field_offset < limit) then
-        subtree = tree:add_le(f.${fvar}, buffer(field_offset, limit - offset - ${foffset}), value)
-    else
-        subtree = tree:add_le(f.${fvar}, value)
-    end
+    subtree, value = tree:add_le(f.${fvar}, padded(field_offset, ${fbytes}))
 """, {'foffset': offset + i * size, 'fbytes': size, 'ftvbfunc': tvb_func, 'fvar': field_var})
 
         if flag_enum is not None:


### PR DESCRIPTION
Previously, fields sometimes showed the wrong value, byte offsets were from the beginning of the IP packet, and truncated fields were omitted.
Now, the correct value is shown, byte offsets are from the beginning of the MAVLink packet, and truncated values are kept.

![image](https://user-images.githubusercontent.com/119948/167056978-5da117c9-bc24-4efb-9b9d-f6aa05f1b395.png)

![image](https://user-images.githubusercontent.com/119948/167057326-68dabe3c-85dd-4721-acca-9bc83d762422.png)
