### PR TITLE
tools: use instancing for MAG msg in onboard logs

### DIFF
--- a/tools/magfit.py
+++ b/tools/magfit.py
@@ -105,14 +105,15 @@ def magfit(logfile):
             mag = Vector3(m.xmag, m.ymag, m.zmag)
             # add data point after subtracting the current offsets
             data.append(mag - offsets + noise())
-        if m.get_type() == "MAG" and not args.mag2:
-            offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
-            mag = Vector3(m.MagX,m.MagY,m.MagZ)
-            data.append(mag - offsets + noise())
-        if m.get_type() == "MAG2" and args.mag2:
-            offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
-            mag = Vector3(m.MagX,m.MagY,m.MagZ)
-            data.append(mag - offsets + noise())
+        if m.get_type() == "MAG":
+            if m.I==0 and not args.mag2:
+                offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
+                mag = Vector3(m.MagX,m.MagY,m.MagZ)
+                data.append(mag - offsets + noise())
+            elif m.I==1 and args.mag2:
+                offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
+                mag = Vector3(m.MagX,m.MagY,m.MagZ)
+                data.append(mag - offsets + noise())
 
     print("Extracted %u data points" % len(data))
     print("Current offsets: %s" % offsets)

--- a/tools/magfit_WMM.py
+++ b/tools/magfit_WMM.py
@@ -293,11 +293,6 @@ def magfit(logfile):
     BAT = None
     CTUN = None
 
-    if args.mag == 1:
-        mag_msg = 'MAG'
-    else:
-        mag_msg = 'MAG%s' % args.mag
-
     count = 0
     parameters = {}
 
@@ -327,7 +322,7 @@ def magfit(logfile):
 
     # extract MAG data
     while True:
-        msg = mlog.recv_match(type=['GPS',mag_msg,ATT_NAME,'CTUN','BARO', 'BAT'], condition=args.condition)
+        msg = mlog.recv_match(type=['GPS','MAG',ATT_NAME,'CTUN','BARO', 'BAT'], condition=args.condition)
         if msg is None:
             break
         if msg.get_type() == 'GPS' and msg.Status >= 3 and earth_field is None:
@@ -344,7 +339,7 @@ def magfit(logfile):
             BAT = msg
         if msg.get_type() == 'CTUN':
             CTUN = msg
-        if msg.get_type() == mag_msg and ATT is not None:
+        if msg.get_type() == 'MAG' and msg.I == (args.mag - 1) and ATT is not None:
             if count % args.reduce == 0:
                 data.append((msg,ATT,BAT,CTUN))
             count += 1

--- a/tools/magfit_compassmot.py
+++ b/tools/magfit_compassmot.py
@@ -61,7 +61,7 @@ def magfit(logfile):
         m = mlog.recv_match(condition=args.condition)
         if m is None:
             break
-        if m.get_type() == "MAG":
+        if m.get_type() == "MAG" and m.I==0:
             mag = Vector3(m.MagX, m.MagY, m.MagZ)
             data.append((mag, throttle))
         #if m.get_type() == "RCOU":

--- a/tools/magfit_elliptical.py
+++ b/tools/magfit_elliptical.py
@@ -140,14 +140,15 @@ def magfit(logfile):
             # add data point after subtracting the current offsets
             if offsets is not None:
                 data.append(mag - offsets + noise())
-        if m.get_type() == "MAG" and not args.mag2:
-            offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
-            mag = Vector3(m.MagX,m.MagY,m.MagZ)
-            data.append(mag - offsets + noise())
-        if m.get_type() == "MAG2" and args.mag2:
-            offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
-            mag = Vector3(m.MagX,m.MagY,m.MagZ)
-            data.append(mag - offsets + noise())
+        if m.get_type() == "MAG"
+            if m.I==0 and not args.mag2:
+                offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
+                mag = Vector3(m.MagX,m.MagY,m.MagZ)
+                data.append(mag - offsets + noise())
+            elif m.I==1 and args.mag2:
+                offsets = Vector3(m.OfsX,m.OfsY,m.OfsZ)
+                mag = Vector3(m.MagX,m.MagY,m.MagZ)
+                data.append(mag - offsets + noise())
 
     print("Extracted %u data points" % len(data))
     print("Current offsets: %s" % offsets)

--- a/tools/magfit_rotation_gyro.py
+++ b/tools/magfit_rotation_gyro.py
@@ -145,7 +145,7 @@ def magfit(logfile):
             elif m.get_type() == "IMU":
                 last_gyr = Vector3(m.GyrX,m.GyrY,m.GyrZ)
                 continue
-            elif last_gyr is not None:
+            elif m.I==0 and last_gyr is not None:
                 mag = Vector3(m.MagX,m.MagY,m.MagZ)
                 gyr = last_gyr
                 usec = m.TimeMS * 1000


### PR DESCRIPTION
The onboard messages `MAG` and `MAG2` have been replaced with a single `MAG` message with an instance variable. Code that was intended to read from the primary mag was reading from all mags, and code that was intended to read from `MAG2` wasn't working.

I have only tested magfit_WMM.py, but while I was there, decided to search for any other outdated usages of `MAG`