### PR TITLE
mavlogdump: Use sys.exit instead of quit on error

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -79,7 +79,7 @@ if args.format == 'mat':
     # Check that the mat_file argument has been specified
     if args.mat_file is None:
         print("mat_file argument must be specified when mat format is selected")
-        quit()
+        sys.exit(1)
     # Load these modules here, as they're only needed for MAT file creation
     import scipy.io
     import numpy as np
@@ -190,13 +190,13 @@ if istlog and args.format == 'csv': # we know our fields from the get-go
                 offsets[type] = currentOffset
                 currentOffset += len(fields)
             except IndexError:
-                quit()
+                sys.exit(1)
             except AttributeError:
                 print("Message type '%s' not found" % (type))
-                quit()
+                sys.exit(1)
     except TypeError:
         print("You must specify a list of message types if outputting CSV format via the --types argument.")
-        exit()
+        sys.exit(1)
 
     # The first line output are names for all columns
     print(args.csv_sep.join(fields))
@@ -204,7 +204,7 @@ if istlog and args.format == 'csv': # we know our fields from the get-go
 if (isbin or islog) and args.format == 'csv': # need to accumulate columns from message
     if types is None or len(types) != 1:
         print("Need exactly one type when dumping CSV from bin file")
-        quit()
+        sys.exit(1)
 
 # Track types found
 available_types = set()
@@ -224,7 +224,7 @@ if (isbin or islog) and args.format == 'csv':
     # Make sure the specified type was found
     if match_types is None:
         print("Specified type '%s' not found in log file" % (types[0]))
-        quit()
+        sys.exit(1)
     # we need FMT messages for column headings
     match_types.append("FMT")
 


### PR DESCRIPTION
As @peterbarker pointed out in comments on #928, quit() should not be normally be used in scripts, but instead sys.exit() is preferred.
This PR replaces the uses of quit() and exit() in mavlogdump with sys.exit(1) - all uses are error conditions, hence using return code 1.
I tested a few of the error conditions out, and checked they return neatly with the correct error code set, for example:
```
$ mavlogdump.py --format=csv file.BIN 
Need exactly one type when dumping CSV from bin file
$ echo $?
1
```