### PR TITLE
DFReader: Fix some missing bitmask info in dump verbose

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -327,30 +327,26 @@ class DFMessage(object):
                 if bit_offset > highest:
                     highest = bit_offset
 
-            for i in range(bit_offset):
+            for i in range(highest+1):
                 bit_value = 1 << i
+                if val & bit_value:
+                    bang = " "
+                else:
+                    bang = "!"
                 done = False
                 for bit in bitmask.bit:
                     if bit["value"] != bit_value:
                         continue
-                    if val & bit_value:
-                        bang = ""
-                    else:
-                        bang = "!"
                     bit_name = bit.get('name')
-                    bit_desc = None
-                    try:
-                        bit_desc = bit["description"]
-                    except KeyError:
-                        pass
-                    if bit_desc is None:
-                        f.write("        %s%s\n" % (bang, bit_name,))
+                    f.write("      %s %s" % (bang, bit_name,))
+                    if hasattr(bit, 'description'):
+                        f.write(" (%s)\n" % bit["description"])
                     else:
-                        f.write("        %s%s (%s)\n" % (bang, bit_name, bit_desc))
+                        f.write("\n")
                     done = True
                     break
                 if not done:
-                    f.write("        %{s}UNKNOWN_BIT%s\n" % (bang, str(i)))
+                    f.write("      %s UNKNOWN_BIT%d\n" % (bang, i))
         except Exception as e:
             # print(e)
             pass


### PR DESCRIPTION
Following #937, I noticed a few things with bitmask displays that wasn't quite behaving, which this PR aims to fix:

1/ The bits of ArmChecks are not being displayed when doing `dump --verbose ARM`
This was because these bits have no description, and the `except KeyError` does not catch this.
Fixed by using if `hasattr(bit, 'description')` instead.

2/ The last bit was always missing (e.g. CHANGED bit on POWR.Flags)
This was because `for i in range(bit_offset)` needs a `+1`.
Actually I realised this should rather be using `highest_bit+1` in case more bits are set than defined.

3/ If any bit is missing a definition from the XML, then this and subsequent bit are not shown 
This was because `bang` variable was being used undefined in this case.
Fixed by defining `bang` earlier, so it is available in either case.

I have also aligned the "!" to be spaced out consistently with how TLOGs and MavProxy show these things.

Tested with a number of examples:
ARM now showing bits:
```
2024-05-27 11:35:58.749: ARM
    TimeUS: 190359078 µs
    ArmState: 0
    ArmChecks: 0
      ! ARMING_CHECK_ALL
      ! ARMING_CHECK_BARO
      ! ARMING_CHECK_COMPASS
      ! ARMING_CHECK_GPS
...
```
POWR now showing last bit:
```
2024-05-27 11:36:13.747: POWR
    TimeUS: 205357102 µs
    Vcc: qnan V
    VServo: qnan V
    Flags: 0
      ! BRICK_VALID (main brick power supply valid)
      ! SERVO_VALID (main servo power supply valid for FMU)
      ! USB_CONNECTED (USB power is connected)
      ! PERIPH_OVERCURRENT (peripheral supply is in over-current state)
      ! PERIPH_HIPOWER_OVERCURRENT (hi-power peripheral supply is in over-current state)
      ! CHANGED (Power status has changed since boot)
...
```
And by removing the bits except USING_SIGNING from the MAV definition in my local .pymavlink/LogMessages/Plane.xml file:
```
2024-05-27 11:36:13.274: MAV
    TimeUS: 204884099 µs
    chan: 1 instance
    txp: 15274
    rxp: 624
    rxdp: 0
    flags: 6
      ! USING_SIGNING
        UNKNOWN_BIT1
        UNKNOWN_BIT2
    ss: 0 ms
    tf: 0
```