### PR TITLE
Mavgen WLua: Add param units to display

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -162,10 +162,11 @@ def generate_field_or_param(outf, field_or_param, name, label, physical_type, fi
             field_type = "ftypes.UINT32"
     else:
         display_type = physical_type
+    unitstr = " " + field_or_param.units if field_or_param.units else ""
     t.write(outf,
 """
-f.${fname} = ProtoField.new("${flabel} (${ftypename})", "mavlink_proto.${fname}", ${ftype}, ${fvalues})
-""", {'fname': name, 'flabel': label, 'ftypename': display_type, 'ftype': field_type, 'fvalues': values})
+f.${fname} = ProtoField.new("${flabel} (${ftypename})${unitname}", "mavlink_proto.${fname}", ${ftype}, ${fvalues})
+""", {'fname': name, 'flabel': label, 'ftypename': display_type, 'ftype': field_type, 'fvalues': values, 'unitname': unitstr})
 
     # generate flag enum subfields
     if enum_obj and enum_obj.bitmask:


### PR DESCRIPTION
The idea of this pull request is to add the field unit to the Wireshark display, whenever units are specified in the Mavlink dialect XML file. For example, output is as shown below, where the text such as "[us]", "[degE7]", etc is new:
```
Payload: GPS_RAW_INT (24)
    time_usec (uint64_t) [us]: 3625540000
    fix_type (GPS_FIX_TYPE): GPS_FIX_TYPE_3D_FIX (3)
    lat (int32_t) [degE7]: 514783466
    lon (int32_t) [degE7]: -25922214
    alt (int32_t) [mm]: 56900
    eph (uint16_t): 100
    epv (uint16_t): 100
    vel (uint16_t) [cm/s]: 0
    cog (uint16_t) [cdeg]: 0
    satellites_visible (uint8_t): 16
    alt_ellipsoid (int32_t) [mm]: 0
    h_acc (uint32_t) [mm]: 1000
    v_acc (uint32_t) [mm]: 1000
    vel_acc (uint32_t) [mm]: 200
    hdg_acc (uint32_t) [degE5]: 0
    yaw (uint16_t) [cdeg]: 0
``` 
Code lines changed is quite small, and I have done a number of manual checks on the output, but let me know if I need to do more...