### PR TITLE
mavutil: Add option to set dialect directly from file

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -144,6 +144,28 @@ def set_dialect(dialect, with_type_annotations=None):
     current_dialect = dialect
     mavlink = mod
 
+def set_dialect_from_file(file):
+    '''set the MAVLink dialect to work with from a file.
+    For example, set_dialect_from_file("/home/user/my_dialects/v20/my_special_dialect.py")
+    '''
+    global mavlink, current_dialect
+    import importlib.util
+
+    dialect = os.path.splitext(os.path.basename(file))[0]
+
+    spec = importlib.util.spec_from_file_location(dialect, file)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[dialect] = mod
+    try:
+        spec.loader.exec_module(mod)
+    except FileNotFoundError:
+        print('Could not find dialect file %s' % file)
+        print('Stay on dialect %s' % current_dialect)
+    else:
+        current_dialect = dialect
+        mavlink = mod
+        print('Set dialect %s' % current_dialect)
+
 # Set the default dialect. This is done here as it needs to be after the function declaration
 set_dialect(os.environ['MAVLINK_DIALECT'])
 


### PR DESCRIPTION
Add option to set a dialect directly from a file anywhere on the system. The dialect file has to be generated beforehand from message definitions using mavgen.

This is useful in situations where different versions of the same dialect might be needed to talk to different devices (see https://github.com/ArduPilot/pymavlink/issues/864).

Example:
```python
from pymavlink import mavutil
import os

os.environ['MAVLINK20'] = "1"

mavutil.set_dialect_from_file("/home/user/my_dialects/v20/my_special_dialect.py")
```

I'm not sure if this is something that pymavlink intends to support or if there are better solutions to this problem. Happy to be educated.