### PR TITLE
XSD: MAV_CMD missionOnly attribute

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -184,6 +184,7 @@
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
 <xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry has lat/lon/alt location -->
 <xs:attribute name="isDestination" type="xs:boolean" default="true"/>  <!-- entry is a destination -->
+<xs:attribute name="missionOnly" type="xs:boolean" default="true"/>  <!-- entry only makes sense in missions, not commands -->
 
 <!-- definition of complex elements -->
 <xs:element name="param">
@@ -255,6 +256,7 @@
         <xs:attribute ref="name" use="required"/>
         <xs:attribute ref="hasLocation"/>
         <xs:attribute ref="isDestination"/>
+        <xs:attribute ref="missionOnly"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
I'm auto-adding documentation for MAV_CMDs that would be better if sent in COMMAND_INT rather than COMMAND_LONG, based on the `hasLocation` and `isDestination` properties (in https://github.com/mavlink/mavlink/pull/1992).

There are some MAV_CMDs (specifically in fence) that have position, but make no sense in a command. This adds the `missionOnly` attribute that can be applied to the very small subset of mission items to exclude them from getting that note.

Note that at this point haven't found a use case for `commandOnly` - most commands might in theory be used in missions, though for many it is a bit unlikely. I guess we might add this to indicate those commands that really only intended for commands but if desired would address in a separate PR.