### PR TITLE
mavutil: Raise ValueError instead of exiting

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1053,8 +1053,7 @@ class mavudp(mavfile):
     def __init__(self, device, input=True, broadcast=False, source_system=255, source_component=0, use_native=default_native, timeout=0):
         a = device.split(':')
         if len(a) != 2:
-            print("UDP ports must be specified as host:port")
-            sys.exit(1)
+            raise ValueError("UDP ports must be specified as host:port")
         self.port = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self.udp_server = input
         self.broadcast = False
@@ -1225,8 +1224,7 @@ class mavtcp(mavfile):
                  use_native=default_native):
         a = device.split(':')
         if len(a) != 2:
-            print("TCP ports must be specified as host:port")
-            sys.exit(1)
+            raise ValueError("TCP ports must be specified as host:port")
         self.destination_addr = (a[0], int(a[1]))
 
         self.autoreconnect = autoreconnect
@@ -1321,8 +1319,7 @@ class mavtcpin(mavfile):
     def __init__(self, device, source_system=255, source_component=0, retries=3, use_native=default_native):
         a = device.split(':')
         if len(a) != 2:
-            print("TCP ports must be specified as host:port")
-            sys.exit(1)
+            raise ValueError("TCP ports must be specified as host:port")
         self.listen = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.listen_addr = (a[0], int(a[1]))
         self.listen.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
Users of this library may want to handle these values being wrong. While it is possible to handle sys.exit, it is more conventional to raise a ValueError on incorrect data passed as an argument.