### PR TITLE
Update MavFTP code, add MavFTPfs example/tool

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,35 @@
+name: Pylint
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.12"]
+    steps:
+
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+
+    - name: Analysing the code with pylint
+      run: |
+        pylint __init__.py dialects\__init__.py dialects\v09\__init__.py dialects\v09\python2\__init__.py \
+        dialects\v10\__init__.py dialects\v10\python2\__init__.py dialects\v20\__init__.py \
+        examples\__init__.py generator\__init__.py tests\test_mavxml.py tools\__init__.py \
+        mavftp.py mavftp_op.py examples\mavftp_example.py examples\status_msg.py tests\test_mavftp.py \
+        tests\test_mavxml.py
+#        $(git ls-files '*.py')

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,8 @@
+[FORMAT]
+max-line-length=127
+
+[MESSAGES CONTROL]
+disable=missing-function-docstring
+
+enable=useless-suppression
+fail-on=useless-suppression

--- a/mavftp.py
+++ b/mavftp.py
@@ -12,7 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 from argparse import ArgumentParser
 
 from dataclasses import dataclass
-from enum import Enum
+from enum import IntEnum
 import logging
 
 import struct
@@ -55,28 +55,28 @@ from pymavlink.mavftp_op import (
 
 
 # error codes
-ERR_None = 0
-ERR_Fail = 1
-ERR_FailErrno = 2
-ERR_InvalidDataSize = 3
-ERR_InvalidSession = 4
-ERR_NoSessionsAvailable = 5
-ERR_EndOfFile = 6
-ERR_UnknownCommand = 7
-ERR_FileExists = 8
-ERR_FileProtected = 9
-ERR_FileNotFound = 10
-
-ERR_NoErrorCodeInPayload = 64
-ERR_NoErrorCodeInNack = 65
-ERR_NoFilesystemErrorInPayload = 66
-ERR_InvalidErrorCode = 67
-ERR_PayloadTooLarge = 68
-ERR_InvalidOpcode = 69
-ERR_InvalidArguments = 70
-ERR_PutAlreadyInProgress = 71
-ERR_FailToOpenLocalFile = 72
-ERR_RemoteReplyTimeout = 73
+class FtpError(IntEnum):
+    Success = 0
+    Fail = 1
+    FailErrno = 2
+    InvalidDataSize = 3
+    InvalidSession = 4
+    NoSessionsAvailable = 5
+    EndOfFile = 6
+    UnknownCommand = 7
+    FileExists = 8
+    FileProtected = 9
+    FileNotFound = 10
+    NoErrorCodeInPayload = 64
+    NoErrorCodeInNack = 65
+    NoFilesystemErrorInPayload = 66
+    InvalidErrorCode = 67
+    PayloadTooLarge = 68
+    InvalidOpcode = 69
+    InvalidArguments = 70
+    PutAlreadyInProgress = 71
+    FailToOpenLocalFile = 72
+    RemoteReplyTimeout = 73
 
 HDR_Len = 12
 MAX_Payload = 239
@@ -181,48 +181,48 @@ class MAVFTPReturn:
         self.invalid_payload_size = invalid_payload_size
 
     def display_message(self):  # pylint: disable=too-many-branches
-        if self.error_code == ERR_None:
+        if self.error_code == FtpError.Success:
             logging.info("%s succeeded", self.operation_name)
-        elif self.error_code == ERR_Fail:
+        elif self.error_code == FtpError.Fail:
             logging.error("%s failed, generic error", self.operation_name)
-        elif self.error_code == ERR_FailErrno:
+        elif self.error_code == FtpError.FailErrno:
             logging.error("%s failed, system error %u", self.operation_name, self.system_error)
-        elif self.error_code == ERR_InvalidDataSize:
+        elif self.error_code == FtpError.InvalidDataSize:
             logging.error("%s failed, invalid data size", self.operation_name)
-        elif self.error_code == ERR_InvalidSession:
+        elif self.error_code == FtpError.InvalidSession:
             logging.error("%s failed, session is not currently open", self.operation_name)
-        elif self.error_code == ERR_NoSessionsAvailable:
+        elif self.error_code == FtpError.NoSessionsAvailable:
             logging.error("%s failed, no sessions available", self.operation_name)
-        elif self.error_code == ERR_EndOfFile:
+        elif self.error_code == FtpError.EndOfFile:
             logging.error("%s failed, offset past end of file", self.operation_name)
-        elif self.error_code == ERR_UnknownCommand:
+        elif self.error_code == FtpError.UnknownCommand:
             logging.error("%s failed, unknown command", self.operation_name)
-        elif self.error_code == ERR_FileExists:
+        elif self.error_code == FtpError.FileExists:
             logging.warning("%s failed, file/directory already exists", self.operation_name)
-        elif self.error_code == ERR_FileProtected:
+        elif self.error_code == FtpError.FileProtected:
             logging.warning("%s failed, file/directory is protected", self.operation_name)
-        elif self.error_code == ERR_FileNotFound:
+        elif self.error_code == FtpError.FileNotFound:
             logging.warning("%s failed, file/directory not found", self.operation_name)
 
-        elif self.error_code == ERR_NoErrorCodeInPayload:
+        elif self.error_code == FtpError.NoErrorCodeInPayload:
             logging.error("%s failed, payload contains no error code", self.operation_name)
-        elif self.error_code == ERR_NoErrorCodeInNack:
+        elif self.error_code == FtpError.NoErrorCodeInNack:
             logging.error("%s failed, no error code", self.operation_name)
-        elif self.error_code == ERR_NoFilesystemErrorInPayload:
+        elif self.error_code == FtpError.NoFilesystemErrorInPayload:
             logging.error("%s failed, file-system error missing in payload", self.operation_name)
-        elif self.error_code == ERR_InvalidErrorCode:
+        elif self.error_code == FtpError.InvalidErrorCode:
             logging.error("%s failed, invalid error code %u", self.operation_name, self.invalid_error_code)
-        elif self.error_code == ERR_PayloadTooLarge:
+        elif self.error_code == FtpError.PayloadTooLarge:
             logging.error("%s failed, payload is too long %u", self.operation_name, self.invalid_payload_size)
-        elif self.error_code == ERR_InvalidOpcode:
+        elif self.error_code == FtpError.InvalidOpcode:
             logging.error("%s failed, invalid opcode %u", self.operation_name, self.invalid_opcode)
-        elif self.error_code == ERR_InvalidArguments:
+        elif self.error_code == FtpError.InvalidArguments:
             logging.error("%s failed, invalid arguments", self.operation_name)
-        elif self.error_code == ERR_PutAlreadyInProgress:
+        elif self.error_code == FtpError.PutAlreadyInProgress:
             logging.error("%s failed, put already in progress", self.operation_name)
-        elif self.error_code == ERR_FailToOpenLocalFile:
+        elif self.error_code == FtpError.FailToOpenLocalFile:
             logging.error("%s failed, failed to open local file", self.operation_name)
-        elif self.error_code == ERR_RemoteReplyTimeout:
+        elif self.error_code == FtpError.RemoteReplyTimeout:
             logging.error("%s failed, remote reply timeout", self.operation_name)
         else:
             logging.error("%s failed, unknown error %u in display_message()", self.operation_name, self.error_code)
@@ -305,7 +305,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         usage = "Usage: ftp <list|set|get|getparams|put|rm|rmdir|rename|mkdir|status|cancel|crc>"
         if len(args) < 1:
             logging.error(usage)
-            return MAVFTPReturn("FTP command", ERR_InvalidArguments)
+            return MAVFTPReturn("FTP command", FtpError.InvalidArguments)
         if args[0] == 'list':
             return self.cmd_list(args[1:])
         if args[0] == "set":
@@ -331,7 +331,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if args[0] == 'cancel':
             return self.cmd_cancel()
         logging.error(usage)
-        return MAVFTPReturn("FTP command", ERR_InvalidArguments)
+        return MAVFTPReturn("FTP command", FtpError.InvalidArguments)
 
     def __send(self, op):
         '''send a request'''
@@ -392,7 +392,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             dname = args[0]
         else:
             logging.error("Usage: list [directory]")
-            return MAVFTPReturn("ListDirectory", ERR_InvalidArguments)
+            return MAVFTPReturn("ListDirectory", FtpError.InvalidArguments)
         logging.info("Listing %s", dname)
         enc_dname = bytearray(dname, 'ascii')
         self.total_size = 0
@@ -428,13 +428,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         elif op.opcode == OP_Nack and op.payload is not None and len(op.payload) == 1 and op.payload[0] == 6:
             self.list_result = self.list_temp_result
         self.list_temp_result.extend(output)
-        return MAVFTPReturn("ListDirectory", ERR_None)
+        return MAVFTPReturn("ListDirectory", FtpError.Success)
 
     def cmd_get(self, args, callback=None, progress_callback=None) -> MAVFTPReturn:
         '''get file'''
         if len(args) == 0 or len(args) > 2:
             logging.error("Usage: get [FILENAME <LOCALNAME>]")
-            return MAVFTPReturn("OpenFileRO", ERR_InvalidArguments)
+            return MAVFTPReturn("OpenFileRO", FtpError.InvalidArguments)
         fname = args[0]
         if len(args) > 1:
             self.filename = args[1]
@@ -458,13 +458,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.open_retries = 0
         op = FTP_OP(self.seq, self.session, OP_OpenFileRO, len(enc_fname), 0, 0, 0, enc_fname)
         self.__send(op)
-        return MAVFTPReturn("OpenFileRO", ERR_None)
+        return MAVFTPReturn("OpenFileRO", FtpError.Success)
 
     def __handle_open_ro_reply(self, op, _m) -> MAVFTPReturn:
         '''handle OP_OpenFileRO reply'''
         if op.opcode == OP_Ack:
             if self.filename is None:
-                return MAVFTPReturn('OpenFileRO', ERR_FileNotFound)
+                return MAVFTPReturn('OpenFileRO', FtpError.FileNotFound)
             try:
                 if self.callback is not None or self.filename == '-':
                     self.fh = SIO()
@@ -473,7 +473,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             except Exception as ex:  # pylint: disable=broad-except
                 logging.error("FTP: Failed to open local file %s: %s", self.filename, ex)
                 self.__terminate_session()
-                return MAVFTPReturn('OpenFileRO', ERR_FileNotFound)
+                return MAVFTPReturn('OpenFileRO', FtpError.FileNotFound)
             if op.size == 4 and len(op.payload) >= 4:
                 self.remote_file_size = op.payload[0] + (op.payload[1] << 8) + (op.payload[2] << 16) + \
                                         (op.payload[3] << 24)
@@ -484,7 +484,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             read = FTP_OP(self.seq, self.session, OP_BurstReadFile, self.burst_size, 0, 0, 0, None)
             self.last_burst_read = time.time()
             self.__send(read)
-            return MAVFTPReturn('OpenFileRO', ERR_None)
+            return MAVFTPReturn('OpenFileRO', FtpError.Success)
 
         ret = self.__decode_ftp_ack_and_nack(op)
         if self.callback is None or self.ftp_settings.debug > 0:
@@ -527,14 +527,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if random.uniform(0, 100) < self.ftp_settings.pkt_loss_tx:
                 if self.ftp_settings.debug > 0:
                     logging.warning("FTP: dropping TX")
-                return MAVFTPReturn('BurstReadFile', ERR_Fail)
+                return MAVFTPReturn('BurstReadFile', FtpError.Fail)
         if self.fh is None or self.filename is None:
             if op.session != self.session:
                 # old session
-                return MAVFTPReturn('BurstReadFile', ERR_InvalidSession)
+                return MAVFTPReturn('BurstReadFile', FtpError.InvalidSession)
             logging.warning("FTP: Unexpected burst read reply. Will be discarded")
             logging.info(op)
-            return MAVFTPReturn('BurstReadFile', ERR_Fail)
+            return MAVFTPReturn('BurstReadFile', FtpError.Fail)
         self.last_burst_read = time.time()
         size = len(op.payload)
         if size > self.burst_size:
@@ -556,11 +556,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     if self.ftp_settings.debug > 0:
                         logging.info("FTP: dup read reply at %u of len %u ofs=%u", op.offset, op.size, self.fh.tell())
                     self.duplicates += 1
-                    return MAVFTPReturn('BurstReadFile', ERR_Fail)
+                    return MAVFTPReturn('BurstReadFile', FtpError.Fail)
                 self.__write_payload(op)
                 self.fh.seek(ofs)
                 if self.__check_read_finished():
-                    return MAVFTPReturn('BurstReadFile', ERR_None)
+                    return MAVFTPReturn('BurstReadFile', FtpError.Success)
             elif op.offset > ofs:
                 # we have a gap
                 gap = (ofs, op.offset-ofs)
@@ -586,38 +586,38 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                                      len(self.read_gaps), time.time() - self.op_start)
                     self.reached_eof = True
                     if self.__check_read_finished():
