### PR TITLE
Javascript: Fix wrong crc calculation

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -846,7 +846,7 @@ unpacked = jspack.Unpack('cBBBBB', msgbuf.slice(0, 6));
     var messageChecksum2 = ${MAVHEAD}.x25Crc([decoder.crc_extra], messageChecksum); 
  
     if ( receivedChecksum != messageChecksum2 ) { 
-        throw new Error('invalid MAVLink CRC in msgID ' +msgId+ ', got 0x' + receivedChecksum + ' checksum, calculated payload checksum as 0x'+messageChecksum2 ); 
+        throw new Error('invalid MAVLink CRC in msgID ' +msgId+ ', got ' + receivedChecksum + ' checksum, calculated payload checksum as '+messageChecksum2 );
     }
  
     // now check the signature... 

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -53,7 +53,7 @@ ${MAVHEAD} = function(){};
 ${MAVHEAD}.x25Crc = function(buffer, crcIN) {
 
     var bytes = buffer;
-    var crcOUT = crcIN || 0xffff;
+    var crcOUT = crcIN ===  undefined ? 0xffff : crcIN;
     _.each(bytes, function(e) {
         var tmp = e ^ (crcOUT & 0xff);
         tmp = (tmp ^ (tmp << 4)) & 0xff;

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -49,7 +49,7 @@ ${MAVHEAD} = function(){};
 ${MAVHEAD}.x25Crc = function(buffer, crcIN) {
 
     var bytes = buffer;
-    var crcOUT = crcIN || 0xffff;
+    var crcOUT = crcIN ===  undefined ? 0xffff : crcIN;
     _.each(bytes, function(e) {
         var tmp = e ^ (crcOUT & 0xff);
         tmp = (tmp ^ (tmp << 4)) & 0xff;

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -570,7 +570,7 @@ unpacked = jspack.Unpack('cBBBBB', msgbuf.slice(0, 6));
     messageChecksum = ${MAVHEAD}.x25Crc([decoder.crc_extra], messageChecksum);
     
     if ( receivedChecksum != messageChecksum ) {
-        throw new Error('invalid MAVLink CRC in msgID ' +msgId+ ', got 0x' + receivedChecksum + ' checksum, calculated payload checksum as 0x'+messageChecksum );
+        throw new Error('invalid MAVLink CRC in msgID ' +msgId+ ', got ' + receivedChecksum + ' checksum, calculated payload checksum as '+messageChecksum );
     }
 
     var paylen = jspack.CalcLength(decoder.format);


### PR DESCRIPTION
Currently, the javascript code will throw a wrong CRC error even though the crc is correct with a probability of 1 to 65535.

This happens because in the x25Crc method we don't differentiate `crcIN === undefined` from `crcIN === 0`.