### PR TITLE
Mavgen JS: Heartbeat message mavlink_version should be automaticlly completed

### DIFF
--- a/generator/javascript/test/message10.js
+++ b/generator/javascript/test/message10.js
@@ -93,13 +93,12 @@ describe('Complete MAVLink 1.0 packet', function() {
             , base_mode=45
             , custom_mode=68
             , system_status=13
-            , mavlink_version=1
         );
         
         this.mav.seq = 7;
 
         // Create a buffer that matches what the Python version of MAVLink creates
-        var reference = new Buffer.from([0xfe, 0x09, 0x07, 0x2a, 0x96, 0x00, 0x44, 0x00, 0x00, 0x00, 0x05, 0x03, 0x2d, 0x0d, 0x01, 0xac, 0x9d]);
+        var reference = new Buffer.from([0xfe, 0x09, 0x07, 0x2a, 0x96, 0x00, 0x44, 0x00, 0x00, 0x00, 0x05, 0x03, 0x2d, 0x0d, 0x03, 0x1c, 0xae]);
         new Buffer.from(heartbeat.pack(this.mav)).should.eql(reference);
 
     });
@@ -161,7 +160,6 @@ describe('MAVLink 1.0 message', function() {
             0, // base mode, mavlink10.MAV_MODE_FLAG_***
             0, // custom mode
             mavlink10.MAV_STATE_STANDBY, // system status
-            3 // MAVLink version
         );
 
         this.mav = new MAVLink10Processor();

--- a/generator/javascript/test/message20.js
+++ b/generator/javascript/test/message20.js
@@ -97,7 +97,6 @@ describe('Complete MAVLink 2.0 packet', function() {
             , base_mode=45
             , custom_mode=68
             , system_status=13
-            , mavlink_version=3 // it's NOT a v1 vs v2 thing here. 3 really is its normal value.
         );
         
         this.mav.seq = 7;
@@ -356,7 +355,6 @@ describe('MAVLink 2.0 message', function() {
             0, // base mode, mavlink.MAV_MODE_FLAG_***
             0, // custom mode
             mavlink20.MAV_STATE_STANDBY, // system status
-            3 // MAVLink version
         );
 
         this.mav = new MAVLink20Processor();

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -257,7 +257,8 @@ def generate_classes(outf, msgs, xml):
     def field_descriptions(fields):
         ret = ""
         for f in fields:
-            ret += "                %-18s        : %s (%s)\n" % (f.name, f.description.strip(), f.type)
+            if not f.omit_arg:
+                ret += "                %-18s        : %s (%s)\n" % (f.name, f.description.strip(), f.type)
         return ret
 
     # now do all the messages
@@ -265,10 +266,13 @@ def generate_classes(outf, msgs, xml):
 
         # assemble some strings we'll use later in outputting ..
         comment = "%s\n\n%s" % (wrapper.fill(m.description.strip()), field_descriptions(m.fields))
-        selffieldnames = 'self, '
+        argfieldnames = []
+        conststr = ""
         for f in m.fields:
-            selffieldnames += '%s, ' % f.name
-        selffieldnames = selffieldnames[:-2]
+            if not f.omit_arg:
+                argfieldnames.append(f.name)
+            else:
+                conststr = conststr + "    this.%s = %s;\n" % (f.name, f.const_value)
 
         # instance field support copied from mavgen_python
         if m.instance_field is not None:
@@ -289,11 +293,11 @@ def generate_classes(outf, msgs, xml):
         outf.write("    %s.messages.%s = function(" % ( get_mavhead(xml), m.name.lower() ) )
         outf.write(" ...moreargs ) {\n")
         # passing the dynamic args into the correct attributes, we can call the constructor with or without the 'moreargs'
-        outf.write("     [ this.%s ] = moreargs;\n" % " , this.".join(m.fieldnames))
+        outf.write("    [ this.%s ] = moreargs;\n" % " , this.".join(argfieldnames))
+        outf.write(conststr)
 
         # body: set message type properties    
         outf.write("""
-
     this._format = '%s';
     this._id = %s.MAVLINK_MSG_ID_%s;
     this.order_map = %s;


### PR DESCRIPTION
This PR updates the Javascript generator to automate the filling of the HEARTBEAT.mavlink_version parameter.
As per the C Mavgen, it uses 'omit_arg' parameter of the field to determine that the parameter should be omitted from the input parameter list, and 'const_value' parameter to determine the value to set.

When building a HEARTBEAT message via the constructor the parameter should no longer be specified, and the test cases have been updated to do this.
When the message is being read from a data stream, the value is correctly populated to whatever its actual value is, as this uses direct field assignment and not the constructor to build the message (I have tested this).

The change in output ends up looking like this:
from:
```javascript
/*              ...
                system_status             : System status flag. (uint8_t)
                mavlink_version           : MAVLink version, not writable by user, gets added by protocol because of magic data type: uint8_t_mavlink_version (uint8_t)
*/
mavlink20.messages.heartbeat = function( ...moreargs ) {
[ this.type , this.autopilot , this.base_mode , this.custom_mode , this.system_status , this.mavlink_version ] = moreargs;
```
to:
```javascript
/*              ...
                system_status             : System status flag. (uint8_t)
*/
mavlink20.messages.heartbeat = function( ...moreargs ) {
[ this.type , this.autopilot , this.base_mode , this.custom_mode , this.system_status ] = moreargs;
this.mavlink_version = 3;
```

Testing:
I have tested this on my React Native application, including checking that a received message correctly populates the field - even if its value differs from the default.
This is also tested in CI on a variety of NodeJS versions.