### PR TITLE
Mavgen WLua: Pass unix time as integer to os.date

### DIFF
--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -78,12 +78,13 @@ time_usec_threshold = UInt64.new(0,0x40000)
 -- function to append human-readable time onto unix_time_us fields
 local function time_usec_decode(value)
     if value > time_usec_threshold then
-        d = os.date("%Y-%m-%d %H:%M:%S",value:tonumber() / 1000000.0)
+        s = math.floor(value:tonumber() / 1000000.0)
         us = value % 1000000
+        d = os.date("%Y-%m-%d %H:%M:%S",s)
         us = string.format("%06d",us:tonumber())
-        ok, tz = pcall(os.date," %Z",value:tonumber() / 1000000.0)
+        ok, tz = pcall(os.date," %Z",s)
         if not ok then
-            tz = os.date(" %z",value:tonumber() / 1000000.0)
+            tz = os.date(" %z",s)
         end
         return " (" .. d .. "." .. us .. tz .. ")"
     elseif value < 1000000 then


### PR DESCRIPTION
After updating Wireshark to v4.4.2 (Windows), I noticed that the SYSTEM_TIME message was showing an LUA error:
```
Lua Error: ardupilotmega.lua:21: bad argument #2 to 'date' (number has no integer representation)
```
The issue appears to be that the os.date function no longer accepts a floating point input. This is fixed by applying math.floor to the 'seconds' part of the timestamp before calling os.date. The microseconds part was already being appended to the output string separately.
As a side-note, this also avoids potentially calculating "value:tonumber() / 1000000.0" three times.

Output tested, and now working like so:
```
MAVLink Protocol (22)
    Payload: SYSTEM_TIME (2)
        time_unix_usec (uint64_t) [us]: 1733755765960647 (2024-12-09 14:49:25.960647 GMT Standard Time)
        time_boot_ms (uint32_t) [ms]: 7325
    Message CRC: 0xa932
```