### PR TITLE
Mavutil: Output updates to dump_message_verbose

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2458,6 +2458,20 @@ def decode_bitmask(messagetype, field, value):
             ret.append( EnumBitInfo(i, False, enum_entry_name) )
     return ret
 
+'''lookup table to map from a raw unit into a divisor and output unit'''
+dump_message_unit_decoder = {
+    "d%":     [10.0,       "%"],
+    "c%":     [100.0,      "%"],
+    "cA":     [100.0,      "A"],
+    "cdegC":  [100.0,      "degC"],
+    "cdeg":   [100.0,      "deg"],
+    "degE5":  [100000.0,   "deg"],
+    "degE7":  [10000000.0, "deg"],
+    "mG":     [1000.0,     "G"],
+    "mrad/s": [1000.0,     "rad/s"],
+    "mV":     [1000.0,     "V"]
+}
+
 def dump_message_verbose(f, m):
     '''write an excruciatingly detailed dump of message m to file descriptor f'''
     try:
@@ -2478,56 +2492,37 @@ def dump_message_verbose(f, m):
         # try to add units:
         try:
             units = m.fieldunits_by_name[fieldname]
+
             # perform simple unit conversions:
-            divisor = None
-            if units == "d%":
-                divisor = 10.0
-                units = "%"
-            if units == "c%":
-                divisor = 100.0
-                units = "%"
-
-            if units == "cA":
-                divisor = 100.0
-                units = "A"
-
-            elif units == "cdegC":
-                divisor = 100.0
-                units = "degC"
-
-            elif units == "cdeg":
-                divisor = 100.0
-                units = "deg"
-
-            elif units == "degE7":
-                divisor = 10000000.0
-                units = "deg"
-
-            elif units == "mG":
-                divisor = 1000.0
-                units = "G"
-
-            elif units == "mrad/s":
-                divisor = 1000.0
-                units = "rad/s"
-
-            elif units == "mV":
-                divisor = 1000.0
-                units = "V"
-
-            if divisor is not None:
+            if units in dump_message_unit_decoder:
+                divisor = dump_message_unit_decoder[units][0]
+                units = dump_message_unit_decoder[units][1]
                 if type(value) == list:
                     value = [x/divisor for x in value]
                 else:
                     value = value / divisor
 
-            # and give radians in degrees too:
+            # append degrees to fields in radians:
             if units == "rad":
                 value = "%s%s (%sdeg)" % (value, units, math.degrees(value))
             elif units == "rad/s":
                 value = "%s%s (%sdeg/s)" % (value, units, math.degrees(value))
             elif units == "rad/s/s":
                 value = "%s%s (%sdeg/s/s)" % (value, units, math.degrees(value))
+
+            # append local time if us represents unix time:
+            elif units == "us":
+                if value > (1<<50):
+                    local_time = time.localtime(int(value/1000000))
+                    time_str = time.strftime("%Y-%m-%d %H:%M:%S", local_time)
+                    tm_zone = local_time.tm_zone
+                    value = "%s%s (%s.%06d %s)" % (value, units, time_str, value%1000000, tm_zone)
+                elif value > 1000000:
+                    value = "%s%s (%ss)" % (value, units, value / 1000000.0)
+                else:
+                    value = "%s%s" % (value, units)
+
+            # by default, just append the unit:
             else:
                 value = "%s%s" % (value, units)
         except AttributeError as e:
@@ -2538,20 +2533,22 @@ def dump_message_verbose(f, m):
 
         # format any bitmask enumerations:
         try:
-            enum_name = m.fieldenums_by_name[fieldname]
-            display = m.fielddisplays_by_name[fieldname]
-            if enum_name is not None and display == "bitmask":
-                bits = decode_bitmask(m.get_type(), fieldname, value)
-                f.write("    %s: %s\n" % (fieldname, value))
-                for bit in bits:
-                    value = bit.value
-                    name = bit.name
-                    svalue = " "
-                    if not value:
-                        svalue = "!"
-                    if name is None:
-                        name = "[UNKNOWN]"
-                    f.write("      %s %s\n" % (svalue, name))
+            display = m.fielddisplays_by_name[fieldname] if fieldname in m.fielddisplays_by_name else ""
+            if display == "bitmask":
+                # Display bitmasks as hex (dec), regardless of whether there is an enum
+                f.write("    %s: 0x%x (%d)\n" % (fieldname, value, value))
+                enum_name = m.fieldenums_by_name[fieldname] if fieldname in m.fieldenums_by_name else None
+                if enum_name is not None:
+                    bits = decode_bitmask(m.get_type(), fieldname, value)
+                    for bit in bits:
+                        value = bit.value
+                        name = bit.name
+                        svalue = " "
+                        if not value:
+                            svalue = "!"
+                        if name is None:
+                            name = "[UNKNOWN]"
+                        f.write("      %s %s\n" % (svalue, name))
                 continue
 #            except NameError as e:
 #                pass


### PR DESCRIPTION
This PR proposes a few small updates to the outputting of values performed by the dump_message_verbose function in mavutil.py. (I've already started doing similar things for Wireshark, but am keeping that PR separate).

_- Basic unit conversions moved into lookup table, and degE5 added_
To make it a bit easier to read and add to, I replaced the if/elif/elif/... block with a lookup table, which should make it easy to add others in the future. The key is old unit, and the values are an array containing the divisor and new unit, e.g.:
```python
dump_message_unit_decoder = {
    "d%":     [10.0,       "%"], ....
``` 
Whilst there I added a line for "degE5" (divisor:  100000, unit: deg).

_- Fields with "us" units shown with readable local time if value suggests it is a unix time_
If a field with a unit of microseconds has a value larger than 1<<50, then the value is appended with the decoded local time. ("1<<50" was picked as it represents sometime in 2005, should be big enough to be near impossible to show up in any μs field that isn't genuinely a unix time, and looked nice and round to type in code). e.g.:
```
status SYSTEM_TIME --verbose
2023-12-19 17:10:37.39: SYSTEM_TIME (id=2) (link=None) (signed=False) (seq=154) (src=1/1)
    time_unix_usec: 1703005808636579us (2023-12-19 17:10:08.636579 GMT)
``` 
Also, any smaller μs field with a value of at least 1000000 is shown with seconds value appended, e.g.:
2023-12-19 17:20:21.43: GPS_RAW_INT (id=24) (link=None) (signed=False) (seq=127) (src=1/1)
``` 
2023-12-19 17:21:20.59: GPS_GLOBAL_ORIGIN (id=49) (link=None) (signed=False) (seq=242) (src=1/1)
    time_usec: 16542370067us (16542.370067s)
``` 

_- Bitfield values shown as "hex (dec)", including if not attached to enum_
I find that the value of bitfields makes more sense to read in hex, so I changed the value display of these to show both hex and dec values. I also added functionality to do this for bitfields which have no enum attached, which is the case for mask param on TERRAIN_REQUEST message. e.g.:
```
2023-12-19 17:25:02.68: TERRAIN_REQUEST (id=133) (link=None) (signed=False) (seq=87) (src=1/1)
    mask: 0xffffffffffffff (72057594037927935)
```

I've Tested by running "status --verbose" a good few times in Mavproxy and checking over the outputs being shown, and even switched my PC timezone around to check time output in places that are not on UTC (as we are here).