### PR TITLE
mavschema.xsd - max, min, increment on fields

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -232,6 +232,9 @@
         <xs:attribute ref="enum" />
         <xs:attribute ref="display" />
         <xs:attribute ref="units" />
+        <xs:attribute ref="increment"/>
+        <xs:attribute ref="minValue"/>
+        <xs:attribute ref="maxValue"/>        
         <xs:attribute ref="default" />
         <xs:attribute ref="instance" />
         <xs:attribute ref="invalid" />


### PR DESCRIPTION
For exactly the same reason that they are useful on parameters it would useful to have max, min, increment on fields - i.e. to restrict values as displayed in the UI and to make it easier to enforce ranges and test ranges in messages.


FYI @peterbarker @amilcarlucas , a high level view on the current schema is shown below prior to this PR. Are there any that we should have in both other than these? I don't think so, except possibly for decimalPlaces (not in any hurry to add it)

Another change we might make is to restrict some of these on `enum` - i.e. you shouldn't specify units if you have an enum and so on. I don't see it as a risk, but as a nice to have. OK?

---

MAV_CMD
  - attributes
    - value (an id number)
    - name
    - hasLocation | isDestination
  - wip | deprecated | superseded (?)
  - description

  - param (7)
    - description
    - attributes
      - index [1-7]
      - label
      - units
      - enum
      - decimalPlaces
      - increment
      - minValue
      - maxValue
      - reserved (for future use, default false)
      - default (default value of 0 or NaN, intended for reserved params).

MESSAGE
  - attributes:
    - id
    - name
  - wip | deprecated | superseded (?)
  - description
  - field (s)
    - type
    - name
    - enum (or units)
    - display ('bitmask')
    - units
    - print_format (?)
    - default (?)
    - instance
    - invalid
    
ENUM
  - attributes:
    - name
    - bitmask (true | false)
  - wip | deprecated | superseded (?)
  - description
  - entry (s)
    - attributes:
      - value (id)
      - name
    - description
    - wip | deprecated | superseded (?)