### PR TITLE
mavutil: cope with enum entry rename

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2114,8 +2114,6 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     mavlink.MAV_TYPE_COAXIAL:     mode_mapping_acm,
     # plane
     mavlink.MAV_TYPE_FIXED_WING: mode_mapping_apm,
-    mavlink.MAV_TYPE_VTOL_DUOROTOR: mode_mapping_apm,
-    mavlink.MAV_TYPE_VTOL_QUADROTOR: mode_mapping_apm,
     mavlink.MAV_TYPE_VTOL_TILTROTOR: mode_mapping_apm,
     # rover
     mavlink.MAV_TYPE_GROUND_ROVER: mode_mapping_rover,
@@ -2129,6 +2127,18 @@ AP_MAV_TYPE_MODE_MAP_DEFAULT = {
     mavlink.MAV_TYPE_AIRSHIP: mode_mapping_blimp,
 }
 
+# cope with enumeration renaming:
+for (name, some_map) in ([
+        # plane, see https://github.com/ArduPilot/pymavlink/issues/571
+        ("MAV_TYPE_VTOL_DUOROTOR", mode_mapping_apm),
+        ("MAV_TYPE_VTOL_TAILSITTER_DUOROTOR", mode_mapping_apm),
+        ("MAV_TYPE_VTOL_QUADROTOR", mode_mapping_apm),
+        ("MAV_TYPE_VTOL_TAILSITTER_QUADROTOR", mode_mapping_apm),
+        ]):
+    try:
+        AP_MAV_TYPE_MODE_MAP_DEFAULT[getattr(mavlink, name)] = some_map
+    except AttributeError:
+        pass
 
 try:
     # Allow for using custom mode maps by importing a JSON dict from


### PR DESCRIPTION
two entries were renamed in the MAV_TYPE enumeration.  Since mavutil uses those enumeration entries without checking if they exist, using the entries which no longer exist goes poorly.

Rename was done here: https://github.com/mavlink/mavlink/pull/1818/files


Alternative to https://github.com/ArduPilot/pymavlink/pull/889


Tested on the command-line for the values currently in the mavlink commit references in ardupilot/master
