### PR TITLE
Remove Python2 support; inline typing markup into templates

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,8 +27,8 @@ jobs:
 
     - name: Analysing the code known to be pylint clean
       run: |
-        pylint __init__.py dialects/__init__.py dialects/v09/__init__.py dialects/v09/python2/__init__.py \
-        dialects/v10/__init__.py dialects/v10/python2/__init__.py dialects/v20/__init__.py \
+        pylint __init__.py dialects/__init__.py dialects/v09/__init__.py \
+        dialects/v10/__init__.py dialects/v20/__init__.py \
         examples/__init__.py generator/__init__.py tests/test_mavxml.py tools/__init__.py \
         mavftp.py mavftp_op.py examples/mavftp_example.py examples/status_msg.py tests/test_mavftp.py \
         tests/test_mavxml.py

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,13 +62,8 @@ jobs:
 
       - name: Lint generated python code
         run: |
-          if [ "${{ matrix.python-version }}" = "3.5" ]
-          then
-            flake8 --ignore='W503,E203,E501,E741' --statistics dialects/v10/python2/*.py dialects/v20/python2/*.py
-          else
             flake8 --ignore='W503,E203,E501,E741' --statistics dialects/
             mypy --config-file ./.github/workflows/mypy-generated.ini dialects/v10/*.py dialects/v20/*.py
-          fi
 
       - name: Generate messages
         run: |

--- a/files/archlinux/PKGBUILD
+++ b/files/archlinux/PKGBUILD
@@ -1,15 +1,16 @@
 # Maintainer: Thomas Gubler <thomasgubler@gmail.com>
-pkgname=python2-mavlink-git
-pkgver=20140119
+# blindly changed python2 to python3 in 2025, completely untested -pb
+pkgname=python3-mavlink-git
+pkgver=20250412
 pkgrel=1
 pkgdesc="Python implementation of the MAVLink protocol"
 arch=(any)
 url="https://github.com/ArduPilot/pymavlink"
 license=('LGPL3')
-depends=('python2')
-makedepends=('git' 'python2' 'python2-setuptools')
+depends=('python3')
+makedepends=('git' 'python3' 'python3-setuptools')
 optdepends=()
-provides=('python2-mavlink-git')
+provides=('python3-mavlink-git')
 conflicts=()
 options=(!emptydirs)
 
@@ -34,12 +35,12 @@ build() {
   git clean -fdx
 
   msg "Starting make..."
-  python2 setup.py build
+  python3 setup.py build
 }
 
 package() {
   cd "$srcdir/$_gitname/$_subfoldername"
-  python2 setup.py install --prefix=/usr --root=$pkgdir/ --optimize=1
+  python3 setup.py install --prefix=/usr --root=$pkgdir/ --optimize=1
 
   install -Dm644 "$srcdir/$_gitname/$_subfoldername/README.txt" "$pkgdir/usr/share/licenses/$pkgname/README.txt"
 }

--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -23,13 +23,7 @@ class x25crc_slow(object):
 
     def accumulate(self, buf):
         """add in some more bytes (it also accepts strings)"""
-        if sys.version_info[0] == 2:
-            if type(buf) is str:
-                buf = bytearray(buf)
-            elif type(buf).__name__ == 'unicode':
-                # we can't use the identifier unicode in python3
-                buf = bytearray(buf.encode())
-        elif type(buf) is str:
+        if type(buf) is str:
             buf = buf.encode()
 
         accum = self.crc
@@ -54,13 +48,7 @@ class x25crc_fast(object):
 
     def accumulate(self, buf):
         """add in some more bytes (it also accepts strings)"""
-        if sys.version_info[0] == 2:
-            if type(buf) is str:
-                buf = bytearray(buf)
-            elif type(buf).__name__ == 'unicode':
-                # we can't use the identifier unicode in python3
-                buf = bytearray(buf.encode())
-        elif type(buf) is str:
+        if type(buf) is str:
             buf = bytes(buf.encode())
         elif type(buf) is list:
             buf = bytes(buf)

--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -310,7 +310,7 @@ class Opts(object):
         self.strict_units = strict_units
 
 
-def mavgen_python_dialect(dialect, wire_protocol, with_type_annotations):
+def mavgen_python_dialect(dialect, wire_protocol):
     '''generate the python code on the fly for a MAVLink dialect'''
     dialects = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'dialects')
     mdef = os.getenv("MDEF", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'message_definitions'))

--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -47,7 +47,7 @@ MAXIMUM_INCLUDE_FILE_NESTING = 5
 
 # List the supported languages. This is done globally because it's used by the GUI wrapper too
 # Right now, 'JavaScript' ~= 'JavaScript_Stable', in the future it may be made equivalent to 'JavaScript_NextGen'
-supportedLanguages = ["Ada", "C", "CS", "JavaScript", "JavaScript_Stable","JavaScript_NextGen", "TypeScript", "Python2", "Python3", "Python", "Lua", "WLua", "ObjC", "Swift", "Java", "C++11"]
+supportedLanguages = ["Ada", "C", "CS", "JavaScript", "JavaScript_Stable","JavaScript_NextGen", "TypeScript", "Python3", "Python", "Lua", "WLua", "ObjC", "Swift", "Java", "C++11"]
 
 
 def mavgen(opts, args):
@@ -251,19 +251,9 @@ def mavgen(opts, args):
 
     # convert language option to lowercase and validate
     opts.language = opts.language.lower()
-    if opts.language == 'python':
-        # We support generating type annotations starting with
-        # python3.6. Type annotations were introduced in 3.5, but
-        # useful things like variable annotations are only supported
-        # starting with 3.6.
+    if opts.language == 'python3' or opts.language == 'python':
         from . import mavgen_python
-        mavgen_python.generate(opts.output, xml, enable_type_annotations=sys.version_info >= (3, 6))
-    elif opts.language == 'python2':
-        from . import mavgen_python
-        mavgen_python.generate(opts.output, xml, enable_type_annotations=False)
-    elif opts.language == 'python3':
-        from . import mavgen_python
-        mavgen_python.generate(opts.output, xml, enable_type_annotations=True)
+        mavgen_python.generate(opts.output, xml)
     elif opts.language == 'c':
         from . import mavgen_c
         mavgen_c.generate(opts.output, xml)
@@ -324,33 +314,25 @@ def mavgen_python_dialect(dialect, wire_protocol, with_type_annotations):
     '''generate the python code on the fly for a MAVLink dialect'''
     dialects = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', 'dialects')
     mdef = os.getenv("MDEF", default=os.path.join(os.path.dirname(os.path.realpath(__file__)), '..', '..', 'message_definitions'))
-    legacy_path = "python2" if not with_type_annotations else ""
     if wire_protocol == mavparse.PROTOCOL_0_9:
-        py = os.path.join(dialects, 'v09', legacy_path, dialect + '.py')
+        py = os.path.join(dialects, 'v09', dialect + '.py')
         xml = os.path.join(dialects, 'v09', dialect + '.xml')
         if not os.path.exists(xml):
             xml = os.path.join(mdef, 'v0.9', dialect + '.xml')
     elif wire_protocol == mavparse.PROTOCOL_1_0:
-        py = os.path.join(dialects, 'v10', legacy_path, dialect + '.py')
+        py = os.path.join(dialects, 'v10', dialect + '.py')
         xml = os.path.join(dialects, 'v10', dialect + '.xml')
         if not os.path.exists(xml):
             xml = os.path.join(mdef, 'v1.0', dialect + '.xml')
     else:
-        py = os.path.join(dialects, 'v20', legacy_path, dialect + '.py')
+        py = os.path.join(dialects, 'v20', dialect + '.py')
         xml = os.path.join(dialects, 'v20', dialect + '.xml')
         if not os.path.exists(xml):
             xml = os.path.join(mdef, 'v1.0', dialect + '.xml')
 
-    if with_type_annotations:
-        opts = Opts(py, wire_protocol, language="Python3")
-    else:
-        opts = Opts(py, wire_protocol, language='Python2')
+    opts = Opts(py, wire_protocol, language="Python3")
 
-    # Python 2 to 3 compatibility
-    try:
-        import StringIO as io
-    except ImportError:
-        import io
+    import io
 
     # throw away stdout while generating
     stdout_saved = sys.stdout

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -150,9 +150,6 @@ MAVLINK_SIGNATURE_BLOCK_LEN = 13
 
 MAVLINK_IFLAG_SIGNED = 0x01
 
-if sys.version_info[0] == 2:
-    logging.basicConfig()
-
 logger = logging.getLogger(__name__)
 
 # allow MAV_IGNORE_CRC=1 to ignore CRC, allowing some
@@ -182,10 +179,6 @@ class x25crc(object):
             self.accumulate(buf)
 
     def accumulate(self, buf${type_intseq})${type_none_ret}:
-        """add in some more bytes (it also accepts python2 strings)"""
-        if sys.version_info[0] == 2 and type(buf) is str:
-            buf = bytearray(buf)
-
         accum = self.crc
         for b in buf:
             tmp = b ^ (accum & 0xFF)
@@ -267,8 +260,6 @@ class MAVLink_message(object):
         """override field getter"""
         raw_attr = cast(${type_mavlink_message_attr_cast}, getattr(self, field))
         if isinstance(raw_attr, bytes):
-            if sys.version_info[0] == 2:
-                return raw_attr.rstrip(b"\\x00")
             return raw_attr.decode(errors="backslashreplace").rstrip("\\x00")
         return raw_attr
 
@@ -373,10 +364,7 @@ class MAVLink_message(object):
         if float(WIRE_PROTOCOL_VERSION) == 2.0 and not force_mavlink1:
             # in MAVLink2 we can strip trailing zeros off payloads. This allows for simple
             # variable length arrays and smaller packets
-            if sys.version_info[0] == 2:
-                nullbyte = chr(0)
-            else:
-                nullbyte = 0
+            nullbyte = 0
             while plen > 1 and payload[plen - 1] == nullbyte:
                 plen -= 1
         self._payload = payload[:plen]
@@ -797,10 +785,7 @@ class MAVLink_bad_data(MAVLink_message):
 
     def __str__(self)${type_str_ret}:
         """Override the __str__ function from MAVLink_messages because non-printable characters are common in to be the reason for this message to exist."""
-        if sys.version_info[0] == 2:
-            hexstr = ["{:x}".format(ord(i)) for i in self.data]
-        else:
-            hexstr = ["{:x}".format(i) for i in self.data]
+        hexstr = ["{:x}".format(i) for i in self.data]
         return "%s {%s, data:%s}" % (self._type, self.reason, hexstr)
 
 
@@ -818,10 +803,7 @@ class MAVLink_unknown(MAVLink_message):
 
     def __str__(self)${type_str_ret}:
         """Override the __str__ function from MAVLink_messages because non-printable characters are common."""
-        if sys.version_info[0] == 2:
-            hexstr = ["{:x}".format(ord(i)) for i in self.data]
-        else:
-            hexstr = ["{:x}".format(i) for i in self.data]
+        hexstr = ["{:x}".format(i) for i in self.data]
         return "%s {data:%s}" % (self._type, hexstr)
 
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -19,17 +19,11 @@ from pymavlink import mavexpression
 # We want to re-export x25crc here
 from pymavlink.generator.mavcrc import x25crc as x25crc
 
-is_py3 = sys.version_info >= (3,0)
-supports_type_annotations = sys.version_info >= (3,6)
-
 # adding these extra imports allows pymavlink to be used directly with pyinstaller
 # without having complex spec files. To allow for installs that don't have ardupilotmega
 # at all we avoid throwing an exception if it isn't installed
 try:
-    if supports_type_annotations:
-        from pymavlink.dialects.v10 import ardupilotmega
-    else:
-        from pymavlink.dialects.v10.python2 import ardupilotmega
+    from pymavlink.dialects.v10 import ardupilotmega
 except Exception:
     pass
 
@@ -76,9 +70,7 @@ def evaluate_condition(condition, vars):
     return v
 
 def u_ord(c):
-    if is_py3:
-        return c
-    return ord(c)
+    return c
 
 class location(object):
     '''represent a GPS coordinate'''
@@ -118,18 +110,17 @@ def set_dialect(dialect, with_type_annotations=None):
     from .generator import mavparse
 
     if with_type_annotations is None:
-        with_type_annotations = supports_type_annotations
+        with_type_annotations = True
 
-    legacy_python_module = "python2." if not with_type_annotations else ""
     if 'MAVLINK20' in os.environ:
         wire_protocol = mavparse.PROTOCOL_2_0
-        modname = "pymavlink.dialects.v20." + legacy_python_module + dialect
+        modname = "pymavlink.dialects.v20." + dialect
     elif mavlink is None or mavlink.WIRE_PROTOCOL_VERSION == "1.0" or not 'MAVLINK09' in os.environ:
         wire_protocol = mavparse.PROTOCOL_1_0
-        modname = "pymavlink.dialects.v10." + legacy_python_module + dialect
+        modname = "pymavlink.dialects.v10." + dialect
     else:
         wire_protocol = mavparse.PROTOCOL_0_9
-        modname = "pymavlink.dialects.v09." + legacy_python_module + dialect
+        modname = "pymavlink.dialects.v09." + dialect
 
     try:
         mod = __import__(modname)
@@ -487,10 +478,7 @@ class mavfile(object):
 
             if numnew != 0:
                 if self.logfile_raw:
-                    if is_py3:
-                        self.logfile_raw.write(s)
-                    else:
-                        self.logfile_raw.write(str(s))
+                    self.logfile_raw.write(s)
                 if self.first_byte:
                     self.auto_mavlink_version(s)
 
@@ -500,10 +488,7 @@ class mavfile(object):
             if msg:
                 if self.logfile and  msg.get_type() != 'BAD_DATA' :
                     usec = int(time.time() * 1.0e6) & ~3
-                    if is_py3:
-                        self.logfile.write(struct.pack('>Q', usec) + msg.get_msgbuf())
-                    else:
-                        self.logfile.write(str(struct.pack('>Q', usec) + msg.get_msgbuf()))
+                    self.logfile.write(struct.pack('>Q', usec) + msg.get_msgbuf())
                 self.post_message(msg)
                 return msg
             else:
@@ -580,7 +565,7 @@ class mavfile(object):
             idx = int(name)
             self.mav.param_request_read_send(self.target_system, self.target_component, b"", idx)
         except Exception:
-            if sys.version_info.major >= 3 and not isinstance(name, bytes):
+            if not isinstance(name, bytes):
                 name = bytes(name,'ascii')
             self.mav.param_request_read_send(self.target_system, self.target_component, name, -1)
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -109,8 +109,8 @@ def set_dialect(dialect, with_type_annotations=None):
     global mavlink, current_dialect
     from .generator import mavparse
 
-    if with_type_annotations is None:
-        with_type_annotations = True
+    if with_type_annotations is not None:
+        print("with_type_annotations ignored; remove parameter")
 
     if 'MAVLINK20' in os.environ:
         wire_protocol = mavparse.PROTOCOL_2_0
@@ -127,7 +127,7 @@ def set_dialect(dialect, with_type_annotations=None):
     except Exception:
         # auto-generate the dialect module
         from .generator.mavgen import mavgen_python_dialect
-        mavgen_python_dialect(dialect, wire_protocol, with_type_annotations=with_type_annotations)
+        mavgen_python_dialect(dialect, wire_protocol)
         mod = __import__(modname)
     components = modname.split('.')
     for comp in components[1:]:

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ def generate_content():
             if not fnmatch.fnmatch(dialect, wildcard):
                 continue
             print("Building %s for protocol 1.0" % xml)
-            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0, with_type_annotations=True):
+            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0):
                 print("Building failed %s for protocol 1.0" % xml)
                 sys.exit(1)
 
@@ -72,7 +72,7 @@ def generate_content():
             if not fnmatch.fnmatch(dialect, wildcard):
                 continue
             print("Building %s for protocol 2.0" % xml)
-            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_2_0, with_type_annotations=True):
+            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_2_0):
                 print("Building failed %s for protocol 2.0" % xml)
                 sys.exit(1)
 

--- a/setup.py
+++ b/setup.py
@@ -65,9 +65,6 @@ def generate_content():
             if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0, with_type_annotations=True):
                 print("Building failed %s for protocol 1.0" % xml)
                 sys.exit(1)
-            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_1_0, with_type_annotations=False):
-                print("Building failed %s (Python2) for protocol 1.0" % xml)
-                sys.exit(1)
 
         for xml in v20_dialects:
             dialect = os.path.basename(xml)[:-4]
@@ -77,9 +74,6 @@ def generate_content():
             print("Building %s for protocol 2.0" % xml)
             if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_2_0, with_type_annotations=True):
                 print("Building failed %s for protocol 2.0" % xml)
-                sys.exit(1)
-            if not mavgen.mavgen_python_dialect(dialect, mavparse.PROTOCOL_2_0, with_type_annotations=False):
-                print("Building failed %s (Python2) for protocol 2.0" % xml)
                 sys.exit(1)
 
 
@@ -131,9 +125,8 @@ setup (name = 'pymavlink',
                    'pymavlink.generator',
                    'pymavlink.dialects',
                    'pymavlink.dialects.v10',
-                   'pymavlink.dialects.v10.python2',
                    'pymavlink.dialects.v20',
-                   'pymavlink.dialects.v20.python2'],
+                   ],
        scripts = [ 'tools/magfit_delta.py', 'tools/mavextract.py',
                    'tools/mavgraph.py', 'tools/mavparmdiff.py',
                    'tools/mavtogpx.py', 'tools/magfit_gps.py',

--- a/test_generate_all.sh
+++ b/test_generate_all.sh
@@ -8,7 +8,6 @@ echo "Test Generate ALL in mavlink v1"
 mavgen.py --lang='C'          --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
 mavgen.py --lang='CS'         --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
 mavgen.py --lang='JavaScript' --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
-mavgen.py --lang='Python2'    --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
 mavgen.py --lang='Python3'     --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
 mavgen.py --lang='WLua'       --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
 mavgen.py --lang='ObjC'       --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=1.0 --strict-units
@@ -22,7 +21,6 @@ mavgen.py --lang='C'          --output=/tmp/mavgen_test mavlink/message_definiti
 mavgen.py --lang='CS'         --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
 mavgen.py --lang='JavaScript' --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
 mavgen.py --lang='TypeScript' --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
-mavgen.py --lang='Python2'    --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
 mavgen.py --lang='Python3'     --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
 mavgen.py --lang='WLua'       --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units
 mavgen.py --lang='ObjC'       --output=/tmp/mavgen_test mavlink/message_definitions/v1.0/common.xml --wire-protocol=2.0 --strict-units

--- a/tools/mavftpdecode.py
+++ b/tools/mavftpdecode.py
@@ -60,12 +60,8 @@ def param_decode(data):
     count = 0
     params = []
 
-    if sys.version_info.major < 3:
-        pad_byte = chr(0)
-        last_name = ''
-    else:
-        pad_byte = 0
-        last_name = bytes()
+    pad_byte = 0
+    last_name = bytes()
     ret = []
 
     while True:

--- a/tools/mavgraph.py
+++ b/tools/mavgraph.py
@@ -20,10 +20,7 @@ try:
 except:
     print("WARNING: Numpy missing, mathematical notation will not be supported.")
 
-if sys.version_info[0] >= 3:
-    text_types = frozenset([str,])
-else:
-    text_types = frozenset([unicode, str])
+text_types = frozenset([str,])
 
 # cope with rename of raw_input in python3
 try:

--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -16,12 +16,6 @@ import struct
 import sys
 import time
 
-# Detect python version
-if sys.version_info[0] < 3:
-    runningPython3 = False
-else:
-    runningPython3 = True
-
 try:
     from pymavlink.mavextra import *
 except:
@@ -160,9 +154,6 @@ def to_string(s):
     '''desperate attempt to convert a string regardless of what garbage we get'''
     if isinstance(s, str):
         return s
-    if sys.version_info[0] == 2:
-        # In python2 we want to return unicode for passed in unicode
-        return s
     return s.decode(errors="backslashreplace")
 
 def match_type(mtype, patterns):
@@ -181,10 +172,7 @@ if istlog and args.format == 'csv': # we know our fields from the get-go
         for type in types:
             try:
                 typeClass = "MAVLink_{0}_message".format(type.lower())
-                if runningPython3:
-                    fields += [type + '.' + x for x in inspect.getfullargspec(getattr(mavutil.mavlink, typeClass).__init__).args[1:]]
-                else:
-                    fields += [type + '.' + x for x in inspect.getargspec(getattr(mavutil.mavlink, typeClass).__init__).args[1:]]
+                fields += [type + '.' + x for x in inspect.getfullargspec(getattr(mavutil.mavlink, typeClass).__init__).args[1:]]
                 offsets[type] = currentOffset
                 currentOffset += len(fields)
             except IndexError:

--- a/tools/mavtomfile.py
+++ b/tools/mavtomfile.py
@@ -14,8 +14,6 @@ from pymavlink import mavutil
 def process_tlog(filename):
     '''convert a tlog to a .m file'''
 
-    is_py2 = sys.version_info < (3,0)
-
     print("Processing %s" % filename)
 
     mlog = mavutil.mavlink_connection(filename, dialect=args.dialect, zero_time_base=True)
@@ -66,10 +64,6 @@ def process_tlog(filename):
             for field in fieldnames:
                 val = getattr(m, field)
 
-                if is_py2:
-                    if isinstance(val,unicode): # NOQA
-                        val = str(val)
-
                 if not isinstance(val, str):
                     if type(val) is not list:
                         f.write(",'%s'" % field)
@@ -82,10 +76,6 @@ def process_tlog(filename):
         f.write("%s.data(%u,:) = [%f" % (mtype, type_counters[mtype], m._timestamp))
         for field in m._fieldnames:
             val = getattr(m, field)
-
-            if is_py2:
-                if isinstance(val,unicode): # NOQA
-                    val = str(val)
 
             if not isinstance(val, str):
                 if type(val) is not list:


### PR DESCRIPTION
This removes support for generating Python2 bindings, and for running the generator under Python2.

Working with the non-inline type annotations was rather painful when modifying them recently.  It was a good hack, but we really shouldn't need it any more given how dead Python2 is now.
