### PR TITLE
mavutil.py: add vtol mode mapping

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2106,6 +2106,9 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     mavlink.MAV_TYPE_COAXIAL:     mode_mapping_acm,
     # plane
     mavlink.MAV_TYPE_FIXED_WING: mode_mapping_apm,
+    mavlink.MAV_TYPE_VTOL_DUOROTOR: mode_mapping_apm,
+    mavlink.MAV_TYPE_VTOL_QUADROTOR: mode_mapping_apm,
+    mavlink.MAV_TYPE_VTOL_TILTROTOR: mode_mapping_apm,
     # rover
     mavlink.MAV_TYPE_GROUND_ROVER: mode_mapping_rover,
     # boat


### PR DESCRIPTION
Fixed a problem in which mode mapping was not set correctly when starting SITL for quadplane due to this PR.
https://github.com/ArduPilot/ardupilot/pull/21596
