### PR TITLE
Mavgen C: Use strncpy instead of memcpy to pack char[n] fields

### DIFF
--- a/generator/C/include_v0.9/protocol.h
+++ b/generator/C/include_v0.9/protocol.h
@@ -169,12 +169,41 @@ static void mav_array_memcpy(void *dest, const void *src, size_t n)
 }
 
 /*
+ * Array direct assignment, for use when fields align and no byte swapping
+ * is required. Most are directly #defined to mav_array_memcpy, except for 
+ * mav_array_assign_char, which uses strncpy instead.
+ */
+#if !MAVLINK_NEED_BYTE_SWAP && MAVLINK_ALIGNED_FIELDS
+static inline void mav_array_assign_char(char *dest, const char *src, size_t n)
+{
+	if (src == NULL) {
+		memset(dest, 0, n);
+	} else {
+		strncpy(dest, src, n);
+	}
+}
+#define mav_array_assign_uint8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint8_t))
+#define mav_array_assign_int8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int8_t))
+#define mav_array_assign_uint16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint16_t))
+#define mav_array_assign_int16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int16_t))
+#define mav_array_assign_uint32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint32_t))
+#define mav_array_assign_int32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int32_t))
+#define mav_array_assign_uint64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint64_t))
+#define mav_array_assign_int64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int64_t))
+#define mav_array_assign_float(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(float))
+#define mav_array_assign_double(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(double))
+#endif
+
+/*
  * Place a char array into a buffer
  */
 static inline void _mav_put_char_array(char *buf, uint8_t wire_offset, const char *b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+	if (b == NULL) {
+		memset(&buf[wire_offset], 0, array_length);
+	} else {
+		strncpy(&buf[wire_offset], b, array_length);
+	}
 }
 
 /*

--- a/generator/C/include_v1.0/protocol.h
+++ b/generator/C/include_v1.0/protocol.h
@@ -187,12 +187,41 @@ static inline void mav_array_memcpy(void *dest, const void *src, size_t n)
 }
 
 /*
+ * Array direct assignment, for use when fields align and no byte swapping
+ * is required. Most are directly #defined to mav_array_memcpy, except for 
+ * mav_array_assign_char, which uses strncpy instead.
+ */
+#if !MAVLINK_NEED_BYTE_SWAP && MAVLINK_ALIGNED_FIELDS
+static inline void mav_array_assign_char(char *dest, const char *src, size_t n)
+{
+	if (src == NULL) {
+		memset(dest, 0, n);
+	} else {
+		strncpy(dest, src, n);
+	}
+}
+#define mav_array_assign_uint8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint8_t))
+#define mav_array_assign_int8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int8_t))
+#define mav_array_assign_uint16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint16_t))
+#define mav_array_assign_int16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int16_t))
+#define mav_array_assign_uint32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint32_t))
+#define mav_array_assign_int32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int32_t))
+#define mav_array_assign_uint64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint64_t))
+#define mav_array_assign_int64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int64_t))
+#define mav_array_assign_float(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(float))
+#define mav_array_assign_double(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(double))
+#endif
+
+/*
  * Place a char array into a buffer
  */
 static inline void _mav_put_char_array(char *buf, uint8_t wire_offset, const char *b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+	if (b == NULL) {
+		memset(&buf[wire_offset], 0, array_length);
+	} else {
+		strncpy(&buf[wire_offset], b, array_length);
+	}
 }
 
 /*

--- a/generator/C/include_v2.0/protocol.h
+++ b/generator/C/include_v2.0/protocol.h
@@ -180,12 +180,41 @@ static inline void mav_array_memcpy(void *dest, const void *src, size_t n)
 }
 
 /*
+ * Array direct assignment, for use when fields align and no byte swapping
+ * is required. Most are directly #defined to mav_array_memcpy, except for 
+ * mav_array_assign_char, which uses strncpy instead.
+ */
+#if !MAVLINK_NEED_BYTE_SWAP && MAVLINK_ALIGNED_FIELDS
+static inline void mav_array_assign_char(char *dest, const char *src, size_t n)
+{
+	if (src == NULL) {
+		memset(dest, 0, n);
+	} else {
+		strncpy(dest, src, n);
+	}
+}
+#define mav_array_assign_uint8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint8_t))
+#define mav_array_assign_int8_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int8_t))
+#define mav_array_assign_uint16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint16_t))
+#define mav_array_assign_int16_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int16_t))
+#define mav_array_assign_uint32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint32_t))
+#define mav_array_assign_int32_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int32_t))
+#define mav_array_assign_uint64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(uint64_t))
+#define mav_array_assign_int64_t(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(int64_t))
+#define mav_array_assign_float(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(float))
+#define mav_array_assign_double(DEST,SRC,N) mav_array_memcpy(DEST,SRC,N*sizeof(double))
+#endif
+
+/*
  * Place a char array into a buffer
  */
 static inline void _mav_put_char_array(char *buf, uint8_t wire_offset, const char *b, uint8_t array_length)
 {
-	mav_array_memcpy(&buf[wire_offset], b, array_length);
-
+	if (b == NULL) {
+		memset(&buf[wire_offset], 0, array_length);
+	} else {
+		strncpy(&buf[wire_offset], b, array_length);
+	}
 }
 
 /*

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -232,7 +232,7 @@ ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array
     mavlink_${name_lower}_t packet;
 ${{scalar_fields:    packet.${name} = ${putname};
 }}
-${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
+${{array_fields:    mav_array_assign_${type}(packet.${name}, ${name}, ${array_length});
 }}
         memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
 #endif
@@ -304,7 +304,7 @@ ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array
     mavlink_${name_lower}_t packet;
 ${{scalar_fields:    packet.${name} = ${putname};
 }}
-${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
+${{array_fields:    mav_array_assign_${type}(packet.${name}, ${name}, ${array_length});
 }}
         memcpy(_MAV_PAYLOAD_NON_CONST(msg), &packet, MAVLINK_MSG_ID_${name}_LEN);
 #endif
@@ -376,7 +376,7 @@ ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array
     mavlink_${name_lower}_t packet;
 ${{scalar_fields:    packet.${name} = ${putname};
 }}
-${{array_fields:    mav_array_memcpy(packet.${name}, ${name}, sizeof(${type})*${array_length});
+${{array_fields:    mav_array_assign_${type}(packet.${name}, ${name}, ${array_length});
 }}
     _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char *)&packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #endif
@@ -417,7 +417,7 @@ ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array
     mavlink_${name_lower}_t *packet = (mavlink_${name_lower}_t *)msgbuf;
 ${{scalar_fields:    packet->${name} = ${putname};
 }}
-${{array_fields:    mav_array_memcpy(packet->${name}, ${name}, sizeof(${type})*${array_length});
+${{array_fields:    mav_array_assign_${type}(packet->${name}, ${name}, ${array_length});
 }}
     _mav_finalize_message_chan_send(chan, MAVLINK_MSG_ID_${name}, (const char *)packet, MAVLINK_MSG_ID_${name}_MIN_LEN, MAVLINK_MSG_ID_${name}_LEN, MAVLINK_MSG_ID_${name}_CRC);
 #endif


### PR DESCRIPTION
The aim of this PR is to fix #725 and fix mavlink/mavlink#1946

### Current situation:
At present when a user calls the `mavlink_msg_<message>_pack` function on a message containing char[n] fields, these fields will be copied into the destination buffer using memcpy. This can go wrong in a couple of ways, if end users are not careful, for example....

1. If specifying an argument as a string literal, the read will go beyond the input variable's scope, which could have some bad consequences:
```C
mavlink_msg_param_request_read_pack(mysys, mycomp, &msg, tgtsys, tgtcomp, "PARAM", -1);
```
2. Even if using a large enough buffer, it is possible that the bits of memory beyond the null may contain leftover or random values, which would end up in the message. In this example, bytes after null could be anything when requesting PARAM, and will include the last bit of LONGER_PARAM when reading SHORT:
```C
const char* list_of_params = {"PARAM", "LONGER_PARAM", "SHORT"};
char param[17]; // enough for null
for (int i=0; i<3;i++) {
    strcpy(param,list_of_params_i_want[i]);
    mavlink_msg_param_request_read_pack(mysys, mycomp, &msg, tgtsys, tgtcomp, param, -1);
}
```
These extra bytes will stop the Mavlink 2 message-truncation from being as efficient as it can be, and may confuse some receivers.

### Proposal:
This PR proposes to use the strncpy function when packing char arrays, as I believe that this aligns with the way in which Mavlink char array fields are specified and used:
* destination array will be filled up to a maximum of n chars, and therefore may not be null-terminated.
* if null is found within the n characters, reading stops, and the remainder of the destination up to n is filled with zeros.

This should both protect against reading bad memory, and also ensure bytes beyond the length of short strings are zero, allowing the Mavlink 2 message truncation to work properly.

For little-endian and struct-aligned cases:
This is done by replacing the calls to `mav_array_memcpy` in mavgen_c.py with type-specific array assignment macros `mavlink_array_assign_[type]`.
For char arrays, this uses `strncpy` (after check that input is not null pointer).
For other arrays, this is a thin-macro which calls `mav_array_memcpy`, as per current behaviour.

Big big-endian or non-struct-aligned cases:
This is done by an update to the existing `_mav_put_char_array` function to use `strncpy` (after check that input is not null pointer).

### Testing
I've tested this update (in particular using the PARAM_REQUEST_READ and PLAY_TUNE messages) on my system.
I also checked compilation with MAVLINK_ALIGNED_FIELDS=0.
