### PR TITLE
isb_extract.py - unit and reading corrections

### DIFF
--- a/tools/isb_extract.py
+++ b/tools/isb_extract.py
@@ -31,7 +31,7 @@ def mavfft_fttd(logfile):
             self.instance = ffth.instance
             self.sample_rate_hz = ffth.smp_rate
             self.multiplier = ffth.mul
-            self.SampleUS = ffth.SampleUS
+            self.SampleUS = ffth.TimeUS
             self.data = {}
             self.data["X"] = []
             self.data["Y"] = []
@@ -119,9 +119,9 @@ def mavfft_fttd(logfile):
         f = files[fname]
         dt = 1.0e6 / p.sample_rate_hz
         for i in range(len(p.data['X'])):
-            x = p.data['X'][i]/p.multiplier
-            y = p.data['Y'][i]/p.multiplier
-            z = p.data['Z'][i]/p.multiplier
+            x = p.data['X'][i]/float(p.multiplier)
+            y = p.data['Y'][i]/float(p.multiplier)
+            z = p.data['Z'][i]/float(p.multiplier)
             f.write("%u,%.5f,%.5f,%.5f\n" % (int(p.SampleUS+i*dt), x, y, z))
     for f in files:
         files[f].close()


### PR DESCRIPTION
- The script isb_extract.py outputs the IMU values as integers (int divided by int = int) -> fixed
- My bin files have the us timestamps in the field TimeUS, not Sample US -> should be verified by other people