### PR TITLE
mavgen: always report generator errors in the exit code

### DIFF
--- a/tools/mavgen.py
+++ b/tools/mavgen.py
@@ -25,10 +25,10 @@ parser.add_argument("--wire-protocol", choices=[mavparse.PROTOCOL_0_9, mavparse.
 parser.add_argument("--no-validate", action="store_false", dest="validate", default=mavgen.DEFAULT_VALIDATE, help="Do not perform XML validation. Can speed up code generation if XML files are known to be correct.")
 parser.add_argument("--error-limit", default=mavgen.DEFAULT_ERROR_LIMIT, help="maximum number of validation errors to display")
 parser.add_argument("--strict-units", action="store_true", dest="strict_units", default=mavgen.DEFAULT_STRICT_UNITS, help="Perform validation of units attributes.")
-parser.add_argument("--exit-code", action="store_true", dest="exit_code", default=False, help="Return an error code if generation fails.")
 parser.add_argument("definitions", metavar="XML", nargs="+", help="MAVLink definitions")
 args = parser.parse_args()
 
 ok = mavgen.mavgen(args, args.definitions)
-if not ok and args.exit_code:
+# report failure in the exit code when no exception is thrown
+if not ok:
     exit(1)


### PR DESCRIPTION
I'm thankful that @nexton-winjeel added the option to have the exit code indicate an error in https://github.com/ArduPilot/pymavlink/pull/863. I'm asking myself why this isn't default. I imagine the generator to be called automatically by CI or like in my case a build step in PX4. Shouldn't it fail by default instead of silently succeeding without a certain dialect properly generated? I would have expected that.

I changed it for PX4 to explicitly add the flag in https://github.com/PX4/PX4-Autopilot/pull/23313 but want to save the next developer having the hassle.

**EDIT:** To clarify some mistakes e.g. using a non-existing type in a message definition makes the generation throw an exception and fail early. Other mistakes like referring to a non-existing enum don't throw an exception but rather print `Enum X in X does not exist` and make the `mavgen.mavgen()` function return `False`. These should be caught early to not cause problems down the road in the build workflow.