### PR TITLE
[new] adding new unit of consumption: L/h

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -170,9 +170,11 @@
     <!-- flow -->
     <xs:enumeration value="g/min"/>    <!-- grams/minute -->
     <xs:enumeration value="cm^3/min"/> <!-- cubic centimetres/minute -->
+    <xs:enumeration value="L/h"/>      <!-- Litres/hour -->
     <!-- volume -->
     <xs:enumeration value="cm^3"/>     <!-- cubic centimetres -->
     <xs:enumeration value="l"/>        <!-- litres -->
+    <xs:enumeration value="L"/>        <!-- Litres -->
   </xs:restriction>
 </xs:simpleType>
 


### PR DESCRIPTION
[new]
Adding a new consumption unit (L/h), that is better suited for large scale drones with Internal Combustion Engines.
Adding an already existing unit of volume litre "L". This is done to prevent breaking changes in various MAVLink CI runners that depend on unit definition using lower case "l" for the litre unit. Unit "l" is to be deprecated in the future.
