### PR TITLE
mavwp: mark re.match pattern as regex string

### DIFF
--- a/mavwp.py
+++ b/mavwp.py
@@ -502,7 +502,7 @@ class MissionItemProtocol_Fence(MissionItemProtocol):
         version_line = get_first_line_from_file(filename)
 
         if (version_line is None or
-            not re.match("[-0-9.]+\s+[-0-9.]+", version_line)):
+            not re.match(r"[-0-9.]+\s+[-0-9.]+", version_line)):
             return super(MissionItemProtocol_Fence, self).load(filename)
 
         # shamelessly copy-and-pasted from traditional loader, below


### PR DESCRIPTION
```
/home/pbarker/.local/lib/python3.12/site-packages/pymavlink-2.4.41-py3.12.egg/pymavlink/mavwp.py:505: SyntaxWarning: invalid escape sequence '\s'
  not re.match("[-0-9.]+\s+[-0-9.]+", version_line)):
```
