### PR TITLE
DFReader: fixed missing instance messages

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -816,6 +816,7 @@ class DFReader_binary(DFReader):
                 if not idata in type_instances[mtype]:
                     # its a new one, need to parse it so we have the complete set of instances
                     type_instances[mtype].add(idata)
+                    self.offset = ofs
                     self._parse_next()
 
             self.counts[mtype] += 1


### PR DESCRIPTION
the parsing offset for new instance fields was wrong, leading to some
instances of messages being missing, for example, MAVExplorer not
setting GPS[1] messages in tab completion