### PR TITLE
Replace validator with xmlschema (XSD1.1 compliant)

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -249,12 +249,6 @@ def mavgen(opts, args):
                 for fieldItem in messageItem.iter('field'): #
                     if forbidden_names_re.search(fieldItem.get('name')):
                         xmlvalid = False
-                        #print(f"messageItem value: {entryItem.get('value')}")
-                        #print(f"messageItem name: {entryItem.get('name')}")
-                        #print(f"Fielditem name: {fieldItem.attrib}")
-                        #print(f"Fielditem name: {fieldItem.text}")
-                        #print(f"Entry name: {fieldItem.tostring(root, encoding='utf8').decode('utf8')}")
-                        #TODO: Print out the whole field?
                         raise Exception(
                             "Validation Error: Message : "
                             f"{messageItem.get('name')} ({messageItem.get('id')}) "

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-lxml>=3.6.0
+xmlschema>=2.2.3
 future>=0.15.2
 wheel>=0.37.1


### PR DESCRIPTION
The current validator is XSD 1.0 compliant. That means you can validate for order of elements, and number and type of elements. 
I'd like to update to an XSD 1.1 compliant validator, as XSD 1.1 allows validation using patterns, and inter-element validation. For example, with XSD 1.0 you can require that a command has 7 parameters, and that their index is between 1 and 7, but with XSD 1.1 you can also require that they be unique.

My main interest at this point is to add range checking - allowing us to validate in XSD the allow range(s) for the command and message IDs, and to add exclusion ranges so that we can reserve items more obviously inside the allocated ranges.

The only Python XSD1.1 validate I can find is this one: https://github.com/sissaschool/xmlschema

This update is pretty much a direct replacement. Right now it drops one feature - the ability to turn off strict checking of the types. I've raised a question here to see if there is a way to do this: https://github.com/sissaschool/xmlschema/issues/346

In many ways I prefer the existing parser, but there is no indication if or when it will get v1.1 parsing. Note that the existing parser is capable of doing the same kind of tests that I want, but only in Python, not in XSD. That is not really OK because we want others to be able to validate in their own programming languages if they so wish - so best to embed in the XSD file.