### PR TITLE
Add multiplier value for GPS_STATUS.satellite_azimuth where 255 means 360deg

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -178,6 +178,7 @@
 <xs:simpleType name="factor">
   <xs:restriction base="xs:string">
     <xs:enumeration value="1E-2"/>        <!-- actual value = stated value / 100 -->
+    <xs:enumeration value="360/255"/>     <!-- actual value = stated value * 360/255, as used for GPS_STATUS.satellite_azimuth -->
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
Relates to https://github.com/mavlink/mavlink/issues/2062, point 2.

> 2/ Satellite Azimuth unit doesn't consider scale factor
The satellite_azimuth field of the GPS_STATUS message has a unit of "deg", but the description says "0: 0 deg, 255: 360 deg".
To be consistent with other units, and allow automatic value decoding, I would propose that a specific unit is used here too.
e.g. "degS8" (meaning "Degree Scaled to 8 bit integer"), or "deg/360*255" or any sensible simplification thereof.
I would also question if 255 is really supposed to be 360deg - as this means a value of 0 and 255 represents the same angle.
Perhaps what was intended is that 255 represents 360-(360/256) = 358.59375 ?

This PR adds the "degS8" unit, and an associated comment to the mavschema.xsd file.