### PR TITLE
mavftp: handle file transfer to local path in cmd_get

### DIFF
--- a/mavftp.py
+++ b/mavftp.py
@@ -533,6 +533,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                                         (op.payload[3] << 24)
                 if self.ftp_settings.debug > 0:
                     logging.info("Remote file size: %u", self.remote_file_size)
+                self.requested_size = self.remote_file_size
             else:
                 self.remote_file_size = None
             read = FTP_OP(self.seq, self.session, OP_BurstReadFile, self.burst_size, 0, 0, 0, None)
@@ -565,7 +566,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 print(self.fh.read().decode('utf-8'))
             else:
                 logging.info("Wrote %u/%u bytes to %s in %.2fs %.1fkByte/s",
-                    self.read_total, self.requested_size, self.filename, dt, rate)
+                    self.read_total, self.requested_size, self.temp_filename, dt, rate)
                 logging.info("terminating with %u out of %u (ofs=%u)", self.read_total, self.requested_size, ofs)
                 self.done = True
 
@@ -577,6 +578,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if len(self.get_result) < self.requested_size:
                 logging.warning("expected %u, got %u", self.requested_size, len(self.get_result))
             logging.info("read %u bytes", len(self.get_result))
+            self.fh.flush()
+            self.fh.close()
+            # Move the result to the final location
+            logging.info("Moving %s to %s", self.temp_filename, self.filename)
+            self.fh = open(self.filename, "wb")
+            self.fh.write(self.get_result)
             self.fh.flush()
             self.fh.close()
             self.__terminate_session()


### PR DESCRIPTION
This pull request fixes an issue in `mavftp.py` where the specified local file path (`arg2` of `cmd_get`) was not used to save the downloaded file. Instead, the downloaded file's contents were left in the `/tmp` directory.

The changes ensure that the downloaded contents are now correctly moved to the local file specified in the get argument.

Without these changes, the output of the `get` command is:
```
py mavftp.py --device /dev/ttyACM0 get REMOTE_TEST.txt LOCAL_TEST.txt
INFO - Waiting for flight controller heartbeat
INFO - Heartbeat from system 0, component 0
INFO - Getting REMOTE_TEST.txt to LOCAL_TEST.txt
INFO - Wrote 1324/0 bytes to T24.txt in 0.04s 36.2kByte/s
INFO - terminating with 1324 out of 0 (ofs=1324)
INFO - read 0 bytes
```
(No file LOCAL_TEST.txt is created, only /tmp/temp_mavftp_file exist)

With the changes:
```
py mavftp.py --device /dev/ttyACM0 get REMOTE_TEST.txt LOCAL_TEST.txt
INFO - Waiting for flight controller heartbeat
INFO - Heartbeat from system 1, component 1
INFO - Getting REMOTE_TEST.txt to LOCAL_TEST.txt
INFO - Wrote 1324/1324 bytes to /tmp/temp_mavftp_file in 0.04s 35.0kByte/s
INFO - terminating with 1324 out of 1324 (ofs=1324)
INFO - read 1324 bytes
INFO - Moving /tmp/temp_mavftp_file to LOCAL_TEST.txt
```