### PR TITLE
fix close function in DFReader

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -735,6 +735,7 @@ class DFReader(object):
     
     def close(self):
         '''close the log file'''
+        self.data_map.close()
         self.filehandle.close()
     
 


### PR DESCRIPTION
the close function only closed the file, however to lift the lock on the file the mmap also needs to be closed.
I noticed that I was not able to move the file with shutil.move even after calling close on the DFReader object. After adding `self.data_map.close()` to the close function in DFReader the file was no longer locked after calling close.

Tested on Win11, python 3.12.0