### PR TITLE
DFReader.py: correct fatal error when stringifying FILE messages

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -238,7 +238,14 @@ class DFMessage(object):
                     noisy_nan = "\x7f\xf8\x00\x00\x00\x00\x00\x00"
                 if struct.pack(">d", val) != noisy_nan:
                     val = "qnan"
-            ret += "%s : %s, " % (c, val)
+
+            if is_py3:
+                ret += "%s : %s, " % (c, val)
+            else:
+                try:
+                    ret += "%s : %s, " % (c, val)
+                except UnicodeDecodeError:
+                    ret += "%s : %s, " % (c, to_string(val))
             col_count += 1
         if col_count != 0:
             ret = ret[:-2]


### PR DESCRIPTION
These are arbitrary binary data and don't have a single-byte representation we can use in this text output if we want plain-ascii.

Only do this on py2 as py3 doesn't have a problem.
