### PR TITLE
mavgen_python: add method of last resort for displaying something abo…

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -105,11 +105,22 @@ def to_string(s):
     # so it's a nasty one. Let's grab as many characters as we can
     r = ""
     try:
-        for c in s:
-            r2 = r + c
-            r2 = r2.encode("ascii", "ignore")
-            x = u"%s" % r2
-            r = r2
+        for index, c in enumerate(s):
+            # check if all the remaining characters are zero
+            if s.count(s[index]) == len(s[index:]):
+                break
+            try:
+                r2 = c.encode("ascii", "ignore")
+                x = u"%s" % r2
+                r += x
+            except Exception:
+                # method of last resort, print the value recieved in hex
+                try:
+                    r2 = "\\\\" + str(hex(c))
+                    r += r2
+                except Exception as e:
+                    print(e)
+                    pass
     except Exception:
         pass
     return r + "_XXX"


### PR DESCRIPTION
…ut the incoming string bytes

Found it a little annoying while debugging a Lua driver that MAVProxy would only show "_XXX" if the byte values where outside of utf-8 range. This will give the best effort to display ascii characters and then just show the hex value when that fails. To me that would be better than nothing happening.

Similar goals as #568 