### PR TITLE
CI: Use pytest<=7.4.4 as 8.0.0 will not run the tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ future>=0.15.2
 wheel>=0.37.1
 
 # dev dependencies:
-pytest
+pytest<=7.4.4
 syrupy; python_version>='3.6'


### PR DESCRIPTION
As of approx 06/02/2024, the pytest part of pymavlink CI began failing on Python v3.8+. This appears to be because pytest 8.0.0 is now being used as opposed to 7.4.4 before.
For now, this PR offers a fix, by pegging the version at <=7.4.4 in requirements.txt.
(Note that we need to use "<=" as Python 3.5 is using an older version of pytest).

For info, the error message when using pytest 8.0.0 was:
```
_____________________ ERROR collecting tests/test_trim.py ______________________
ImportError while importing test module '/home/runner/work/pymavlink/pymavlink/tests/test_trim.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.8.18/x64/lib/python3.8/importlib/__init__.py:127: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
E   ModuleNotFoundError: No module named 'pymavlink.tests'
```