### PR TITLE
DFReader_text: some meta-data dicts are indexed by bytes instead of str

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1147,8 +1147,8 @@ class DFReader_text(DFReader):
 
         while ofs+16 < self.data_len:
             mtype = self.data_map[ofs:ofs+4]
-            if mtype[3] == b',':
-                mtype = mtype[0:3]
+            # convert to string and cut if there is a ','
+            mtype = mtype.decode().split(',')[0]
             if not mtype in self.offsets:
                 self.counts[mtype] = 0
                 self.offsets[mtype] = []


### PR DESCRIPTION
When reading a DF text log, the 'counts' and 'offsets' dictionaries end up being indexed by the message name as 'bytes', whereas the 'formats' and 'name_to_id' are indexed by message name as 'str'.
This PR aims to fix this to align the indexing to strings.

Effectively, there were 3 issues:
* `mtype = self.data_map[ofs:ofs+4]` gives bytes, which is then used as index without converting.
* `if mtype[3] == b',':` doesn't do as intended, as it always returns false in Python 3 (try: `b'abc,'[3] == b','`).
* Even if it did work, mtype[3] doesn't take account of messages 'EV' and 'PM' as they are only 2 chars long.

The fix uses decode and split to get the text up to the first comma (if there is one) as str, which should then align.

Note that I came across this after seeing that the MAVExplorer 'stats' command throws an exception on DF text logs - this PR alone doesn't fix this, but I've got a something lined up which will once both are in.
Tested by checking some debug prints of the keys at the end of init_arrays, and by taking MAVExplorer for a spin.