-                        return MAVFTPReturn('BurstReadFile', ERR_None)
+                        return MAVFTPReturn('BurstReadFile', FtpError.Success)
                     self.__check_read_send()
-                    return MAVFTPReturn('BurstReadFile', ERR_None)
+                    return MAVFTPReturn('BurstReadFile', FtpError.Success)
                 more = self.last_op
                 more.offset = op.offset + op.size
                 if self.ftp_settings.debug > 0:
                     logging.info("FTP: burst continue at %u %u", more.offset, self.fh.tell())
                 self.__send(more)
         elif op.opcode == OP_Nack:
-            ecode = op.payload[0]
-            if ecode in (ERR_EndOfFile, 0):
+            ecode = FtpError(op.payload[0])
+            if ecode in (FtpError.EndOfFile, 0):
                 if not self.reached_eof and op.offset > self.fh.tell():
                     # we lost the last part of the burst
                     if self.ftp_settings.debug > 0:
                         logging.error("FTP: burst lost EOF %u %u", self.fh.tell(), op.offset)
-                    return MAVFTPReturn('BurstReadFile', ERR_Fail)
+                    return MAVFTPReturn('BurstReadFile', FtpError.Fail)
                 if not self.reached_eof and self.ftp_settings.debug > 0:
                     logging.info("FTP: EOF at %u with %u gaps t=%.2f", self.fh.tell(),
                                  len(self.read_gaps), time.time() - self.op_start)
                 self.reached_eof = True
                 if self.__check_read_finished():
