### PR TITLE
mavgen_python: make enumerations MavEnum instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Examples can be found [in the repository](examples/) or in the [ArduSub book](ht
 
 # Installation 
 
-Pymavlink supports both Python 2 and Python 3.
-
 The following instructions assume you are using Python 3 and a Debian-based (like Ubuntu) installation.
 
 .. note::
@@ -27,7 +25,7 @@ The following instructions assume you are using Python 3 and a Debian-based (lik
 
 Pymavlink has several dependencies :
 
-    - [future](http://python-future.org/) : for Python 2 and Python 3 interoperability
+    - [future](http://python-future.org/) : for interoperability
     - [lxml](http://lxml.de/installation.html) : for checking and parsing xml file 
 
 Optional :
@@ -38,10 +36,6 @@ Optional :
 ### On Linux
 
 lxml has some additional dependencies that can be installed with your package manager (here with `apt-get`) :
-
-.. note::
-
-   If you continue to use Python 2 you may need to change package names here (e.g. python3-numpy => python-numpy)
 
 ```bash
 sudo apt-get install libxml2-dev libxslt-dev

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -44,6 +44,8 @@ def extend_with_type_info(extended, enable_type_annotations):
         "mavlink_message_signed_callback": ('Callable[["MAVLink", int], bool]', None),
         "dict_str_to_str_float_int": ("Dict[str, Union[str, float, int]]", None),
         "dict_str_to_dict_int_to_enumentry": ("Dict[str, Dict[int, EnumEntry]]", None),
+        "dict_int_to_enumentry": ("Dict[int, EnumEntry]", None),
+        "dict_str_to_MavEnum": ("Dict[str, MavEnum]", None),
         "dict_int_to_str": ("Dict[int, str]", None),
         "dict_str_to_str": ("Dict[str, str]", None),
         "dict_int_int_int_to_int": ("Dict[Tuple[int, int, int], int]", None),
@@ -457,14 +459,26 @@ class EnumEntry(object):
         self.has_location = False
 
 
-enums${type_dict_str_to_dict_int_to_enumentry} = {}
+class MavEnum(${type_dict_int_to_enumentry_cast}):
+    def __init__(self, bitmask${type_bool_default})${type_none_ret}:
+        super(MavEnum, self).__init__()
+        self.bitmask = bitmask
+
+    def is_bitmask(self)${type_bool_ret}:
+        return self.bitmask
+
+
+enums${type_dict_str_to_MavEnum} = {}
 """,
         type_info,
     )
 
     for e in enums:
         outf.write("\n# %s\n" % e.name)
-        outf.write('enums["%s"] = {}\n' % e.name)
+        mavenum_kwargs = ""
+        if bool(e.bitmask):
+            mavenum_kwargs = "bitmask=True"
+        outf.write('enums["%s"] = MavEnum(%s)\n' % (e.name, mavenum_kwargs))
         for entry in e.entry:
             outf.write("%s = %u\n" % (entry.name, entry.value))
             description = entry.description.replace("\t", "    ")


### PR DESCRIPTION
... instead of just bare dictionaries

... and add an is_bitmask method to them


```
# MAV_GENERATOR_STATUS_FLAG
enums["MAV_GENERATOR_STATUS_FLAG"] = MavEnum(bitmask=1)
MAV_GENERATOR_STATUS_FLAG_OFF = 1
enums["MAV_GENERATOR_STATUS_FLAG"][1] = EnumEntry("MAV_GENERATOR_STATUS_FLAG_OFF", """Generator is off.""")
MAV_GENERATOR_STATUS_FLAG_READY = 2
enums["MAV_GENERATOR_STATUS_FLAG"][2] = EnumEntry("MAV_GENERATOR_STATUS_FLAG_READY", """Generator is ready to start generating power.""")
```

... and one which is not a bitmask:


```
# MAV_VTOL_STATE
enums["MAV_VTOL_STATE"] = MavEnum()
MAV_VTOL_STATE_UNDEFINED = 0
enums["MAV_VTOL_STATE"][0] = EnumEntry("MAV_VTOL_STATE_UNDEFINED", """MAV is not configured as VTOL""")
MAV_VTOL_STATE_TRANSITION_TO_FW = 1
enums["MAV_VTOL_STATE"][1] = EnumEntry("MAV_VTOL_STATE_TRANSITION_TO_FW", """VTOL is in transition from multicopter to fixed-wing""")
MAV_VTOL_STATE_TRANSITION_TO_MC = 2
enums["MAV_VTOL_STATE"][2] = EnumEntry("MAV_VTOL_STATE_TRANSITION_TO_MC", """VTOL is in transition from fixed-wing to multicopter""")
```