### PR TITLE
Improve to_string and x25crc

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -127,7 +127,7 @@ class DFFormat(object):
     def set_mult_ids(self, mult_ids):
         '''set mult IDs string from FMTU'''
         self.mult_ids = mult_ids
-            
+
     def __str__(self):
         return ("DFFormat(%s,%s,%s,%s)" %
                 (self.type, self.name, self.format, self.columns))
@@ -135,28 +135,12 @@ class DFFormat(object):
 # Swiped into mavgen_python.py
 def to_string(s):
     '''desperate attempt to convert a string regardless of what garbage we get'''
-    try:
-        return s.decode("utf-8")
-    except Exception as e:
-        pass
-    try:
-        s2 = s.encode('utf-8', 'ignore')
-        x = u"%s" % s2
-        return s2
-    except Exception:
-        pass
-    # so it's a nasty one. Let's grab as many characters as we can
-    r = ''
-    while s != '':
-        try:
-            r2 = r + s[0]
-            s = s[1:]
-            r2 = r2.encode('ascii', 'ignore')
-            x = u"%s" % r2
-            r = r2
-        except Exception:
-            break
-    return r + '_XXX'
+    if isinstance(s, str):
+        return s
+    if sys.version_info[0] == 2:
+        # In python2 we want to return unicode for passed in unicode
+        return s
+    return s.decode(errors="backslashreplace")
 
 def null_term(string):
     '''null terminate a string'''
@@ -1130,7 +1114,7 @@ class DFReader_text(DFReader):
             if mtype == "FMTU":
                 self.offset = ofs
                 self._parse_next()
-                
+
             ofs = self.data_map.find(b"\n", ofs)
             if ofs == -1:
                 break

--- a/DFReader.py
+++ b/DFReader.py
@@ -157,15 +157,15 @@ def to_string(s):
         except Exception:
             break
     return r + '_XXX'
-    
-def null_term(str):
+
+def null_term(string):
     '''null terminate a string'''
-    if isinstance(str, bytes):
-        str = to_string(str)
-    idx = str.find("\0")
+    if isinstance(string, bytes):
+        string = to_string(string)
+    idx = string.find("\0")
     if idx != -1:
-        str = str[:idx]
-    return str
+        string = string[:idx]
+    return string
 
 
 class DFMessage(object):

