### PR TITLE
Mavgen JS: Add require('buffer') statement to allow JS output to work in React Native

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -39,6 +39,7 @@ jspack = require("jspack").jspack,
     events = require("events"), // for .emit(..), MAVLink20Processor inherits from events.EventEmitter
     util = require("util");
 
+var Buffer = require('buffer').Buffer; // required in react - no impact in node
 var Long = require('long');
 
 // Add a convenience method to Buffer


### PR DESCRIPTION
I am using the Mavlink JS Nextgen output in a React Native project on Android mobile device.
In Node JS, the 'Buffer' object is globally available by default, but in React Native this is not the case.
This PR adds the line: `var Buffer = require('buffer').Buffer;` to the generated output.
This provides the Buffer object in React Native, and it is benign to also include this line in Node JS.

I have successfully used the updated generator in my React Native project, and checked that it also can be imported successfully in Node. Also, the CI tests the generator output in various versions of Node.