### PR TITLE
Fix python2 support due to https://github.com/ArduPilot/pymavlink/com…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 from setuptools.command.build_py import build_py
+from io import open
 # Work around mbcs bug in distutils.
 # http://bugs.python.org/issue10945
 import codecs


### PR DESCRIPTION
…mit/046ffa432928010ea051e74aec6f345e7cb9136a

this cause   TypeError: 'encoding' is an invalid keyword argument for this function

close https://github.com/ArduPilot/pymavlink/issues/722
Can be seen on ArduPilot environement testing CI : https://github.com/ArduPilot/ardupilot/runs/7927723395?check_suite_focus=true#step:5:4355