### PR TITLE
generator: add javascript "lite"

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -45,7 +45,7 @@ MAXIMUM_INCLUDE_FILE_NESTING = 5
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
 # Right now, 'JavaScript' ~= 'JavaScript_Stable', in the future it may be made equivalent to 'JavaScript_NextGen'
-supportedLanguages = ["Ada", "C", "CS", "JavaScript", "JavaScript_Stable","JavaScript_NextGen", "TypeScript", "Python2", "Python3", "Python", "Lua", "WLua", "ObjC", "Swift", "Java", "C++11"]
+supportedLanguages = ["Ada", "C", "CS", "JavaScript", "JavaScript_Stable","JavaScript_NextGen", "JavaScript_lite", "TypeScript", "Python2", "Python3", "Python", "Lua", "WLua", "ObjC", "Swift", "Java", "C++11"]
 
 
 def mavgen(opts, args):
@@ -301,6 +301,9 @@ def mavgen(opts, args):
         else:
             from . import mavgen_ada
             mavgen_ada.generate(opts.output, xml)
+    elif opts.language == 'javascript_lite':
+        from . import mavgen_javascript_lite
+        mavgen_javascript_lite.generate(opts.output, xml)
     else:
         print("Unsupported language %s" % opts.language)
 

--- a/generator/mavgen_javascript_lite.py
+++ b/generator/mavgen_javascript_lite.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+'''
+parse a MAVLink protocol XML file and generate a javascript file to get CRC extra and name from message ID and MAV_COMPONENT enum. No payload fields are considered.
+'''
+from __future__ import print_function
+
+from builtins import range
+
+import os
+
+def generate(basename, xml):
+    msgs = []
+    enums = []
+    filelist = []
+    for x in xml:
+        msgs.extend(x.message)
+        enums.extend(x.enum)
+        filelist.append(os.path.basename(x.filename))
+
+    print("Generating %s/mavlink_msgs.js" % basename)
+    # create the output directory if needed
+    if not os.path.exists(basename):
+        os.makedirs(basename)
+    outf = open("%s/mavlink_msgs.js" % basename, "w")
+
+    outf.write("// Auto generated MAVLink parsing script\n\nmavlink_msgs = []\n")
+
+    for msg in msgs:
+        outf.write("mavlink_msgs[%i] = { name: \"%s\", CRC: %i }\n" % (msg.id, msg.name, msg.crc_extra))
+    outf.write("\n")
+
+    for enum in enums:
+        if enum.name != "MAV_COMPONENT":
+            # Only need component ID
+            continue
+        outf.write("%s = []\n" % enum.name)
+        for entry in enum.entry:
+            outf.write("%s[%i] = \"%s\"\n" % (enum.name, entry.value, entry.name))
+        outf.write("\n")
+
+
+    outf.close()
+    print("Generated %s OK" % basename)
+


### PR DESCRIPTION
This adds a very basic JavaScript generator. This outputs message name and CRC for a given index. Also outputs "MAV_COMPONENT" enum. 

This is not a full parser, and does not consider fields at all. Used for https://github.com/ArduPilot/WebTools/pull/124

Example output https://github.com/IamPete1/WebTools/blob/updates/StreamStats/mavlink_msgs.js
