### PR TITLE
Fix mavutil.mavtcpin not closing the accept()ed port on close()

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -920,7 +920,7 @@ class mavfile(object):
         self.mav.signing.timestamp = 0
 
 def set_close_on_exec(fd):
-    '''set the clone on exec flag on a file descriptor. Ignore exceptions'''
+    '''set the close on exec flag on a file descriptor. Ignore exceptions'''
     try:
         import fcntl
         flags = fcntl.fcntl(fd, fcntl.F_GETFD)
@@ -1321,6 +1321,8 @@ class mavtcpin(mavfile):
         self.port = None
 
     def close(self):
+        if self.port is not None:
+            self.port.close()
         self.listen.close()
 
     def recv(self,n=None):


### PR DESCRIPTION
Hi, `mavutil.mavtcpin` may leave the `accept()`ed port open after closing, leading to `ResourceWarning`s like this one:

```
<frozen importlib._bootstrap>:241: ResourceWarning: unclosed <socket.socket fd=10, family=AddressFamily.AF_INET, type=SocketKind.SOCK_STREAM, proto=0, laddr=('127.0.0.1', 24550)>
Object allocated at (most recent call last):
  ...
  File "/host/MY_MODULE", lineno 339
    mavlink_msg = self._mavlink.recv_match(
  File "/usr/local/lib/python3.10/site-packages/pymavlink/mavutil.py", lineno 502
    m = self.recv_msg()
  File "/usr/local/lib/python3.10/site-packages/pymavlink/mavutil.py", lineno 459
    s = self.recv(n)
  File "/usr/local/lib/python3.10/site-packages/pymavlink/mavutil.py", lineno 1317
    (self.port, addr) = self.listen.accept()
  File "/usr/local/lib/python3.10/socket.py", lineno 294
    sock = socket(self.family, self.type, self.proto, fileno=fd)
```

pymavlink 2.4.37 on both Windows and Linux (x86_64) and Python 3.10.

This MR fixes it. Also there's an unrelated `set_close_on_exec` docstring typo fix.