### PR TITLE
mavlink_helpers.h: Don't restart parsing on second CRC byte

### DIFF
--- a/generator/C/include_v1.0/mavlink_helpers.h
+++ b/generator/C/include_v1.0/mavlink_helpers.h
@@ -537,17 +537,10 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
     uint8_t msg_received = mavlink_frame_char(chan, c, r_message, r_mavlink_status);
     if (msg_received == MAVLINK_FRAMING_BAD_CRC) {
 	    // we got a bad CRC. Treat as a parse failure
-	    mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan);
 	    mavlink_status_t* status = mavlink_get_channel_status(chan);
 	    status->parse_error++;
 	    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
 	    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-	    if (c == MAVLINK_STX)
-	    {
-		    status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-		    rxmsg->len = 0;
-		    mavlink_start_checksum(rxmsg);
-	    }
 	    return 0;
     }
     return msg_received;

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -993,17 +993,10 @@ MAVLINK_HELPER uint8_t mavlink_parse_char(uint8_t chan, uint8_t c, mavlink_messa
     if (msg_received == MAVLINK_FRAMING_BAD_CRC ||
 	msg_received == MAVLINK_FRAMING_BAD_SIGNATURE) {
 	    // we got a bad CRC. Treat as a parse failure
-	    mavlink_message_t* rxmsg = mavlink_get_channel_buffer(chan);
 	    mavlink_status_t* status = mavlink_get_channel_status(chan);
 	    _mav_parse_error(status);
 	    status->msg_received = MAVLINK_FRAMING_INCOMPLETE;
 	    status->parse_state = MAVLINK_PARSE_STATE_IDLE;
-	    if (c == MAVLINK_STX)
-	    {
-		    status->parse_state = MAVLINK_PARSE_STATE_GOT_STX;
-		    rxmsg->len = 0;
-		    mavlink_start_checksum(rxmsg);
-	    }
 	    return 0;
     }
     return msg_received;


### PR DESCRIPTION
If an unknown message is received it would fail parsing due to bad CRC, thanks to the crc_extra. Before this change the parser would restart parsing on the second CRC byte. This can cause the parser to be out of sync and drop messages if the second CRC byte happens to be MAVLINK_STX.
Now the parser will ignore the MAVLINK_STX if it was received as the second byte of a bad CRC message.

Fixes #881 