### PR TITLE
fix description line endings in typescript enums

### DIFF
--- a/generator/mavgen_typescript.py
+++ b/generator/mavgen_typescript.py
@@ -34,7 +34,7 @@ def generate_enums(dir, enums):
             f.write("export enum {} {{\n".format(camelcase(e.name)))
             for entry in e.entry:
                 f.write(
-                    "\t{} = {}, // {}\n".format(entry.name, entry.value, entry.description.remove("\r"," ").remove("\n"," ")))
+                    "\t{} = {}, // {}\n".format(entry.name, entry.value, entry.description.replace("\r"," ").replace("\n"," ")))
             f.write("}")
 
 

--- a/generator/mavgen_typescript.py
+++ b/generator/mavgen_typescript.py
@@ -34,7 +34,7 @@ def generate_enums(dir, enums):
             f.write("export enum {} {{\n".format(camelcase(e.name)))
             for entry in e.entry:
                 f.write(
-                    "\t{} = {}, // {}\n".format(entry.name, entry.value, entry.description.rstrip("\r").rstrip("\n")))
+                    "\t{} = {}, // {}\n".format(entry.name, entry.value, entry.description.remove("\r"," ").remove("\n"," ")))
             f.write("}")
 
 


### PR DESCRIPTION
https://github.com/ArduPilot/pymavlink/blob/ac64ac01e3935f0bd861d86a9b255e88b789d0f4/generator/mavgen_typescript.py#L37

If a xml schema contains a multiline description on windows, the CRLF remains in the generated code leaving a syntax error
I believe this is due to the order of the rstrip operations
Think it would be better to replace with a space, so then comments will still have some sort of separator

![image](https://user-images.githubusercontent.com/101225045/177659469-4129571e-f3a4-484f-a90a-72c7077a87cf.png)
![image](https://user-images.githubusercontent.com/101225045/177659522-f0c02c2d-5b54-4660-8b06-b2e0196b2b36.png)

