### PR TITLE
Fix bitshifting issue on 8bit AVR boards when using msgid > 255 with generated C libs

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -707,7 +707,7 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		break;
 
 	case MAVLINK_PARSE_STATE_GOT_MSGID1:
-		rxmsg->msgid |= c<<8;
+		rxmsg->msgid |= ((uint32_t)c)<<8;
 		mavlink_update_checksum(rxmsg, c);
 		status->parse_state = MAVLINK_PARSE_STATE_GOT_MSGID2;
 		break;


### PR DESCRIPTION
This is fixing an issue within the C libs generated with mavgenerate.py for an ATMega4809 MCU. 

Using the ATMega4809 MCU compiled with AVR-GCC 5.4.0, during the decoding of the second byte of the msgid if it is non-zero, the high byte of the msgid would be set to 0xFF. This would in turn never get corrected in the receiving of the high byte of the msgid since it was ORd with the current msgid high byte (which should be 0, but is now 0xFF).

Adding this explicit typecast to the input byte of the second msgid byte seems to have fixed this issue and it works as expected on the ATMega4809 as well as a custom 64bit QGroundControl and 2 custom STM32 based boards.

I would also like to point out that without this fix, there were no issues in the decoding of the msgid on the custom 64bit QGC or on the 2 custom STM32 boards. This issue only showed up on a custom AVR based board.