### PR TITLE
Tools: fix mlog attribute in mavplayback

### DIFF
--- a/tools/mavplayback.py
+++ b/tools/mavplayback.py
@@ -122,18 +122,18 @@ class App(object):
 
     def rewind(self):
         '''rewind 10%'''
-        pos = int(self.mlog.f.tell() - 0.1*self.filesize)
+        pos = int(self.mlog.f.tell() - 0.1 * self.filesize)
         if pos < 0:
             pos = 0
-        self.mlog.filehandle.seek(pos)
+        self.mlog.f.seek(pos)
         self.find_message()
 
     def forward(self):
         '''forward 10%'''
-        pos = int(self.mlog.f.tell() + 0.1*self.filesize)
+        pos = int(self.mlog.f.tell() + 0.1 * self.filesize)
         if pos > self.filesize:
             pos = self.filesize - 2048
-        self.mlog.filehandle.seek(pos)
+        self.mlog.f.seek(pos)
         self.find_message()
 
     def status(self):
@@ -158,7 +158,7 @@ class App(object):
         '''move to a given position in the file'''
         if float(value) != self.filepos:
             pos = float(value) * self.filesize
-            self.mlog.filehandle.seek(int(pos))
+            self.mlog.f.seek(int(pos))
             self.find_message()
 
 


### PR DESCRIPTION
Currently, rewind & forward buttons as well as dragging across the timeline don't work and produce an error:

`Exception in Tkinter callback
Traceback (most recent call last):
  File "/usr/lib64/python3.11/tkinter/__init__.py", line 1948, in __call__
    return self.func(*args)
           ^^^^^^^^^^^^^^^^
  File "/home/szymon/development/opensource/forks/pymavlink/tools/mavplayback.py", line 136, in forward
    self.mlog.filehandle.seek(pos)
    ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'mavmmaplog' object has no attribute 'filehandle'`

Some of the calls were changed from mlog.filehandle to mlog.f by @tridge in #890, it seems to me that the remaining have to be changed as well.