### PR TITLE
mavutil: add RTL mode for Blimp

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2092,6 +2092,7 @@ mode_mapping_blimp = {
     1 : 'MANUAL',
     2 : 'VELOCITY',
     3 : 'LOITER',
+    4 : 'RTL',
 }
 
 AP_MAV_TYPE_MODE_MAP_DEFAULT = {


### PR DESCRIPTION
Adds RTL mode to Blimp's mode mapping.

@peterbarker Do I need to do module update PRs for mavlink and ardupilot or will you guys do the updates?