### PR TITLE
mavschema: add nanoseconds

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -86,6 +86,7 @@
     <xs:enumeration value="cs"/>       <!-- centiseconds -->
     <xs:enumeration value="ms"/>       <!-- milliseconds -->
     <xs:enumeration value="us"/>       <!-- microseconds -->
+    <xs:enumeration value="ns"/>       <!-- nanoseconds -->
     <xs:enumeration value="Hz"/>       <!-- Herz -->
     <xs:enumeration value="MHz"/>      <!-- Mega-Herz -->
     <!-- distance -->


### PR DESCRIPTION
For the TIMESYNC message we actually use nanoseconds, so to document that properly we need to add nanoseconds to the schema.

Related to https://github.com/mavlink/mavlink/pull/1878.