### PR TITLE
fix EOF error for cpp11

### DIFF
--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -41,6 +41,9 @@ MACROS = {
     'MIN': 'MIN_',
     'MAX': 'MAX_',
     'NO_DATA': 'NO_DATA_',  # fix uAvionix enum bug
+    'TRUE': 'TRUE_',
+    'FALSE': 'FALSE_',
+    'EOF': 'EOF_',
 }
 
 EType = collections.namedtuple('EType', ('type', 'max'))

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -41,6 +41,7 @@ MACROS = {
     'MIN': 'MIN_',
     'MAX': 'MAX_',
     'NO_DATA': 'NO_DATA_',  # fix uAvionix enum bug
+    'NULL': 'NULL_',
     'TRUE': 'TRUE_',
     'FALSE': 'FALSE_',
     'EOF': 'EOF_',


### PR DESCRIPTION
Fix issue: https://github.com/ArduPilot/pymavlink/issues/762

Changes identical to [this fix](https://github.com/mavlink/mavlink-gbp-release/blob/master/patch/pymavlink/generator/mavgen_cpp11.py#L44-L47)

Related to PR: https://github.com/ArduPilot/pymavlink/pull/698
We prefer solution from this PR, but both works and both are OK.