### PR TITLE
Run tests with big endian case also

### DIFF
--- a/generator/C/test/posix/Makefile
+++ b/generator/C/test/posix/Makefile
@@ -1,7 +1,7 @@
 # We really don't want -Wno-address-of-packed-member here, as it's hiding potential 
 # errors in the generator, but without it, we can't run the tests to completion. 
 # particular issues are with pointers to arrays right now. TODO - fix the generator and remove this.
-CFLAGS = -g -Wall -Werror -O0 -Wno-address-of-packed-member -Wno-unused-function
+CFLAGS = -g -Wall -Werror -O0 -Wno-address-of-packed-member -Wno-unused-function -DMAVLINK_ENDIAN=$(ENDIANESS)
 TESTPROTOCOL = ardupilotmega
 ALLPROTOCOLS = minimal test common pixhawk ardupilotmega slugs ualberta
 

--- a/test_generator.sh
+++ b/test_generator.sh
@@ -18,11 +18,17 @@ tools/mavgen.py --lang C $MDEF/v1.0/all.xml -o generator/C/include_v2.0 --wire-p
 tools/mavgen.py --lang C++11 $MDEF/v1.0/all.xml -o generator/CPP11/include_v2.0 --wire-protocol=2.0
 
 pushd generator/C/test/posix
-make clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega
 
+make ENDIANESS=MAVLINK_LITTLE_ENDIAN clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega
 # these test tools emit the test packet as hexadecimal and human-readable, other tools consume it as a cross-reference, we ignore the hex here.
 ./testmav1.0_ardupilotmega | egrep -v '(^fe|^fd)'
 ./testmav2.0_ardupilotmega | egrep -v '(^fe|^fd)'
+
+make ENDIANESS=MAVLINK_BIG_ENDIAN clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega
+# these test tools emit the test packet as hexadecimal and human-readable, other tools consume it as a cross-reference, we ignore the hex here.
+./testmav1.0_ardupilotmega | egrep -v '(^fe|^fd)'
+./testmav2.0_ardupilotmega | egrep -v '(^fe|^fd)'
+
 popd
 
 pushd generator/CPP11/test/posix


### PR DESCRIPTION
The test_generator.sh script verifies only LITTLE_ENDIAN (default) case, but does not verify MAVLINK_ENDIAN == MAVLINK_BIG_ENDIAN case at all.

Modified test script and test Makefile to add also big endian test run.