-                    return MAVFTPReturn('BurstReadFile', ERR_None)
+                    return MAVFTPReturn('BurstReadFile', FtpError.Success)
                 self.__check_read_send()
             elif self.ftp_settings.debug > 0:
                 logging.info("FTP: burst Nack (ecode:%u): %s", ecode, op)
-                return MAVFTPReturn('BurstReadFile', ERR_Fail)
+                return MAVFTPReturn('BurstReadFile', FtpError.Fail)
             if self.ftp_settings.debug > 0:
                 logging.error("FTP: burst nack: %s", op)
-                return MAVFTPReturn('BurstReadFile', ERR_Fail)
+                return MAVFTPReturn('BurstReadFile', FtpError.Fail)
         else:
             logging.warning("FTP: burst error: %s", op)
-        return MAVFTPReturn('BurstReadFile', ERR_Fail)
+        return MAVFTPReturn('BurstReadFile', FtpError.Fail)
 
     def __handle_reply_read(self, op, _m) -> MAVFTPReturn:
         '''handle OP_ReadFile reply'''
@@ -625,7 +625,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.warning("FTP: Unexpected read reply")
                 logging.warning(op)
-            return MAVFTPReturn('ReadFile', ERR_Fail)
+            return MAVFTPReturn('ReadFile', FtpError.Fail)
         if self.backlog > 0:
             self.backlog -= 1
         if op.opcode == OP_Ack and self.fh is not None:
@@ -639,7 +639,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 if self.ftp_settings.debug > 0:
                     logging.info("FTP: removed gap %u, %u, %u", gap, self.reached_eof, len(self.read_gaps))
                 if self.__check_read_finished():
-                    return MAVFTPReturn('ReadFile', ERR_None)
+                    return MAVFTPReturn('ReadFile', FtpError.Success)
             elif op.size < self.burst_size:
                 logging.info("FTP: file size changed to %u", op.offset+op.size)
                 self.__terminate_session()
@@ -651,16 +651,16 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info("FTP: Read failed with %u gaps %s", len(self.read_gaps), str(op))
             self.__terminate_session()
         self.__check_read_send()
-        return MAVFTPReturn('ReadFile', ERR_None)
+        return MAVFTPReturn('ReadFile', FtpError.Success)
 
     def cmd_put(self, args, fh=None, callback=None, progress_callback=None) -> MAVFTPReturn:
         '''put file'''
         if len(args) == 0 or len(args) > 2:
             logging.error("Usage: put [FILENAME <REMOTENAME>]")
-            return MAVFTPReturn("CreateFile", ERR_InvalidArguments)
+            return MAVFTPReturn("CreateFile", FtpError.InvalidArguments)
         if self.write_list is not None:
             logging.error("FTP: put already in progress")
-            return MAVFTPReturn("CreateFile", ERR_PutAlreadyInProgress)
+            return MAVFTPReturn("CreateFile", FtpError.PutAlreadyInProgress)
         fname = args[0]
         self.fh = fh
         if self.fh is None:
@@ -668,7 +668,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 self.fh = open(fname, 'rb')  # pylint: disable=consider-using-with
             except Exception as ex:  # pylint: disable=broad-exception-caught
                 logging.error("FTP: Failed to open %s: %s", fname, ex)
-                return MAVFTPReturn("CreateFile", ERR_FailToOpenLocalFile)
+                return MAVFTPReturn("CreateFile", FtpError.FailToOpenLocalFile)
         if len(args) > 1:
             self.filename = args[1]
         else:
@@ -704,7 +704,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         enc_fname = bytearray(self.filename, 'ascii')
         op = FTP_OP(self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 0, 0, enc_fname)
         self.__send(op)
-        return MAVFTPReturn("CreateFile", ERR_None)
+        return MAVFTPReturn("CreateFile", FtpError.Success)
 
     def __put_finished(self, flen):
         '''finish a put'''
@@ -723,14 +723,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''handle OP_CreateFile reply'''
         if self.fh is None:
             self.__terminate_session()
-            return MAVFTPReturn('CreateFile', ERR_FileNotFound)
+            return MAVFTPReturn('CreateFile', FtpError.FileNotFound)
         if op.opcode == OP_Ack:
             self.__send_more_writes()
         else:
             ret = self.__decode_ftp_ack_and_nack(op)
             self.__terminate_session()
             return ret
-        return MAVFTPReturn('CreateFile', ERR_None)
+        return MAVFTPReturn('CreateFile', FtpError.Success)
 
     def __send_more_writes(self):
         '''send some more writes'''
@@ -765,11 +765,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''handle OP_WriteFile reply'''
         if self.fh is None:
             self.__terminate_session()
