### PR TITLE
Add altitudeOnly attribute

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -197,7 +197,7 @@
 <xs:attribute name="reserved" type="xs:boolean" default="false"/>      <!-- parameter is reserved -->
 
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
-<xs:attribute name="hasLocation" type="xs:boolean" default="false"/>    <!-- entry is an ROI or other non-destination (lat/lon/alt location in params 5, 6, 7). -->
+<xs:attribute name="hasLocation" type="xs:boolean" default="false"/> <!-- lat/lon/alt location in params 5, 6, 7 (entry contains location information). -->
 <xs:attribute name="isDestination" type="xs:boolean" default="false"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
 <xs:attribute name="hasAltitudeOnly" type="xs:boolean" default="false"/>  <!-- alt in param7 and lat/lon not in param 5/6 -->
 <xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -197,8 +197,9 @@
 <xs:attribute name="reserved" type="xs:boolean" default="false"/>      <!-- parameter is reserved -->
 
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
-<xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry has lat/lon/alt location -->
-<xs:attribute name="isDestination" type="xs:boolean" default="true"/>  <!-- entry is a destination -->
+<xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry is an ROI or other non-destination (lat/lon/alt location in params 5, 6, 7). -->
+<xs:attribute name="isDestination" type="xs:boolean" default="true"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
+<xs:attribute name="altitudeOnly" type="xs:boolean" default="true"/>  <!-- entry contains an altitude but no lat/lon (alt in param 7) -->
 <xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->
 
 <!-- definition of complex elements -->
@@ -287,9 +288,10 @@
         </xs:sequence>
         <xs:attribute ref="value" />
         <xs:attribute ref="name" use="required"/>
-        <xs:attribute ref="hasLocation"/>
+        <xs:attribute ref="hasLocation"/> <!-- should be choice with altitudeOnly, but can't enforce in XSD1.0 -->
+        <xs:attribute ref="altitudeOnly"/>
         <xs:attribute ref="isDestination"/>
-        <xs:attribute ref="missionOnly"/>
+        <xs:attribute ref="missionOnly"/> 
     </xs:complexType>
 </xs:element>
 

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -199,7 +199,7 @@
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
 <xs:attribute name="hasLocation" type="xs:boolean" default="false"/>    <!-- entry is an ROI or other non-destination (lat/lon/alt location in params 5, 6, 7). -->
 <xs:attribute name="isDestination" type="xs:boolean" default="false"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
-<xs:attribute name="altitudeOnly" type="xs:boolean" default="false"/>  <!-- entry contains an altitude but no lat/lon (alt in param 7) -->
+<xs:attribute name="hasAltitudeOnly" type="xs:boolean" default="false"/>  <!-- alt in param7 and lat/lon not in param 5/6 -->
 <xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->
 
 <!-- definition of complex elements -->
@@ -288,10 +288,10 @@
         </xs:sequence>
         <xs:attribute ref="value" />
         <xs:attribute ref="name" use="required"/>
-        <xs:attribute ref="hasLocation"/> <!-- should be choice with altitudeOnly, but can't enforce in XSD1.0 -->
-        <xs:attribute ref="altitudeOnly"/>
+        <xs:attribute ref="hasLocation"/> <!-- Mutually exclusive with hasAltitudeOnly (can't enforce in XSD1.0) -->
+        <xs:attribute ref="hasAltitudeOnly"/>
         <xs:attribute ref="isDestination"/>
-        <xs:attribute ref="missionOnly"/> 
+        <xs:attribute ref="missionOnly"/>
     </xs:complexType>
 </xs:element>
 

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -197,9 +197,9 @@
 <xs:attribute name="reserved" type="xs:boolean" default="false"/>      <!-- parameter is reserved -->
 
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
-<xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry is an ROI or other non-destination (lat/lon/alt location in params 5, 6, 7). -->
-<xs:attribute name="isDestination" type="xs:boolean" default="true"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
-<xs:attribute name="altitudeOnly" type="xs:boolean" default="true"/>  <!-- entry contains an altitude but no lat/lon (alt in param 7) -->
+<xs:attribute name="hasLocation" type="xs:boolean" default="false"/>    <!-- entry is an ROI or other non-destination (lat/lon/alt location in params 5, 6, 7). -->
+<xs:attribute name="isDestination" type="xs:boolean" default="false"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
+<xs:attribute name="altitudeOnly" type="xs:boolean" default="false"/>  <!-- entry contains an altitude but no lat/lon (alt in param 7) -->
 <xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->
 
 <!-- definition of complex elements -->


### PR DESCRIPTION
This adds an attribute in order to indicate a command has an altitude in param 7, but not a lat/lon in param 5/6. It also adds comments to note exactly what the other attributes mean (i.e. a lat/lon in param 3, 4 would not "count").

This allows more precise documentation about issues with using a altitude-only command.

This comes out of MAV call discussion summarised here: https://github.com/mavlink/mavlink/pull/1994#issuecomment-1581629423 . There was thought of modifying these to be hasLatLon, and hasAltitude, but decided to reduce churn.