### PR TITLE
mavextra: correct radian conversion in distance_lat_lon function

### DIFF
--- a/mavextra.py
+++ b/mavextra.py
@@ -549,7 +549,13 @@ def get_lat_lon_alt(MSG):
 
 
 def _distance_two(MSG1, MSG2, horizontal=True):
-    '''distance between two points'''
+    '''
+    Return the distance between two points in metres
+    Calculated as the great-circle distance using 'haversine’ formula
+    (Ref: http://www.movable-type.co.uk/scripts/latlong.html)
+    Uses the globally-average earth radius value of 6371km
+    '''
+    # get_lat_lon_alt returns radians - so no need to convert here
     (lat1, lon1, alt1) = get_lat_lon_alt(MSG1)
     (lat2, lon2, alt2) = get_lat_lon_alt(MSG2)
     dLat = lat2 - lat1
@@ -1044,7 +1050,7 @@ def distance_gps2(GPS, GPS2):
         return None
     return distance_two(GPS, GPS2)
 
-
+# SI base unit for 1 Rgeo / equatorial radius
 radius_of_earth = 6378100.0 # in meters
 
 def wrap_valid_longitude(lon):
@@ -1499,7 +1505,12 @@ def airspeed_estimate(GLOBAL_POSITION_INT,WIND):
 
 
 def distance_from(GPS_RAW1, lat, lon):
-    '''distance from a given location'''
+    '''
+    Return the distance from a given location in meters
+    Calculated as the great-circle distance using 'haversine’ formula
+    (Ref: http://www.movable-type.co.uk/scripts/latlong.html)
+    Uses the globally-average earth radius value of 6371km
+    '''
     if hasattr(GPS_RAW1, 'Lat'):
         lat1 = radians(GPS_RAW1.Lat)
         lon1 = radians(GPS_RAW1.Lng)
@@ -1522,9 +1533,19 @@ def distance_from(GPS_RAW1, lat, lon):
     return ground_dist
 
 def distance_lat_lon(lat1, lon1, lat2, lon2):
-    '''distance between two points'''
-    dLat = radians(lat2) - radians(lat1)
-    dLon = radians(lon2) - radians(lon1)
+    '''
+    Return the distance between two points in metres
+    Calculated as the great-circle distance using 'haversine’ formula
+    (Ref: http://www.movable-type.co.uk/scripts/latlong.html)
+    Uses the globally-average earth radius value of 6371km
+    '''
+    lat1 = radians(lat1)
+    lon1 = radians(lon1)
+    lat2 = radians(lat2)
+    lon2 = radians(lon2)
+
+    dLat = lat2 - lat1
+    dLon = lon2 - lon1
 
     a = sin(0.5*dLat)**2 + sin(0.5*dLon)**2 * cos(lat1) * cos(lat2)
     c = 2.0 * atan2(sqrt(a), sqrt(1.0-a))


### PR DESCRIPTION
fix #635 
As pointed out in issue #635, there is an error in the distance_lat_lon function in mavextra, as `cos(lat1)` and `cos(lat2)` were being applied to the value in degrees not radians.
This PR fixes this, using the code proposed by @gitdillo, by ensuring all function inputs are converted before use.

I chose not to use the code from the gps_distance function in mp_util.py (as linked @khancyr), as the mp_util function calculates the rhumb line distance, rather than the great-circle distance, and I did not want to alter the original author's intent of the function.

I also added extra words to the comments of all 3 similar functions in mavextra.py and the radius_of_earth variable, to make it more clear which formula and earth radius are being used.

I checked a few spot points before and after against the [Movable Type Scripts website](http://www.movable-type.co.uk/scripts/latlong.html). For example:
Before fix:
```python
>>> import pymavlink.mavextra
>>> pymavlink.mavextra.distance_lat_lon(51,0,53,2)
125501.69695239903
``` 
After fix:
```python
>>> import pymavlink.mavextra
>>> pymavlink.mavextra.distance_lat_lon(51,0,53,2)
261134.12945358222
``` 
Movable Type Scripts website: 261.1 km (to 4 SF)