-            return MAVFTPReturn('WriteFile', ERR_FileNotFound)
+            return MAVFTPReturn('WriteFile', FtpError.FileNotFound)
         if op.opcode != OP_Ack:
             logging.error("FTP: Write failed")
             self.__terminate_session()
-            return MAVFTPReturn('WriteFile', ERR_FileProtected)
+            return MAVFTPReturn('WriteFile', FtpError.FileProtected)
 
         # assume the FTP server processes the blocks sequentially. This means
         # when we receive an ack that any blocks between the last ack and this
@@ -784,13 +784,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.put_callback_progress:
             self.put_callback_progress(self.write_acks/float(self.write_total))
         self.__send_more_writes()
-        return MAVFTPReturn('WriteFile', ERR_None)
+        return MAVFTPReturn('WriteFile', FtpError.Success)
 
     def cmd_rm(self, args) -> MAVFTPReturn:
         '''remove file'''
         if len(args) != 1:
             logging.error("Usage: rm [FILENAME]")
-            return MAVFTPReturn("RemoveFile", ERR_InvalidArguments)
+            return MAVFTPReturn("RemoveFile", FtpError.InvalidArguments)
         fname = args[0]
         logging.info("Removing file %s", fname)
         enc_fname = bytearray(fname, 'ascii')
@@ -802,7 +802,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''remove directory'''
         if len(args) != 1:
             logging.error("Usage: rmdir [DIRECTORYNAME]")
-            return MAVFTPReturn("RemoveDirectory", ERR_InvalidArguments)
+            return MAVFTPReturn("RemoveDirectory", FtpError.InvalidArguments)
         dname = args[0]
         logging.info("Removing directory %s", dname)
         enc_dname = bytearray(dname, 'ascii')
@@ -818,7 +818,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''rename file or directory'''
         if len(args) < 2:
             logging.error("Usage: rename [OLDNAME NEWNAME]")
-            return MAVFTPReturn("Rename", ERR_InvalidArguments)
+            return MAVFTPReturn("Rename", FtpError.InvalidArguments)
         name1 = args[0]
         name2 = args[1]
         logging.info("Renaming %s to %s", name1, name2)
@@ -837,7 +837,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''make directory'''
         if len(args) != 1:
             logging.error("Usage: mkdir NAME")
-            return MAVFTPReturn("CreateDirectory", ERR_InvalidArguments)
+            return MAVFTPReturn("CreateDirectory", FtpError.InvalidArguments)
         name = args[0]
         logging.info("Creating directory %s", name)
         enc_name = bytearray(name, 'ascii')
@@ -853,7 +853,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''get file crc'''
         if len(args) != 1:
             logging.error("Usage: crc [NAME]")
-            return MAVFTPReturn("CalcFileCRC32", ERR_InvalidArguments)
+            return MAVFTPReturn("CalcFileCRC32", FtpError.InvalidArguments)
         name = args[0]
         self.filename = name
         self.op_start = time.time()
@@ -874,7 +874,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     def cmd_cancel(self) -> MAVFTPReturn:
         '''cancel any pending op'''
         self.__terminate_session()
-        return MAVFTPReturn("TerminateSession", ERR_None)
+        return MAVFTPReturn("TerminateSession", FtpError.Success)
 
     def cmd_status(self) -> MAVFTPReturn:
         '''show status'''
@@ -886,7 +886,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             rate = (ofs / dt) / 1024.0
             logging.info("Transfer at offset %u with %u gaps %u retries %.1f kByte/sec",
                          ofs, len(self.read_gaps), self.read_retries, rate)
-        return MAVFTPReturn("Status", ERR_None)
+        return MAVFTPReturn("Status", FtpError.Success)
 
     def __op_parse(self, m):
         '''parse a FILE_TRANSFER_PROTOCOL msg'''
@@ -901,12 +901,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         mtype = m.get_type()
         if mtype != "FILE_TRANSFER_PROTOCOL":
             logging.error("FTP: Unexpected MAVLink message type %s", mtype)
-            return MAVFTPReturn(operation_name, ERR_Fail)
+            return MAVFTPReturn(operation_name, FtpError.Fail)
 
         if m.target_system != self.master.source_system or m.target_component != self.master.source_component:
             logging.info("FTP: wrong MAVLink target %u component %u. Will discard message",
                          m.target_system, m.target_component)
-            return MAVFTPReturn(operation_name, ERR_Fail)
+            return MAVFTPReturn(operation_name, FtpError.Fail)
 
         op = self.__op_parse(m)
         now = time.time()
@@ -917,13 +917,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.warning("FTP: wrong session replied %u expected %u. Will discard message",
                                 op.session, self.session)
-            return MAVFTPReturn(operation_name, ERR_InvalidSession)
+            return MAVFTPReturn(operation_name, FtpError.InvalidSession)
         self.last_op_time = now
         if self.ftp_settings.pkt_loss_rx > 0:
             if random.uniform(0, 100) < self.ftp_settings.pkt_loss_rx:
                 if self.ftp_settings.debug > 1:
                     logging.warning("FTP: dropping packet RX")
-                return MAVFTPReturn(operation_name, ERR_Fail)
+                return MAVFTPReturn(operation_name, FtpError.Fail)
 
         if op.req_opcode == self.last_op.opcode and op.seq == (self.last_op.seq + 1) % 256:
             self.rtt = max(min(self.rtt, dt), 0.01)
@@ -937,7 +937,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.req_opcode == OP_ResetSessions:
             return self.__handle_reset_sessions_reply(op, m)
         if op.req_opcode in [OP_None, OP_TerminateSession]:
-            return MAVFTPReturn(operation_name, ERR_None)  # ignore reply
+            return MAVFTPReturn(operation_name, FtpError.Success)  # ignore reply
         if op.req_opcode == OP_CreateFile:
             return self.__handle_create_file_reply(op, m)
         if op.req_opcode == OP_WriteFile:
@@ -954,7 +954,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             return self.__handle_crc_reply(op, m)
 
         logging.info('FTP Unknown %s', str(op))
-        return MAVFTPReturn(operation_name, ERR_InvalidOpcode)
+        return MAVFTPReturn(operation_name, FtpError.InvalidOpcode)
 
     def __send_gap_read(self, g):
         '''send a read for a gap'''
@@ -1056,7 +1056,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     def process_ftp_reply(self, operation_name, timeout=5) -> MAVFTPReturn:
         ''' execute an FTP operation that requires processing a MAVLink response'''
         start_time = time.time()
