### PR TITLE
mavschema.xsd: add superseded tag

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -62,14 +62,14 @@
     </xs:restriction>
   </xs:simpleType>
 </xs:attribute>
-<xs:attribute name="since"> <!-- used in deprecated elements -->
+<xs:attribute name="since"> <!-- used in elements: wip, superseded, deprecated -->
   <xs:simpleType>
     <xs:restriction base="xs:string">
-      <xs:pattern value="(20)\d{2}-(0[1-9]|1[012])"/>  <!-- restrict dates to 20YY-MM format -->
+      <xs:pattern value="(20)\d{2}-(0[1-9]|1[012])"/> <!-- restrict dates to 20YY-MM format -->
     </xs:restriction>
   </xs:simpleType>
 </xs:attribute>
-<xs:attribute name="replaced_by" type="xs:string"/> <!-- used in deprecated elements -->
+<xs:attribute name="replaced_by" type="xs:string"/> <!-- used in elements: superseded, deprecated -->
 
 <!-- mavlink message IDs are unsigned 24-bit values. -->
 <xs:simpleType name="mavlinkMsgId" id="mavlinkMsgId">
@@ -202,7 +202,16 @@
     </xs:complexType>
 </xs:element>
 
-<xs:element name="deprecated">
+<xs:element name="wip">
+    <xs:complexType mixed="true">
+        <xs:sequence>
+            <xs:element ref="description" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute ref="since" />
+    </xs:complexType>
+</xs:element>
+
+<xs:element name="superseded">
     <xs:complexType mixed="true">
         <xs:sequence>
             <xs:element ref="description" minOccurs="0"/>
@@ -212,12 +221,13 @@
     </xs:complexType>
 </xs:element>
 
-<xs:element name="wip">
+<xs:element name="deprecated">
     <xs:complexType mixed="true">
         <xs:sequence>
             <xs:element ref="description" minOccurs="0"/>
         </xs:sequence>
-        <xs:attribute ref="since" />
+        <xs:attribute ref="since" use="required"/>
+        <xs:attribute ref="replaced_by" use="required"/>
     </xs:complexType>
 </xs:element>
 
@@ -245,8 +255,9 @@
     <xs:complexType>
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="1">
-                <xs:element ref="deprecated"/>
                 <xs:element ref="wip"/>
+                <xs:element ref="superseded"/>
+                <xs:element ref="deprecated"/>
             </xs:choice>
             <xs:element ref="description" minOccurs="0"/>
             <xs:element ref="param" minOccurs="0" maxOccurs="unbounded" />
@@ -265,8 +276,9 @@
     <xs:complexType>
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="1">
-                <xs:element ref="deprecated"/>
                 <xs:element ref="wip"/>
+                <xs:element ref="superseded"/>
+                <xs:element ref="deprecated"/>
             </xs:choice>
             <xs:element ref="description" minOccurs="0"/>
             <xs:element ref="entry" maxOccurs="unbounded"/>
@@ -281,8 +293,9 @@
         <xs:sequence>
             <xs:sequence minOccurs="1" maxOccurs="1">
                 <xs:choice minOccurs="0" maxOccurs="1">
-                    <xs:element ref="deprecated"/>
-                    <xs:element ref="wip"/>
+                <xs:element ref="wip"/>
+                <xs:element ref="superseded"/>
+                <xs:element ref="deprecated"/>
                 </xs:choice>
                 <xs:element ref="description" minOccurs="1" maxOccurs="1"/>
                 <xs:element ref="field" minOccurs="1" maxOccurs="unbounded"/>


### PR DESCRIPTION
This adds a `superseded` tag. Once this is in. my intent is to divide the existing deprecated tags into those that are actually deprecated by the standard (and we hope to remove) and those that are just superseded by a new message, command, enum that we hope one day everyone will upgrade too.

The difference being that superseded is as much a hint to autopilots as users that there is something that might we worth upgrading to. 

This is a precondition to any kind of release process.