### PR TITLE
Fix/typescript

### DIFF
--- a/generator/javascript/node_modules/jspack
+++ b/generator/javascript/node_modules/jspack
@@ -1,1 +1,0 @@
-../local_modules/jspack

--- a/generator/javascript/node_modules/long
+++ b/generator/javascript/node_modules/long
@@ -1,1 +1,0 @@
-../local_modules/long

--- a/generator/mavgen_typescript.py
+++ b/generator/mavgen_typescript.py
@@ -45,7 +45,6 @@ def generate_classes(dir, registry, msgs, xml):
     ts_types = {"uint8_t": "number", "uint16_t": "number", "uint32_t": "number", "uint64_t": "number",
                 "int8_t": "number", "int16_t": "number", "int32_t": "number", "int64_t": "number",
                 "float": "number", "double": "number", "char": "string"}
-    magic_number = 0
 
     if not os.path.isdir(dir):
         os.mkdir(dir)
@@ -87,7 +86,7 @@ def generate_classes(dir, registry, msgs, xml):
                         f.write("\tpublic {}!: {};\n".format(field.name, ts_types[field.type]))
                 f.write("\tstatic MSG_ID: number = {};\n".format(m.id))
                 f.write("\tstatic MSG_NAME: string = '{}';\n".format(m.name))
-                f.write("\tstatic _crc_extra: number = {};\n".format(m.crc_extra))
+                f.write("\tstatic MAGIC_NUMBER: number = {};\n".format(m.crc_extra))
 
                 i = 0
                 f.write("\tstatic FIELDS: MavLinkPacketField[] = [\n")

--- a/generator/mavgen_typescript.py
+++ b/generator/mavgen_typescript.py
@@ -110,7 +110,7 @@ def generate_classes(dir, registry, msgs, xml):
                     """
                     f.write("\t\t/* {} */\n".format(field.description.strip()))
                     if field.array_length > 1:
-                        f.write("\t\tnew MavLinkPacketField('{}', '{}', {}, {}, {}, '{}', '{}',{}),\n".format(field.name, field.name, field.wire_offset, extension, field.type_length, field.type, field.units, field.array_length))
+                        f.write("\t\tnew MavLinkPacketField('{}', '{}', {}, {}, {}, '{}', '{}',{}),\n".format(field.name, field.name, field.wire_offset, extension, field.type_length, field.type +"[]", field.units, field.array_length))
                         offset += field.type_length * field.array_length
                     else:
                         f.write("\t\tnew MavLinkPacketField('{}', '{}', {}, {}, {}, '{}', '{}'),\n".format(field.name, field.name, field.wire_offset, extension, field.type_length, field.type, field.units))


### PR DESCRIPTION
While recently testing the typescript generation with the latest node-mavlink we found a number of issues. For example

- multi-line comments in the XML show up only as single line
- incorrect exports/imports
- other misc differences

This is now working with the current head of node-mavlink  for us.