### PR TITLE
DFReader: In dump verbose show hex value for bitmask fields

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -384,6 +384,11 @@ class DFMessage(object):
                 except UnicodeDecodeError:
                     f.write("    %s: %s" % (c, to_string(val)))
 
+            # If this is a bitmask, then append the hex value
+            if c in field_metadata_by_name:
+                if hasattr(field_metadata_by_name[c], 'bitmask'):
+                    f.write(" (0x%x)" % val)
+
             # see if this is an enumeration entry, emit enumeration
             # entry name if it is
             if c in field_metadata_by_name:


### PR DESCRIPTION
The aim of this PR is to add the hex value alongside the decimal value, when displaying bitmask fields with the "dump --verbose" command in MavExplorer, as I think it is easier to follow which bits are set in hex.

This is also more in-line with how bitmasks are shown from TLog files when using "dump --verbose".

For example, on XKF4:
```
> dump --verbose XKF4
2024-12-04 14:53:37.722: XKF4
    ...
    SS: 107327 (0x1a33f)
        ATTITUDE (attitude estimate valid)
        HORIZ_VEL (horizontal velocity estimate valid)
        VERT_VEL (vertical velocity estimate valid)
    ...
 ```

Tested locally with a variety of messages containing bitmasks.