### PR TITLE
.github: use pip to install pymavlink

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install pymavlink
         run: |
-          python setup.py build install
+          python3 -m pip install .
 
       - name: Lint generated python code
         run: |


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/runner/work/pymavlink/pymavlink/setup.py", line 90, in <module>
    setup (name = 'pymavlink',
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/__init__.py", line 117, in setup
    return distutils.core.setup(**attrs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 186, in setup
    return run_commands(dist)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 202, in run_commands
    dist.run_commands()
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1002, in run_commands
    self.run_command(cmd)
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/dist.py", line 1104, in run_command
    super().run_command(command)
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 1021, in run_command
    cmd_obj.run()
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/command/install.py", line 105, in run
    self.do_egg_install()
  File "/opt/hostedtoolcache/Python/3.12.10/x64/lib/python3.12/site-packages/setuptools/command/install.py", line 143, in do_egg_install
    raise NotImplementedError("Support for egg-based install has been removed.")
NotImplementedError: Support for egg-based install has been removed.
```
