### PR TITLE
Mavschema: Allow enum values to be powers of 2

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -29,7 +29,8 @@
     <xs:restriction base="xs:string">
         <xs:pattern value="\d{1,20}"/> <!-- base 10 int -->
         <xs:pattern value="0[xX][0-9a-fA-F]{1,16}"/> <!-- base 16 -->
-        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 1 -->
+        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 2 -->
+        <xs:pattern value="2\*\*\d{1,2}"/> <!-- power of 2 -->
     </xs:restriction>
   </xs:simpleType>
 </xs:attribute>
@@ -38,7 +39,8 @@
     <xs:restriction base="xs:string">
         <xs:pattern value="\d{1,20}"/> <!-- base 10 int -->
         <xs:pattern value="0[xX][0-9a-fA-F]{1,16}"/> <!-- base 16 -->
-        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 1 -->
+        <xs:pattern value="0[bB][0-1]{1,64}"/> <!-- base 2 -->
+        <xs:pattern value="2\*\*\d{1,2}"/> <!-- power of 2 -->
         <xs:pattern value="NaN"/> <!-- Allow not-a-number as a default (for params) -->
     </xs:restriction>
   </xs:simpleType>


### PR DESCRIPTION
This is a follow-up from comments in #915.
It allows use of powers of 2 to specify enum values - which would be most useful for big bitmasks.
Example syntax is: `<entry value="2**7" name="BIT7" />`

@hamishwillee in https://github.com/ArduPilot/pymavlink/pull/915#issuecomment-1932957229 wrote:
> FWIW More than happy for you to try it but:
> 
> * consider restricting to bitmasks

I couldn't see how this was possible, as this is part of the rule for the 'value' field of enum 'entry' tag. Although I suspect xsd syntax can do many things that I don't know about!

> * allow either format

The syntax allows the user to use any of: decimal, hex, binary, power of 2.

> * we will need to have a period where other generators have a chance to catch up before we modify the XML.

No XML has been changed.

Note that the comment next to the binary rule has also been corrected from 'base 1' to 'base 2'.

### Testing

I tried out the full variety of enum value syntax with Mavgen, and it works without any modifications, as it already does an 'eval' on the value. e.g.:
```
      <entry value="1" name="BIT0" />
      <entry value="2**4" name="BIT4" />
      <entry value="0b000100000000" name="BIT8" />
      <entry value="0x10000" name="BIT16" />
      <entry value="0b1000000000000000000000000000000000000000000000000000000000000" name="BIT60" />
      <entry value="2305843009213693952" name="BIT61" />
      <entry value="2**62" name="BIT62" />
      <entry value="0x8000000000000000" name="BIT63" />
```
I was planning to include this in the Wireshark generator test I am building for the fix to issue: https://github.com/ArduPilot/pymavlink/issues/895 (of which the above is an extract). This would mean it will be tested as part of pymavlink CI.