### PR TITLE
generator/C: fix node test in CI

### DIFF
--- a/generator/C/test/posix/Makefile
+++ b/generator/C/test/posix/Makefile
@@ -1,7 +1,7 @@
 # We really don't want -Wno-address-of-packed-member here, as it's hiding potential 
 # errors in the generator, but without it, we can't run the tests to completion. 
 # particular issues are with pointers to arrays right now. TODO - fix the generator and remove this.
-CFLAGS = -g -Wall -Werror -O0 -Wno-address-of-packed-member
+CFLAGS = -g -Wall -Werror -O0 -Wno-address-of-packed-member -Wno-unused-function
 TESTPROTOCOL = ardupilotmega
 ALLPROTOCOLS = minimal test common pixhawk ardupilotmega slugs ualberta
 


### PR DESCRIPTION
The node test in mavlink/mavlink CI fails because of:

```
standard/testsuite.h:29:13: error: ‘mavlink_test_standard’ defined but not used [-Werror=unused-function]

   29 | static void mavlink_test_standard(uint8_t system_id, ...
      |             ^~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
```

Ignoring the warning fixes CI.

See as an example:
https://github.com/mavlink/mavlink/actions/runs/3504071299/jobs/5869516184

FYI @davidbuzz, @hamishwillee, @auturgy 