-        ret = MAVFTPReturn(operation_name, ERR_Fail)
+        ret = MAVFTPReturn(operation_name, FtpError.Fail)
         recv_timeout = 0.1
         assert timeout == 0 or timeout > self.ftp_settings.idle_detection_time, \
             "timeout must be > settings.idle_detection_time"
@@ -1068,14 +1068,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if m is not None:
                 if operation_name == "TerminateSession":
                     #self.silently_discard_terminate_session_reply()
-                    ret = MAVFTPReturn(operation_name, ERR_None)
+                    ret = MAVFTPReturn(operation_name, FtpError.Success)
                 else:
                     ret = self.__mavlink_packet(m)
             if self.__idle_task():
                 break
             if timeout > 0 and time.time() - start_time > timeout:  # pylint: disable=chained-comparison
                 logging.error("FTP: timed out after %f seconds", time.time() - start_time)
-                ret = MAVFTPReturn(operation_name, ERR_RemoteReplyTimeout)
+                ret = MAVFTPReturn(operation_name, FtpError.RemoteReplyTimeout)
                 break
         return ret
 
@@ -1107,28 +1107,31 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             op_ret_name = operation_name_dict.get(op.req_opcode, "Unknown")
         len_payload = len(op.payload) if op.payload is not None else 0
         if op.opcode == OP_Ack:
-            error_code = ERR_None
+            error_code = FtpError.Success
         elif op.opcode == OP_Nack:
             if len_payload <= 0:
-                error_code = ERR_NoErrorCodeInPayload
+                error_code = FtpError.NoErrorCodeInPayload
             elif len_payload == 1:
-                error_code = op.payload[0]
-                if error_code == ERR_None:
-                    error_code = ERR_NoErrorCodeInNack
-                elif error_code == ERR_FailErrno:
-                    error_code = ERR_NoFilesystemErrorInPayload
-                elif error_code not in [ERR_Fail, ERR_InvalidDataSize, ERR_InvalidSession, ERR_NoSessionsAvailable,
-                                        ERR_EndOfFile, ERR_UnknownCommand, ERR_FileExists, ERR_FileProtected,
-                                        ERR_FileNotFound]:
+                try:
+                    error_code = FtpError(op.payload[0])
+                except ValueError:
+                    error_code = op.payload[0]
+                if error_code == FtpError.Success:
+                    error_code = FtpError.NoErrorCodeInNack
+                elif error_code == FtpError.FailErrno:
+                    error_code = FtpError.NoFilesystemErrorInPayload
+                elif error_code not in [FtpError.Fail, FtpError.InvalidDataSize, FtpError.InvalidSession, FtpError.NoSessionsAvailable,
+                                        FtpError.EndOfFile, FtpError.UnknownCommand, FtpError.FileExists, FtpError.FileProtected,
+                                        FtpError.FileNotFound]:
                     invalid_error_code = error_code
-                    error_code = ERR_InvalidErrorCode
-            elif op.payload[0] == ERR_FailErrno and len_payload == 2:
+                    error_code = FtpError.InvalidErrorCode
+            elif op.payload[0] == FtpError.FailErrno and len_payload == 2:
                 system_error = op.payload[1]
-                error_code = ERR_FailErrno
+                error_code = FtpError.FailErrno
             else:
-                error_code = ERR_PayloadTooLarge
+                error_code = FtpError.PayloadTooLarge
         else:
-            error_code = ERR_InvalidOpcode
+            error_code = FtpError.InvalidOpcode
         return MAVFTPReturn(op_ret_name, error_code, system_error=system_error, invalid_error_code=invalid_error_code,
                             invalid_payload_size=len_payload, invalid_opcode=op.opcode)
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -12,6 +12,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 from argparse import ArgumentParser
 
 from dataclasses import dataclass
+from enum import Enum
 import logging
 
 import struct
@@ -30,28 +31,28 @@ from datetime import datetime
 
 from pymavlink import mavutil
 
+from pymavlink.mavftp_op import (
+    FTP_OP,
+    OP_Ack,
+    OP_BurstReadFile,
+    OP_ListDirectory,
+    OP_Nack,
+    OP_OpenFileRO,
+    OP_ReadFile,
+    OP_TerminateSession,
+    OP_ResetSessions,
+    OP_None,
+    OP_CreateFile,
+    OP_WriteFile,
+    OP_RemoveFile,
+    OP_RemoveDirectory,
+    OP_OpenFileWO,
+    OP_CreateDirectory,
+    OP_TruncateFile,
+    OP_Rename,
+    OP_CalcFileCRC32,
+)
 
-# pylint: disable=too-many-lines
-# pylint: disable=invalid-name
-# opcodes
-OP_None = 0
-OP_TerminateSession = 1
-OP_ResetSessions = 2
-OP_ListDirectory = 3
-OP_OpenFileRO = 4
-OP_ReadFile = 5
-OP_CreateFile = 6
-OP_WriteFile = 7
-OP_RemoveFile = 8
-OP_CreateDirectory = 9
-OP_RemoveDirectory = 10
-OP_OpenFileWO = 11
-OP_TruncateFile = 12
-OP_Rename = 13
-OP_CalcFileCRC32 = 14
-OP_BurstReadFile = 15
-OP_Ack = 128
-OP_Nack = 129
 
 # error codes
 ERR_None = 0
@@ -86,43 +87,6 @@ class DirectoryEntry:
     name: str
     is_dir: bool
     size_b: int
-
-class FTP_OP:  # pylint: disable=invalid-name, too-many-instance-attributes
-    """
-    Represents an operation in the MAVLink File Transfer Protocol (FTP).
-
-    This class encapsulates the details of a single FTP operation such as reading, writing, listing directories, etc.,
-    including the necessary parameters and payload for the operation.
-    """
-    def __init__(self, seq, session, opcode, size,  # pylint: disable=too-many-arguments
-                 req_opcode, burst_complete, offset, payload):
-        self.seq = seq                        # Sequence number for the operation.
-        self.session = session                # Session identifier.
-        self.opcode = opcode                  # Operation code indicating the type of FTP operation.
-        self.size = size                      # Size of the operation.
-        self.req_opcode = req_opcode          # Request operation code.
-        self.burst_complete = burst_complete  # (bool) Flag indicating if the burst transfer is complete.
-        self.offset = offset                  # Offset for read/write operations.
-        self.payload = payload                # (bytes) Payload for the operation.
-
-    def pack(self):
-        '''pack message'''
-        ret = struct.pack("<HBBBBBBI", self.seq, self.session, self.opcode, self.size, self.req_opcode, self.burst_complete,
-                          0, self.offset)
-        if self.payload is not None:
-            ret += self.payload
-        ret = bytearray(ret)
-        return ret
-
-    def __str__(self):
-        plen = 0
-        if self.payload is not None:
-            plen = len(self.payload)
-        ret = f"OP seq:{self.seq} sess:{self.session} opcode:{self.opcode} req_opcode:{self.req_opcode}" \
-              f" size:{self.size} bc:{self.burst_complete} ofs:{self.offset} plen={plen}"
-        if plen > 0:
-            ret += f" [{self.payload[0]}]"
-        return ret
 
     def items(self):
         """Yield each attribute and its value for the FTP_OP instance. For debugging purposes."""

