### PR TITLE
mavschema - Typo 10E5 should be 1E5

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -117,8 +117,8 @@
     <xs:enumeration value="deg/s"/>    <!-- degrees per second -->
     <xs:enumeration value="cdeg"/>     <!-- centidegrees -->
     <xs:enumeration value="cdeg/s"/>   <!-- centidegrees per second -->
-    <xs:enumeration value="degE5"/>    <!-- degrees * 10E5 -->
-    <xs:enumeration value="degE7"/>    <!-- degrees * 10E7 -->
+    <xs:enumeration value="degE5"/>    <!-- degrees * 1E5 -->
+    <xs:enumeration value="degE7"/>    <!-- degrees * 1E7 -->
     <xs:enumeration value="rpm"/>      <!-- rotations per minute -->
     <!-- electricity -->
     <xs:enumeration value="V"/>        <!-- Volt -->


### PR DESCRIPTION
Fix typo in comments. Relates to https://github.com/mavlink/mavlink/issues/2062