### PR TITLE
Update requirements.txt for serial connection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 fastcrc
 lxml>=3.6.0
 setuptools>=42
+pyserial>=3.5
 wheel>=0.37.1
 
 # dev dependencies:


### PR DESCRIPTION
Although pymavlink supports the use of serial connections with a flight control board and utilizes a serial connection package, this information is not reflected in the requirements.txt file.

Simply running "pip install -r pymavlink/requirements.txt" and attempting to use the mavutil module over serial will not work as expected.