### PR TITLE
schema - Add Ampere-hours units

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -128,6 +128,7 @@
     <xs:enumeration value="cA"/>       <!-- centi-Ampere -->
     <xs:enumeration value="mA"/>       <!-- milli-Ampere -->
     <xs:enumeration value="mAh"/>      <!-- milli-Ampere hour -->
+    <xs:enumeration value="Ah"/>       <!-- Ampere hour -->
     <!-- magnetism -->
     <xs:enumeration value="mT"/>       <!-- milli-Tesla -->
     <xs:enumeration value="gauss"/>    <!-- Gauss -->


### PR DESCRIPTION
The units of Ampere hours (Ah) are required for the BATTERY_STATUS_V2 message defined in [RFC19](https://github.com/mavlink/rfcs/pull/19) and intended to merge in https://github.com/mavlink/mavlink/pull/1846

