### PR TITLE
dfindexer: add progress callback

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1104,7 +1104,7 @@ class DFReader_binary(DFReader):
             print("You may need to pip install pymavlink again with PYMAVLINK_FAST_INDEX=1")
             use_fast_indexer = False
         if use_fast_indexer and dfindexer.available:
-            self.init_arrays_fast()
+            self.init_arrays_fast(progress_callback=progress_callback)
         else:
             self.init_arrays(progress_callback=progress_callback)
         self.init_clock()
@@ -1260,7 +1260,7 @@ class DFReader_binary(DFReader):
             self._count += counts[i]
         self.offset = 0
 
-    def init_arrays_fast(self):
+    def init_arrays_fast(self, progress_callback=None):
         '''initialise arrays for fast recv_match(), but with Cython'''
 
         self._count = 0
@@ -1296,6 +1296,7 @@ class DFReader_binary(DFReader):
             size_offset,
             self.HEAD1,
             self.HEAD2,
+            progress_callback=progress_callback
         )
 
         # Parse the FMT messages

--- a/dfindexer/dfindexer.h
+++ b/dfindexer/dfindexer.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <Python.h>
 
 typedef struct OffsetArray {
     uint64_t *data;
@@ -13,7 +14,8 @@ typedef struct OffsetArray {
 OffsetArray* scan_offsets(const uint8_t *data, size_t len,
                           uint8_t fmt_type, uint8_t fmt_length,
                           uint8_t type_offset, uint8_t length_offset,
-                          uint8_t head1, uint8_t head2);
+                          uint8_t head1, uint8_t head2,
+                          PyObject *progress_callback);
 
 void free_offsets(OffsetArray *offsets);
 

--- a/dfindexer/dfindexer_cy.pyx
+++ b/dfindexer/dfindexer_cy.pyx
@@ -1,3 +1,5 @@
+from cpython.ref cimport PyObject, Py_INCREF, Py_DECREF
+
 cdef extern from "dfindexer.h":
     cdef struct OffsetArray:
         unsigned long long* data
@@ -7,22 +9,34 @@ cdef extern from "dfindexer.h":
     OffsetArray* scan_offsets(const unsigned char* data, size_t len,
                               unsigned char fmt_type, unsigned char fmt_length,
                               unsigned char type_offset, unsigned char length_offset,
-                              unsigned char head1, unsigned char head2)
+                              unsigned char head1, unsigned char head2,
+                              PyObject* progress_callback)
 
     void free_offsets(OffsetArray* offsets)
 
 def build_offsets(const unsigned char[:] data,
                   unsigned char fmt_type, unsigned char fmt_length,
                   unsigned char type_offset, unsigned char length_offset,
-                  unsigned char head1, unsigned char head2):
+                  unsigned char head1, unsigned char head2,
+                  progress_callback=None):
     cdef OffsetArray* results
     cdef size_t i, j
     cdef list py_offsets = []
 
+    cdef PyObject* cb = NULL
+    if progress_callback is not None:
+        Py_INCREF(progress_callback)  # ensure it stays alive during the C call
+        cb = <PyObject*>progress_callback
+
     results = scan_offsets(&data[0], data.shape[0],
                            fmt_type, fmt_length,
                            type_offset, length_offset,
-                           head1, head2)
+                           head1, head2,
+                           cb)
+
+    if progress_callback is not None:
+        Py_DECREF(progress_callback)  # clean up the reference
+
     if results == NULL:
         raise MemoryError("scan_offsets returned NULL")
 


### PR DESCRIPTION
Adds the progress-bar back for MAVExplorer. It fires every 4 million messages or so. For a 4GB log, that's about one every 4% through the log. For smaller logs, it takes bigger % jumps, but they go fast.