### PR TITLE
 DFReader.py: emit enumeration value name when verbose-dumping 

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -383,6 +383,20 @@ class DFMessage(object):
                 except UnicodeDecodeError:
                     f.write("    %s: %s" % (c, to_string(val)))
 
+            # see if this is an enumeration entry, emit enumeration
+            # entry name if it is
+            if c in field_metadata_by_name:
+                fm = field_metadata_by_name[c]
+                fm_enum = getattr(fm, "enum", None)
+                if fm_enum is not None:
+                    enum_entry_name = "?????"  # default, "not found" value
+                    for entry in fm_enum.iterchildren():
+                        if int(entry.value) == int(val):
+                            enum_entry_name = entry.get('name')
+                            break
+
+                    f.write(f" ({enum_entry_name})")
+
             # Append the unit to the output
             unit = self.fmt.get_unit(c)
             if unit.startswith("rad"):

--- a/DFReader.py
+++ b/DFReader.py
@@ -382,17 +382,18 @@ class DFMessage(object):
                     f.write("    %s: %s" % (c, val))
                 except UnicodeDecodeError:
                     f.write("    %s: %s" % (c, to_string(val)))
+
             # Append the unit to the output
             unit = self.fmt.get_unit(c)
-            if unit == "":
-                # No unit specified - just output the newline
-                f.write("\n")
-            elif unit.startswith("rad"):
+            if unit.startswith("rad"):
                 # For rad or rad/s, add the degrees conversion too
-                f.write(" %s (%s %s)\n" % (unit, math.degrees(val), unit.replace("rad","deg")))
+                f.write(" %s (%s %s)" % (unit, math.degrees(val), unit.replace("rad","deg")))
             else:
                 # Append the unit
-                f.write(" %s\n" % (unit))
+                f.write(" %s" % (unit))
+
+            # output the newline
+            f.write("\n")
 
             # if this is a bitmask then print out all bits set:
             if c in field_metadata_by_name:


### PR DESCRIPTION
@shancock884 

```
    Rsn: 2 GCS_COMMAND 
2024-06-30 03:16:09.587: MODE
    TimeUS: 4987197968 µs
    Mode: 6 
    ModeNum: 6 
    Rsn: 2 GCS_COMMAND 
```

(we don't emit the mode enumerations into the ArduPilot metadata yet)

```
dump --verbose ARM 
MAV> 2024-06-30 03:17:41.162: ARM
    TimeUS: 5078772628 µs
    ArmState: 0 
    ArmChecks: 0 
      ! ARMING_CHECK_ALL
      ! ARMING_CHECK_BARO
      ! ARMING_CHECK_COMPASS
      ! ARMING_CHECK_GPS
      ! ARMING_CHECK_INS
      ! ARMING_CHECK_PARAMETERS
      ! ARMING_CHECK_RC
      ! ARMING_CHECK_VOLTAGE
      ! ARMING_CHECK_BATTERY
      ! ARMING_CHECK_AIRSPEED
      ! ARMING_CHECK_LOGGING
      ! ARMING_CHECK_SWITCH
      ! ARMING_CHECK_GPS_CONFIG
      ! ARMING_CHECK_SYSTEM
      ! ARMING_CHECK_MISSION
      ! ARMING_CHECK_RANGEFINDER
      ! ARMING_CHECK_CAMERA
      ! ARMING_CHECK_AUX_AUTH
      ! ARMING_CHECK_VISION
      ! ARMING_CHECK_FFT
      ! ARMING_CHECK_OSD
    Forced: 0 
    Method: 13 LANDED 
```