### PR TITLE
MavSchema: Allow 64-bit enum values to be specified

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -27,18 +27,18 @@
 <xs:attribute name="value"> <!-- used in entry elements -->
   <xs:simpleType>
     <xs:restriction base="xs:string">
-        <xs:pattern value="\d{1,10}"/> <!-- base 10 int -->
-        <xs:pattern value="0[xX][0-9a-fA-F]{1,8}"/> <!-- base 16 -->
-        <xs:pattern value="0[bB][0-1]{1,32}"/> <!-- base 1 -->
+        <xs:pattern value="\d{1,20}"/> <!-- base 10 int -->
+        <xs:pattern value="0[xX][0-9a-fA-F]{1,16}"/> <!-- base 16 -->
+        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 1 -->
     </xs:restriction>
   </xs:simpleType>
 </xs:attribute>
 <xs:attribute name="default"> <!-- used in enum field elements -->
   <xs:simpleType>
     <xs:restriction base="xs:string">
-        <xs:pattern value="\d{1,10}"/> <!-- base 10 int -->
-        <xs:pattern value="0[xX][0-9a-fA-F]{1,8}"/> <!-- base 16 -->
-        <xs:pattern value="0[bB][0-1]{1,32}"/> <!-- base 1 -->
+        <xs:pattern value="\d{1,20}"/> <!-- base 10 int -->
+        <xs:pattern value="0[xX][0-9a-fA-F]{1,16}"/> <!-- base 16 -->
+        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 1 -->
         <xs:pattern value="NaN"/> <!-- Allow not-a-number as a default (for params) -->
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
Within the Mavlink schema, enum values are currently limited to 10 decimal, 8 hex, or 32 binary digits.
However, we already have two fields which are bitmasks and use uint64_t type (AUTOPILOT_VERSION.capabilities and GENERATOR_STATUS.status). This character limit means that you can't currently specify a value using (most of) the higher 32-bits.
I came across this while trying to build a test case for #895.

My proposal is to extend the character limit to 20 decimal, 16 hex or 64 binary digits to allow for this.
@hamishwillee - does this make sense?

I did wonder if it might be useful to be allowed to specify values as powers of 2 (e.g. "2^0", "2^4", "2^55") to be more readable as the numbers get bigger, but as this would require work on the generators, so have not proposed it.
I also wondered if the test.xml file in Mavlink repo should include at least one enum and bitmask, if it is supposed to be used a nice little test file cover major functionality?