### PR TITLE
mavschema - 1E2 for scaled unitless values

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -171,6 +171,8 @@
     <!-- volume -->
     <xs:enumeration value="cm^3"/>     <!-- cubic centimetres -->
     <xs:enumeration value="l"/>        <!-- litres -->
+    <!-- unitless scaled values -->
+    <xs:enumeration value="1E2"/>        <!-- value scaled up by 100 -->
   </xs:restriction>
 </xs:simpleType>
 

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -22,6 +22,7 @@
 <xs:attribute name="enum" type="xs:string"/> <!-- used in field,param elements -->
 <xs:attribute name="display" type="xs:string"/> <!-- used in field elements -->
 <xs:attribute name="units" type="SI_Unit"/> <!-- this will get changed on the fly to xs:string if no strict-units command line option is used -->
+<xs:attribute name="multiplier" type="factor"/>
 <xs:attribute name="instance" type="xs:boolean"/>
 <xs:attribute name="invalid" type="xs:string"/> <!-- used in message field elements -->
 <xs:attribute name="value"> <!-- used in entry elements -->
@@ -171,7 +172,11 @@
     <!-- volume -->
     <xs:enumeration value="cm^3"/>     <!-- cubic centimetres -->
     <xs:enumeration value="l"/>        <!-- litres -->
-    <!-- unitless scaled values -->
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="factor">
+  <xs:restriction base="xs:string">
     <xs:enumeration value="1E2"/>        <!-- value scaled up by 100 -->
   </xs:restriction>
 </xs:simpleType>
@@ -196,6 +201,7 @@
         <xs:attribute ref="index" use="required"/>
         <xs:attribute ref="label"/>
         <xs:attribute ref="units"/>
+        <xs:attribute ref="multiplier"/>
         <xs:attribute ref="instance"/>
         <xs:attribute ref="enum" />
         <xs:attribute ref="decimalPlaces"/>
@@ -240,6 +246,7 @@
         <xs:attribute ref="increment"/>
         <xs:attribute ref="minValue"/>
         <xs:attribute ref="maxValue"/>        
+        <xs:attribute ref="multiplier"/>
         <xs:attribute ref="default" />
         <xs:attribute ref="instance" />
         <xs:attribute ref="invalid" />

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -177,7 +177,7 @@
 
 <xs:simpleType name="factor">
   <xs:restriction base="xs:string">
-    <xs:enumeration value="1E2"/>        <!-- value scaled up by 100 -->
+    <xs:enumeration value="1E-2"/>        <!-- actual value = stated value / 100 -->
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
This falls out of the discussion in https://github.com/mavlink/mavlink/issues/2062#top

[GPS_RAW_INT.eph](https://mavlink.io/en/messages/common.html#GPS_RAW_INT) and `.evp` and same property names in [HIL_GPS](https://mavlink.io/en/messages/common.html#HIL_GPS) are unitless values, so correctly don't have units added.
However they are scaled by 100 and there is no way to know that programmatically. IN order to allow programmatic comparisons and conversions it is useful to supply this information.

This creates a unit `1E2` that indicates a unitless value scaled by 100. 

FYI @shancock884 

