### PR TITLE
WLua: Handle LUA error with %Z date format on Windows

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -81,7 +81,10 @@ local function time_usec_decode(value)
         d = os.date("%Y-%m-%d %H:%M:%S",value:tonumber() / 1000000.0)
         us = value % 1000000
         us = string.format("%06d",us:tonumber())
-        tz = os.date(" %Z",value:tonumber() / 1000000.0)
+        ok, tz = pcall(os.date," %Z",value:tonumber() / 1000000.0)
+        if not ok then
+            tz = os.date(" %z",value:tonumber() / 1000000.0)
+        end
         return " (" .. d .. "." .. us .. tz .. ")"
     elseif value < 1000000 then
         return ""


### PR DESCRIPTION
I came across an error using  the Wireshark dissector on Windows, with messages containing unix time in μs.
```
Lua Error: ...Data\Roaming\Wireshark\plugins\mavlink_ardupilotmega.lua:22: bad argument #1 to 'date' (invalid conversion specifier '%Z')
    [Expert Info (Error/Undecoded): Lua Error: ...Data\Roaming\Wireshark\plugins\mavlink_ardupilotmega.lua:22: bad argument #1 to 'date' (invalid conversion specifier '%Z')]
        [Lua Error: ...Data\Roaming\Wireshark\plugins\mavlink_ardupilotmega.lua:22: bad argument #1 to 'date' (invalid conversion specifier '%Z')]
        [Severity level: Error]
        [Group: Undecoded]
```

The %Z date formatter should give the timezone as a short name, but it is not working on Lua 5.2.4 on Windows - as currently used in Wireshark. It worked on Linux, and is already fixed in Lua 5.3.3 or later, which I believe Wireshark will switch to at some point.

I have added code to the generator to catch the error, and if it occurs will instead use "%z" - which gives timezone as an offset instead.
So Windows users will see something like:
```
Payload: SYSTEM_TIME (2)
    time_unix_usec (uint64_t) [us]: 1718704143118600 (2024-06-18 10:49:03.118600 +0100)
    time_boot_ms (uint32_t) [ms]: 29935
```
When Wireshark is updated to use a newer Lua, it will give something like this (as Linux users see already):
```
Payload: SYSTEM_TIME (2)
    time_unix_usec (uint64_t) [us]: 1718704143118600 (2024-06-18 10:49:03.118600 BST)
    time_boot_ms (uint32_t) [ms]: 29935
```

Tested on my Windows setup, and the error is gone, and output as shown.
