### PR TITLE
fix undeclared for edians

### DIFF
--- a/generator/CPP11/include_v2.0/msgmap.hpp
+++ b/generator/CPP11/include_v2.0/msgmap.hpp
@@ -6,6 +6,13 @@
 #include <sys/endian.h>
 #elif __APPLE__
 #include <machine/endian.h>
+#include <libkern/OSByteOrder.h>
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
 #else
 #include <endian.h>
 #endif


### PR DESCRIPTION
When compiling mavlink in navtive install of ROS2 Humble in Mac OS X (Sonoma 14.5) with Apple Silicon (M3),

Had to add translation definitions for macos
```
#elif __APPLE__
#include <machine/endian.h>
#include <libkern/OSByteOrder.h>
#define htole16(x) OSSwapHostToLittleInt16(x)
#define le16toh(x) OSSwapLittleToHostInt16(x)
#define htole32(x) OSSwapHostToLittleInt32(x)
#define le32toh(x) OSSwapLittleToHostInt32(x)
#define htole64(x) OSSwapHostToLittleInt64(x)
#define le64toh(x) OSSwapLittleToHostInt64(x)
```
To fix following compile error

```
/test_ws/install/include/mavlink/v2.0/common/../msgmap.hpp:114:12: error: use of undeclared identifier 'htole16'
    return htole16(data);
           ^
/test_ws/install/include/mavlink/v2.0/common/../msgmap.hpp:120:12: error: use of undeclared identifier 'htole32'
    return htole32(data);
           ^
/test_ws/install/include/mavlink/v2.0/common/../msgmap.hpp:126:12: error: use of undeclared identifier 'htole64'
    return htole64(data);
           ^
/install/include/mavlink/v2.0/common/../msgmap.hpp:156:12: error: use of undeclared identifier 'le16toh'
    return le16toh(data);
           ^
/install/include/mavlink/v2.0/common/../msgmap.hpp:162:12: error: use of undeclared identifier 'le32toh'
    return le32toh(data);
           ^
/install/include/mavlink/v2.0/common/../msgmap.hpp:168:12: error: use of undeclared identifier 'le64toh'
    return le64toh(data);
```