### PR TITLE
mavwp: remove old fences-in-waypoints code

### DIFF
--- a/mavwp.py
+++ b/mavwp.py
@@ -289,10 +289,6 @@ class MissionItemProtocol(object):
                 break
             idx += 1
 
-        exclusion_start = -1
-        exclusion_count = -1
-        inclusion_start = -1
-        inclusion_count = -1
         while idx < self.count():
             w = self.wp(idx)
             if idx in done:
@@ -306,34 +302,11 @@ class MissionItemProtocol(object):
                 if self.is_location_wp(w):
                     ret.append(idx)
                 continue
-            # display loops for exclusion and inclusion zones
-            if w.command == mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION:
-                if exclusion_start == -1:
-                    exclusion_count = int(w.param1)
-                    exclusion_start = idx
-                if idx == exclusion_start + exclusion_count - 1:
-                    ret.append(idx)
-                    ret.append(exclusion_start)
-                    return ret
-            if w.command == mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION:
-                if inclusion_start == -1:
-                    inclusion_count = int(w.param1)
-                    inclusion_start = idx
-                if idx == inclusion_start + inclusion_count - 1:
-                    ret.append(idx)
-                    ret.append(inclusion_start)
-                    return ret
             if self.is_location_wp(w):
                 ret.append(idx)
             if w.command in [ mavutil.mavlink.MAV_CMD_NAV_LAND,
                               mavutil.mavlink.MAV_CMD_NAV_VTOL_LAND ]:
                 # stop at landing points
-                return ret
-            exc_zones = [mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION,
-                         mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION]
-            w2 = self.wp(idx+1)
-            if w2 is not None and w.command not in exc_zones and w2.command in exc_zones:
-                # don't draw a line from last WP to first exc zone
                 return ret
             idx += 1
         return ret


### PR DESCRIPTION
we supported the incusion of fences within waypoints for a short period of time in a branch of ArduPilot.  This was removed, but we still have cestiges like this