### PR TITLE
mavlogdump: show clear error message when mat_file arg is missing

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -76,6 +76,10 @@ if args.profile:
     yappi.start()
 
 if args.format == 'mat':
+    # Check that the mat_file argument has been specified
+    if args.mat_file is None:
+        print("mat_file argument must be specified when mat format is selected")
+        quit()
     # Load these modules here, as they're only needed for MAT file creation
     import scipy.io
     import numpy as np


### PR DESCRIPTION
I was trying to use mavlogdump to generate a .mat file from a .bin file, and forgot to specify the --mat_file argument. I found the exception thrown by the call to scipy.io.savemat was not very clear as to my mistake.
This PR adds a check before processing the input file that the required argument is specified, and gives the user a clearer message as follows:
`mat_file argument must be specified when mat format is selected`