--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -4,37 +4,38 @@ MAVLink CRC-16/MCRF4XX code
 Copyright Andrew Tridgell
 Released under GNU LGPL version 3 or later
 '''
+import sys
 from builtins import object
 
 
 class x25crc(object):
-    '''CRC-16/MCRF4XX - based on checksum.h from mavlink library'''
+    """CRC-16/MCRF4XX - based on checksum.h from mavlink library"""
+
     def __init__(self, buf=None):
-        self.crc = 0xffff
+        self.crc = 0xFFFF
         if buf is not None:
-            if isinstance(buf, str):
-                self.accumulate_str(buf)
-            else:
-                self.accumulate(buf)
+            self.accumulate(buf)
 
     def accumulate(self, buf):
-        '''add in some more bytes'''
+        """add in some more bytes (it also accepts strings)"""
+        if sys.version_info[0] == 2:
+            if type(buf) is str:
+                buf = bytearray(buf)
+            elif type(buf).__name__ == 'unicode':
+                # we can't use the identifier unicode in python3
+                buf = bytearray(buf.encode())
+        elif type(buf) is str:
+            buf = buf.encode()
+
         accum = self.crc
         for b in buf:
-            tmp = b ^ (accum & 0xff)
-            tmp = (tmp ^ (tmp<<4)) & 0xFF
-            accum = (accum>>8) ^ (tmp<<8) ^ (tmp<<3) ^ (tmp>>4)
+            tmp = b ^ (accum & 0xFF)
+            tmp = (tmp ^ (tmp << 4)) & 0xFF
+            accum = (accum >> 8) ^ (tmp << 8) ^ (tmp << 3) ^ (tmp >> 4)
         self.crc = accum
 
     def accumulate_str(self, buf):
-        '''add in some more bytes'''
-        accum = self.crc
-        import array
-        bytes_array = array.array('B')
-        try:  # if buf is bytes
-            bytes_array.frombytes(buf)
-        except TypeError:  # if buf is str
-            bytes_array.frombytes(buf.encode())
-        except AttributeError:  # Python < 3.2
-            bytes_array.fromstring(buf)
-        self.accumulate(bytes_array)
+        """
+        Provided for backwards compatibility. accumulate now also works on strings.
+        """
+        return self.accumulate(buf)

--- a/mavutil.py
+++ b/mavutil.py
@@ -15,6 +15,9 @@ import json
 import re
 from pymavlink import mavexpression
 
+# We want to re-export x25crc here
+from pymavlink.generator.mavcrc import x25crc as x25crc
+
 is_py3 = sys.version_info >= (3,0)
 supports_type_annotations = sys.version_info >= (3,6)
 
@@ -2280,27 +2283,6 @@ def mode_string_acm(mode_number):
     if mode_number in mode_mapping_acm:
         return mode_mapping_acm[mode_number]
     return "Mode(%u)" % mode_number
-
-class x25crc(object):
-    '''CRC-16/MCRF4XX - based on checksum.h from mavlink library'''
-    def __init__(self, buf=''):
-        self.crc = 0xffff
-        self.accumulate(buf)
-
-    def accumulate(self, buf):
-        '''add in some more bytes'''
-        byte_buf = array.array('B')
-        if isinstance(buf, array.array):
-            byte_buf.extend(buf)
-        else:
-            byte_buf.fromstring(buf)
-        accum = self.crc
-        for b in byte_buf:
-            tmp = b ^ (accum & 0xff)
-            tmp = (tmp ^ (tmp<<4)) & 0xFF
-            accum = (accum>>8) ^ (tmp<<8) ^ (tmp<<3) ^ (tmp>>4)
-            accum = accum & 0xFFFF
-        self.crc = accum
 
 class MavlinkSerialPort(object):
         '''an object that looks like a serial port, but

--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -155,28 +155,13 @@ if args.csv_sep == "tab":
 
 # swiped from DFReader.py
 def to_string(s):
-    """desperate attempt to convert a string regardless of what garbage we get"""
-    try:
-        return s.decode("utf-8")
-    except Exception:
-        pass
-    try:
-        s2 = s.encode("utf-8", "ignore")
-        x = u"%s" % s2
-        return x
-    except Exception:
-        pass
-    # so it's a nasty one. Let's grab as many characters as we can
-    r = ""
-    try:
-        for c in s:
-            r2 = r + c
-            r2 = r2.encode("ascii", "ignore")
-            x = u"%s" % r2
-            r = r2
-    except Exception:
-        pass
-    return r + "_XXX"
+    '''desperate attempt to convert a string regardless of what garbage we get'''
+    if isinstance(s, str):
+        return s
+    if sys.version_info[0] == 2:
+        # In python2 we want to return unicode for passed in unicode
+        return s
+    return s.decode(errors="backslashreplace")
 
 def match_type(mtype, patterns):
     '''return True if mtype matches pattern'''
@@ -259,7 +244,7 @@ while True:
 
     if args.reduce_rate > 0 and reduce_rate_msg(m, args.reduce_rate):
         continue
-    
+
     if output is not None:
         if (isbin or islog) and m_type == "FMT":
             output.write(m.get_msgbuf())


### PR DESCRIPTION
This improves the to_string method (in theory with correct typing it should not be necessary, but I don't want to reason about types before using only python3 with type annotations).

It also improves the type support of the crc computation and removes an instance where the crc computation was copy-pasted.

This PR should fix https://github.com/ArduPilot/pymavlink/issues/716.