### PR TITLE
mavutil: do not consider MAV_AUTOPILOT_INVALID to be a vehicle heartbeat

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -356,6 +356,10 @@ class mavfile(object):
                         mavlink.MAV_TYPE_ADSB,
                         mavlink.MAV_TYPE_ONBOARD_CONTROLLER):
             return False
+        if msg.autopilot in frozenset([
+                mavlink.MAV_AUTOPILOT_INVALID
+                ]):
+            return False
         return True
 
     def post_message(self, msg):


### PR DESCRIPTION
This will avoid MAVProxy considering a Herelink to be a vehicle.

Here's the pair of heartbeats from hereLink:
```
2023-01-19 11:23:23.88: HEARTBEAT (id=0) (link=None) (signed=False) (seq=139) (src=42/250)
    type: 18 (MAV_TYPE_ONBOARD_CONTROLLER)
    autopilot: 8 (MAV_AUTOPILOT_INVALID)
    base_mode: 0
      ! MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
      ! MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
      ! MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 0
    system_status: 0 (MAV_STATE_UNINIT)
    mavlink_version: 3

2023-01-19 11:23:24.38: HEARTBEAT (id=0) (link=None) (signed=False) (seq=107) (src=42/100)
    type: 0 (MAV_TYPE_GENERIC)
    autopilot: 8 (MAV_AUTOPILOT_INVALID)
    base_mode: 0
      ! MAV_MODE_FLAG_CUSTOM_MODE_ENABLED
      ! MAV_MODE_FLAG_TEST_ENABLED
      ! MAV_MODE_FLAG_AUTO_ENABLED
      ! MAV_MODE_FLAG_GUIDED_ENABLED
      ! MAV_MODE_FLAG_STABILIZE_ENABLED
      ! MAV_MODE_FLAG_HIL_ENABLED
      ! MAV_MODE_FLAG_MANUAL_INPUT_ENABLED
      ! MAV_MODE_FLAG_SAFETY_ARMED
    custom_mode: 33554831
    system_status: 0 (MAV_STATE_UNINIT)
    mavlink_version: 3
```
