### PR TITLE
Mavutil: fix wrong sysid_state update from sysid mismatch

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -423,9 +423,9 @@ class mavfile(object):
                 self.flightmode = mode_string_v10(msg)
                 self.mav_type = msg.type
                 self.base_mode = msg.base_mode
-                self.sysid_state[self.sysid].armed = (msg.base_mode & mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
-                self.sysid_state[self.sysid].mav_type = msg.type
-                self.sysid_state[self.sysid].mav_autopilot = msg.autopilot
+                self.sysid_state[src_system].armed = (msg.base_mode & mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
+                self.sysid_state[src_system].mav_type = msg.type
+                self.sysid_state[src_system].mav_autopilot = msg.autopilot
         elif type == 'HIGH_LATENCY2':
             if self.sysid == 0:
                 # lock onto id tuple of first vehicle heartbeat
@@ -434,9 +434,9 @@ class mavfile(object):
             self.mav_type = msg.type
             if msg.autopilot == mavlink.MAV_AUTOPILOT_ARDUPILOTMEGA:
                 self.base_mode = msg.custom0
-                self.sysid_state[self.sysid].armed = (msg.custom0 & mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
-            self.sysid_state[self.sysid].mav_type = msg.type
-            self.sysid_state[self.sysid].mav_autopilot = msg.autopilot
+                self.sysid_state[src_system].armed = (msg.custom0 & mavlink.MAV_MODE_FLAG_SAFETY_ARMED)
+            self.sysid_state[src_system].mav_type = msg.type
+            self.sysid_state[src_system].mav_autopilot = msg.autopilot
 
         elif type == 'PARAM_VALUE':
             if not src_tuple in self.param_state:


### PR DESCRIPTION
On a link with multiple mavlink device, we store the state of all device into the sysid holding the port which is tottally wrong.

The easiest way to see this bug in action is to run two SITL instance connect via mavlink. Then on either mavproxy instance, use "alllinks mode guided" the SITL instance directly connect to mavproxy will update its mode fine, the other will change to another mode 
![image](https://github.com/user-attachments/assets/521b29d5-7ba5-42db-8933-b131c0508d5f)

GDB screen from mavproxy on the call of mavutil post_message() function

![image](https://github.com/user-attachments/assets/5ac82e5e-9bfb-4560-979a-1edfd49a408a)


After fix : 
![image](https://github.com/user-attachments/assets/b015e15b-fe1b-46d5-a534-b5759757515f)