--- a/mavftp_op.py
+++ b/mavftp_op.py
@@ -1,0 +1,76 @@
+
+import struct
+from typing import Optional
+
+
+OP_None = 0
+OP_TerminateSession = 1
+OP_ResetSessions = 2
+OP_ListDirectory = 3
+OP_OpenFileRO = 4
+OP_ReadFile = 5
+OP_CreateFile = 6
+OP_WriteFile = 7
+OP_RemoveFile = 8
+OP_CreateDirectory = 9
+OP_RemoveDirectory = 10
+OP_OpenFileWO = 11
+OP_TruncateFile = 12
+OP_Rename = 13
+OP_CalcFileCRC32 = 14
+OP_BurstReadFile = 15
+OP_Ack = 128
+OP_Nack = 129
+
+
+# pylint: disable=too-many-arguments
+# pylint: disable=too-many-instance-attributes
+
+
+class FTP_OP:
+    def __init__(
+        self,
+        seq: int,
+        session: int,
+        opcode: int,
+        size: int,
+        req_opcode: int,
+        burst_complete: int,
+        offset: int,
+        payload: Optional[bytearray],
+    ):
+        self.seq = seq
+        self.session = session
+        self.opcode = opcode
+        self.size = size
+        self.req_opcode = req_opcode
+        self.burst_complete = burst_complete
+        self.offset = offset
+        self.payload = payload
+
+    def pack(self) -> bytearray:
+        """pack message"""
+        ret = struct.pack(
+            "<HBBBBBBI",
+            self.seq,
+            self.session,
+            self.opcode,
+            self.size,
+            self.req_opcode,
+            self.burst_complete,
+            0,
+            self.offset,
+        )
+        if self.payload is not None:
+            ret += self.payload
+        ret = bytearray(ret)
+        return ret
+
+    def __str__(self) -> str:
+        plen = 0
+        if self.payload is not None:
+            plen = len(self.payload)
+        ret = f"OP seq:{self.seq} sess:{self.session} opcode:{self.opcode} req_opcode:{self.req_opcode} size:{self.size} bc:{self.burst_complete} ofs:{self.offset} plen={plen}"
+        if self.payload is not None and plen > 0:
+            ret += f" [{self.payload[0]}]"
+        return ret

--- a/mavftp_op.py
+++ b/mavftp_op.py
@@ -1,8 +1,18 @@
+#!/usr/bin/env python3
+
+'''
+MAVLink File Transfer Protocol support - https://mavlink.io/en/services/ftp.html
+
+SPDX-FileCopyrightText: 2011-2024 Andrew Tridgell, 2024 Amilcar Lucas
+
+SPDX-License-Identifier: GPL-3.0-or-later
+'''
 
 import struct
 from typing import Optional
 
 
+# pylint: disable=invalid-name
 OP_None = 0
 OP_TerminateSession = 1
 OP_ResetSessions = 2
@@ -22,12 +32,14 @@ OP_BurstReadFile = 15
 OP_Ack = 128
 OP_Nack = 129
 
+# pylint: enable=invalid-name
 
 # pylint: disable=too-many-arguments
 # pylint: disable=too-many-instance-attributes
 
 
