### PR TITLE
mavgen: add has_location to EnumEntry and use it when generating Pyth…

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -333,6 +333,7 @@ class EnumEntry(object):
         self.name = name
         self.description = description
         self.param = {}
+        self.has_location = False
 
 
 enums = {}
@@ -348,6 +349,9 @@ enums = {}
                 'enums["%s"][%d] = EnumEntry("%s", """%s""")\n'
                 % (e.name, int(entry.value), entry.name, description)
             )
+            if entry.has_location:
+                outf.write('enums["%s"][%d].has_location = True\n' %
+                           (e.name, int(entry.value),))
             for param in entry.param:
                 description = param.description.replace("\t", "    ")
                 outf.write(

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -163,7 +163,7 @@ class MAVEnumParam(object):
             self.description = description
 
 class MAVEnumEntry(object):
-    def __init__(self, name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0):
+    def __init__(self, name, value, description='', end_marker=False, autovalue=False, origin_file='', origin_line=0, has_location=False):
         self.name = name
         self.value = value
         self.description = description
@@ -172,6 +172,7 @@ class MAVEnumEntry(object):
         self.autovalue = autovalue  # True if value was *not* specified in XML
         self.origin_file = origin_file
         self.origin_line = origin_line
+        self.has_location = has_location
 
 class MAVEnum(object):
     def __init__(self, name, linenumber, description='', bitmask=False):
@@ -278,8 +279,15 @@ class MAVXML(object):
                 # check highest value
                 if (value > self.enum[-1].highest_value):
                     self.enum[-1].highest_value = value
+                has_location = attrs.get('hasLocation', False)
+                if has_location == 'true':
+                    has_location = True
+                elif has_location == 'false':
+                    has_location = False
+                if type(has_location) != bool:
+                    raise MAVParseError("invalid has_location value %s" % has_location)
                 # append the new entry
-                self.enum[-1].entry.append(MAVEnumEntry(attrs['name'], value, '', False, autovalue, self.filename, p.CurrentLineNumber))
+                self.enum[-1].entry.append(MAVEnumEntry(attrs['name'], value, '', False, autovalue, self.filename, p.CurrentLineNumber, has_location=has_location))
             elif in_element == "mavlink.enums.enum.entry.param":
                 check_attrs(attrs, ['index'], 'enum param')
                 self.enum[-1].entry[-1].param.append(


### PR DESCRIPTION
…on enums

Python's enumeration entries now get a has_location attribute.

![image](https://user-images.githubusercontent.com/7077857/175447271-36354684-e7ad-4a31-8d5a-eac17b89989d.png)
