### PR TITLE
Test on the current version of Python

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,6 +69,7 @@ jobs:
             flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
             mypy --config-file ./.github/workflows/mypy-generated.ini dialects/v10/*.py dialects/v20/*.py
           fi
+
       - name: Generate messages
         run: |
           ./test_generate_all.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false  # don't cancel if a job from the matrix fails
       matrix:
-        python-version: ['2.7', '3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
 
     steps:
       - uses: actions/checkout@v3
@@ -25,7 +25,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install flake8 pytest pytest-mock numpy
-          if [ "${{ matrix.python-version }}" != "2.7" ] && [ "${{ matrix.python-version }}" != "3.5" ]
+          if [ "${{ matrix.python-version }}" != "3.5" ]
           then
             pip install mypy
           fi
@@ -62,11 +62,9 @@ jobs:
 
       - name: Lint generated python code
         run: |
-          if [ "${{ matrix.python-version }}" = "2.7" ] || [ "${{ matrix.python-version }}" = "3.5" ]
+          flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
+          if [ "${{ matrix.python-version }}" != "3.5" ]
           then
-            flake8 --ignore='W503,E203,E501,E741' --statistics dialects/v10/python2/*.py dialects/v20/python2/*.py
-          else
-            flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
             mypy --config-file ./.github/workflows/mypy-generated.ini dialects/v10/*.py dialects/v20/*.py
           fi
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,13 @@ jobs:
 
       - name: Lint generated python code
         run: |
-          flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
-          if [ "${{ matrix.python-version }}" != "3.5" ]
+          if [ "${{ matrix.python-version }}" = "3.5" ]
           then
+            flake8 --ignore='W503,E203,E501,E741' --statistics dialects/v10/python2/*.py dialects/v20/python2/*.py
+          else
+            flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
             mypy --config-file ./.github/workflows/mypy-generated.ini dialects/v10/*.py dialects/v20/*.py
           fi
-
       - name: Generate messages
         run: |
           ./test_generate_all.sh


### PR DESCRIPTION
### These are the minimal steps required to run all tests successfully while adding Python 3.11.
https://docs.python.org/3.11/whatsnew/3.11.html
> Python 3.11 is between 10-60% faster than Python 3.10. On average, we measured a 1.25x speedup on the standard benchmark suite.

GitHub Actions no longer supports running tests on legacy Python as discussed at https://github.com/ArduPilot/pymavlink/issues/556#issuecomment-1605736268