-class FTP_OP:
+class FTP_OP:  # pylint: disable=invalid-name
+    """FTP operation"""
     def __init__(
         self,
         seq: int,
@@ -70,7 +82,19 @@ class FTP_OP:
         plen = 0
         if self.payload is not None:
             plen = len(self.payload)
-        ret = f"OP seq:{self.seq} sess:{self.session} opcode:{self.opcode} req_opcode:{self.req_opcode} size:{self.size} bc:{self.burst_complete} ofs:{self.offset} plen={plen}"
+        ret = f"OP seq:{self.seq} sess:{self.session} opcode:{self.opcode} req_opcode:{self.req_opcode} size:{self.size}" \
+              f" bc:{self.burst_complete} ofs:{self.offset} plen={plen}"
         if self.payload is not None and plen > 0:
             ret += f" [{self.payload[0]}]"
         return ret
+
+    def items(self):
+        """Yield each attribute and its value for the FTP_OP instance. For debugging purposes."""
+        yield "seq", self.seq
+        yield "session", self.session
+        yield "opcode", self.opcode
+        yield "size", self.size
+        yield "req_opcode", self.req_opcode
+        yield "burst_complete", self.burst_complete
+        yield "offset", self.offset
+        yield "payload", self.payload

--- a/mavftpfs.py
+++ b/mavftpfs.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+import errno
+import os
+import time
+from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
+from typing import Any, Dict, Optional
+
+from fuse import FUSE, FuseOSError, LoggingMixIn, Operations
+from loguru import logger
+from pymavlink import mavutil
+
+from mavftp import MAVFTP
+
+# this allows us to support acessing the special files
+base_file_paths = ["/", "@ROMFS", "@SYS"]
+
+
+class FTP(LoggingMixIn, Operations):
+    def __init__(self, mav: Any) -> None:
+        self.mav = mav
+        self.missing_files = []
+        self.files: Dict[str, Dict[str, int]] = {
+            path: {
+                "st_mode": 0o40755,
+                "st_nlink": 2,
+                "st_size": 0,
+                # we need a timestamp for some systems to be happy
+                "st_ctime": int(time.time()),
+                "st_mtime": int(time.time()),
+                "st_atime": int(time.time()),
+            }
+            for path in base_file_paths
+        }
+        self.ftp = MAVFTP(mav, target_system=mav.target_system, target_component=mav.target_component)
+
+    def fix_path(self, path: str) -> str:
+        if path.startswith("/@"):
+            return path[1:]
+        return path
+
+    def getattr(self, path: str, _fh: int = 0) -> Any:
+        path_fixed = self.fix_path(path)
+        logger.info(f"Fuse: getattr {path_fixed}")
+        if path_fixed in self.missing_files:
+            raise FuseOSError(errno.ENOENT)
+        if path_fixed in self.files:
+            return self.files[path_fixed]
+
+        parent_dir = ("/" + "/".join(path.split("/")[:-1])).replace("//", "/")
+        logger.debug(f"cache miss for {path_fixed}, asking for {parent_dir}")
+        logger.debug(f"files: {self.files.keys()}")
+        logger.debug(f"missing_files: {self.missing_files}")
+        self.readdir(parent_dir)
+        if path not in self.files:
+            self.missing_files.append(path)
+            raise FuseOSError(errno.ENOENT)
+        return self.files[path]
+
+    def read(self, path: str, size: int, offset: int, _fh: int = 0) -> Optional[bytes]:
+        logger.info(f"Fuse: read {path}, size={size}, offset={offset}")
+        buf = self.ftp.read_sector(self.fix_path(path), offset, size)
+        return buf
+
+    def readdir(self, path: str, _fh: int = 0) -> Any:
+        path_fixed = self.fix_path(path)
+        logger.info(f"Fuse: readdir {path_fixed}")
+        self.ftp.cmd_list([path_fixed])
+        directory = self.ftp.list_result
+        if directory is None or len(directory) == 0:
+            return []
+        ret = {}
+        for item in directory:
+            if item.name in [".", ".."]:
+                continue
+            if not item.is_dir:
+                new_item = {"st_mode": (0o100444), "st_size": item.size_b}
+            else:
+                new_item = {
+                    "st_mode": (0o46766),
+                    "st_nlink": 2,  # Self-link and parent link
+                    "st_size": 0,  # Size 0 for simplicity
+                    # current timestamp for filebrowswer to be happy
+                    "st_ctime": int(time.time()),  # Current time
+                    "st_mtime": int(time.time()),  # Current time
+                    "st_atime": int(time.time()),  # Current time
+                }
+            ret[item.name] = new_item
+            new_path = path if path.endswith("/") else path + "/"
+            self.files[new_path + item.name] = new_item
+        self.files[path] = {"st_mode": (0o46766), "st_size": 0}
+        return ret
+
+    def create(self, path: str, fi: int = 0) -> None:
+        logger.info(f"Fuse: create {path}, fi={fi}")
+        raise FuseOSError(errno.ENOENT)
+
+    def mknod(self, path: str) -> None:
+        logger.error(f"Fuse: lookup {path}")
+        raise FuseOSError(errno.ENOENT)
+
+    def write(self, path: str, _data: bytes, _offset: int, _fh: int) -> None:
+        logger.error(f"Fuse: write {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def mkdir(self, path: str, _mode: int) -> None:
+        logger.error(f"Fuse: mkdir {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def rmdir(self, path: str) -> None:
+        logger.error(f"Fuse: rmdir {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def unlink(self, path: str) -> None:
+        logger.error(f"Fuse: unlink {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def rename(self, old: str, new: str) -> None:
+        logger.error(f"Fuse: rename {old} -> {new}")
+        raise FuseOSError(errno.EROFS)
+
+    def chmod(self, path: str, _mode: int) -> None:
+        logger.error(f"Fuse: chmod {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def chown(self, path: str, _uid: int, _gid: int) -> None:
+        logger.error(f"Fuse: chown {path}")
+        raise FuseOSError(errno.EROFS)
+
+    def truncate(self, path: str) -> None:
+        logger.info(f"Fuse: truncate {path}")
+        raise FuseOSError(errno.EROFS)
+
+
+if __name__ == "__main__":
+    # logging.basicConfig(level=logging.DEBUG)
+    parser = ArgumentParser(description="MAVLink FTP", formatter_class=ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        "-m",
+        "--mavlink",
+        default="udpin:127.0.0.1:14555",
+        help="MAVLink connection specifier",
+    )
+    parser.add_argument(
+        "--mountpoint",
+        help="Path to the mountpoint",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.mountpoint):
+        os.makedirs(args.mountpoint)
+
+    fuse = FUSE(
+        FTP(mavutil.mavlink_connection(args.mavlink)),
+        args.mountpoint,
+        foreground=True,
+        ro=True,
+        nothreads=True,
+        allow_other=True,
+    )

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -14,33 +14,11 @@ from io import StringIO
 import logging
 from pymavlink import mavutil
 from pymavlink.mavftp import FTP_OP, MAVFTP, MAVFTPReturn
-
+from pymavlink.mavftp import FtpError
 from pymavlink.mavftp import OP_ListDirectory
 from pymavlink.mavftp import OP_ReadFile
 from pymavlink.mavftp import OP_Ack
 from pymavlink.mavftp import OP_Nack
-from pymavlink.mavftp import ERR_None
-from pymavlink.mavftp import ERR_Fail
-from pymavlink.mavftp import ERR_FailErrno
-from pymavlink.mavftp import ERR_InvalidDataSize
-from pymavlink.mavftp import ERR_InvalidSession
-from pymavlink.mavftp import ERR_NoSessionsAvailable
-from pymavlink.mavftp import ERR_EndOfFile
-from pymavlink.mavftp import ERR_UnknownCommand
-from pymavlink.mavftp import ERR_FileExists
-from pymavlink.mavftp import ERR_FileProtected
-from pymavlink.mavftp import ERR_FileNotFound
-#from pymavlink.mavftp import ERR_NoErrorCodeInPayload
-#from pymavlink.mavftp import ERR_NoErrorCodeInNack
-#from pymavlink.mavftp import ERR_NoFilesystemErrorInPayload
-from pymavlink.mavftp import ERR_InvalidErrorCode
-#from pymavlink.mavftp import ERR_PayloadTooLarge
-#from pymavlink.mavftp import ERR_InvalidOpcode
-from pymavlink.mavftp import ERR_InvalidArguments
-from pymavlink.mavftp import ERR_PutAlreadyInProgress
-from pymavlink.mavftp import ERR_FailToOpenLocalFile
-from pymavlink.mavftp import ERR_RemoteReplyTimeout
-
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):
     """Test MAVFTP payload decoding"""
@@ -90,52 +68,52 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
             },
             {
                 "name": "Generic Failure",
-                "op": self.ftp_operation(seq=2, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_Fail])),
+                "op": self.ftp_operation(seq=2, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.Fail])),
                 "expected_message": "ListDirectory failed, generic error"
             },
             {
                 "name": "System Error",
-                "op": self.ftp_operation(seq=3, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FailErrno, 1])),  # System error 1
+                "op": self.ftp_operation(seq=3, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FailErrno, 1])),  # System error 1
                 "expected_message": "ListDirectory failed, system error 1"
             },
             {
                 "name": "Invalid Data Size",
-                "op": self.ftp_operation(seq=4, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_InvalidDataSize])),
+                "op": self.ftp_operation(seq=4, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.InvalidDataSize])),
                 "expected_message": "ListDirectory failed, invalid data size"
             },
             {
                 "name": "Invalid Session",
-                "op": self.ftp_operation(seq=5, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_InvalidSession])),
+                "op": self.ftp_operation(seq=5, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.InvalidSession])),
                 "expected_message": "ListDirectory failed, session is not currently open"
             },
             {
                 "name": "No Sessions Available",
-                "op": self.ftp_operation(seq=6, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_NoSessionsAvailable])),
+                "op": self.ftp_operation(seq=6, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.NoSessionsAvailable])),
                 "expected_message": "ListDirectory failed, no sessions available"
             },
             {
                 "name": "End of File",
-                "op": self.ftp_operation(seq=7, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_EndOfFile])),
+                "op": self.ftp_operation(seq=7, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.EndOfFile])),
                 "expected_message": "ListDirectory failed, offset past end of file"
             },
             {
                 "name": "Unknown Command",
-                "op": self.ftp_operation(seq=8, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_UnknownCommand])),
+                "op": self.ftp_operation(seq=8, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.UnknownCommand])),
                 "expected_message": "ListDirectory failed, unknown command"
             },
             {
                 "name": "File Exists",
-                "op": self.ftp_operation(seq=9, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FileExists])),
+                "op": self.ftp_operation(seq=9, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FileExists])),
                 "expected_message": "ListDirectory failed, file/directory already exists"
             },
             {
                 "name": "File Protected",
-                "op": self.ftp_operation(seq=10, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FileProtected])),
+                "op": self.ftp_operation(seq=10, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FileProtected])),
                 "expected_message": "ListDirectory failed, file/directory is protected"
             },
             {
                 "name": "File Not Found",
-                "op": self.ftp_operation(seq=11, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FileNotFound])),
+                "op": self.ftp_operation(seq=11, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FileNotFound])),
                 "expected_message": "ListDirectory failed, file/directory not found"
             },
             {
@@ -145,17 +123,17 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
             },
             {
                 "name": "No Error Code in Nack",
-                "op": self.ftp_operation(seq=13, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_None])),
+                "op": self.ftp_operation(seq=13, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.Success])),
                 "expected_message": "ListDirectory failed, no error code"
             },
             {
                 "name": "No Filesystem Error in Payload",
-                "op": self.ftp_operation(seq=14, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FailErrno])),
+                "op": self.ftp_operation(seq=14, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FailErrno])),
                 "expected_message": "ListDirectory failed, file-system error missing in payload"
             },
             {
                 "name": "Invalid Error Code",
-                "op": self.ftp_operation(seq=15, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_InvalidErrorCode])),
+                "op": self.ftp_operation(seq=15, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.InvalidErrorCode])),
                 "expected_message": "ListDirectory failed, invalid error code"
             },
             {
@@ -170,12 +148,12 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
             },
             {
                 "name": "Unknown Opcode in Request",
-                "op": self.ftp_operation(seq=19, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_UnknownCommand])),  # Assuming 100 is an unknown opcode
+                "op": self.ftp_operation(seq=19, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.UnknownCommand])),  # Assuming 100 is an unknown opcode
                 "expected_message": "ListDirectory failed, unknown command"
             },
             {
                 "name": "Payload with System Error",
-                "op": self.ftp_operation(seq=20, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([ERR_FailErrno, 2])),  # System error 2
+                "op": self.ftp_operation(seq=20, opcode=OP_Nack, req_opcode=OP_ListDirectory, payload=bytes([FtpError.FailErrno, 2])),  # System error 2
                 "expected_message": "ListDirectory failed, system error 2"
             },
             {
@@ -202,7 +180,7 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
             self.log_stream.truncate(0)
 
         # Invalid Arguments
-        ret = MAVFTPReturn("Command arguments", ERR_InvalidArguments)
+        ret = MAVFTPReturn("Command arguments", FtpError.InvalidArguments)
         ret.display_message()
         log_output = self.log_stream.getvalue().strip()
         self.assertIn("Command arguments failed, invalid arguments", log_output, "Expected invalid arguments message")
@@ -221,7 +199,7 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         self.log_stream.truncate(0)
 
         # Put already in progress
-        ret = MAVFTPReturn("Put", ERR_PutAlreadyInProgress)
+        ret = MAVFTPReturn("Put", FtpError.PutAlreadyInProgress)
         ret.display_message()
         log_output = self.log_stream.getvalue().strip()
         self.assertIn("Put failed, put already in progress", log_output, "Expected put already in progress message")
@@ -229,7 +207,7 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         self.log_stream.truncate(0)
 
         # Fail to open local file
-        ret = MAVFTPReturn("Put", ERR_FailToOpenLocalFile)
+        ret = MAVFTPReturn("Put", FtpError.FailToOpenLocalFile)
         ret.display_message()
         log_output = self.log_stream.getvalue().strip()
         self.assertIn("Put failed, failed to open local file", log_output, "Expected fail to open local file message")
@@ -237,7 +215,7 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         self.log_stream.truncate(0)
 
         # Remote Reply Timeout
-        ret = MAVFTPReturn("Put", ERR_RemoteReplyTimeout)
+        ret = MAVFTPReturn("Put", FtpError.RemoteReplyTimeout)
         ret.display_message()
         log_output = self.log_stream.getvalue().strip()
         self.assertIn("Put failed, remote reply timeout", log_output, "Expected remote reply timeout message")


### PR DESCRIPTION
This mounts mavftp as a virtual filesystem, which allows for more "human" interfacing with it.

There are caveats. It is obviously slower than doing things on your own machine. but this does allow interfacing using any filebrowser, for instance.

So far the filesystem is mounted as read-only. as there's no mavftp interface to write to a sector of a file, we'd have to create an abstraction layer that caches the whole file...

[Screencast from 2024-09-17 12-21-47.webm](https://github.com/user-attachments/assets/60fcbc26-295a-419a-87e4-89f83f856005)
