### PR TITLE
Update deprecated MAV_TYPE enum for tailsitter

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2113,8 +2113,8 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     mavlink.MAV_TYPE_COAXIAL:     mode_mapping_acm,
     # plane
     mavlink.MAV_TYPE_FIXED_WING: mode_mapping_apm,
-    mavlink.MAV_TYPE_VTOL_DUOROTOR: mode_mapping_apm,
-    mavlink.MAV_TYPE_VTOL_QUADROTOR: mode_mapping_apm,
+    mavlink.MAV_TYPE_VTOL_TAILSITTER_DUOROTOR: mode_mapping_apm,
+    mavlink.MAV_TYPE_VTOL_TAILSITTER_QUADROTOR: mode_mapping_apm,
     mavlink.MAV_TYPE_VTOL_TILTROTOR: mode_mapping_apm,
     # rover
     mavlink.MAV_TYPE_GROUND_ROVER: mode_mapping_rover,


### PR DESCRIPTION
Hi,

This fixes https://github.com/ArduPilot/pymavlink/issues/571.

With latest Pymavlink (master), the mavgen step works, but on trying to import mavutil, I get this error. 
![Screenshot 2023-12-15 at 1 46 44 PM](https://github.com/ArduPilot/pymavlink/assets/23355179/18198763-edeb-4181-8d31-a4b79447e721)

It seems that these two enums were changed, but weren't reflected in mavutil.py
- MAV_TYPE_VTOL_TAILSITTER_QUADROTOR was previously MAV_TYPE_VTOL_QUADROTOR
- MAV_TYPE_VTOL_TAILSITTER_DUOROTOR was previously MAV_TYPE_VTOL_DUOROTOR

I believe there is still a reference to the old enum name in Swift generator tests ```pymavlink/generator/swift/Tests/MAVLinkTests/Testdata/common.xml```, but I haven't run that locally. 
