### PR TITLE
DFReader Param Init

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1054,7 +1054,8 @@ class DFReader(object):
         if self._flightmodes is None:
             self._rewind()
             self._flightmodes = []
-            types = set(['MODE'])
+            # Adding 'PARM' here keeps MAVExplorer behaving the same as before
+            types = set(['MODE', 'PARM'])
             while True:
                 m = self.recv_match(type=types, strict=True)
                 if m is None:

--- a/DFReader.py
+++ b/DFReader.py
@@ -848,7 +848,7 @@ class DFReader(object):
 
         # Try first for a fast lookup for a modern GPS time
         while True:
-            m = self.recv_match(type=['GPS'])
+            m = self.recv_match(type=['GPS'], strict=True)
             if m is None:
                 break
             if getattr(m, "TimeUS", None) is None or \
@@ -1013,7 +1013,7 @@ class DFReader(object):
                 self.param_defaults[m.Name] = m.Default
         self._set_time(m)
 
-    def recv_match(self, condition=None, type=None, blocking=False):
+    def recv_match(self, condition=None, type=None, blocking=False, strict=False):
         '''recv the next message that matches the given condition
         type can be a string or a list of strings'''
         if type is not None:
@@ -1023,9 +1023,6 @@ class DFReader(object):
                 type = set(type)
         while True:
             if type is not None:
-                # If we don't have any conditions, we don't need skip_to_type
-                # to add extra key messages to "type"
-                strict = condition is None
                 self.skip_to_type(type, strict=strict)
             m = self.recv_msg()
             if m is None:
@@ -1056,7 +1053,7 @@ class DFReader(object):
             self._flightmodes = []
             types = set(['MODE'])
             while True:
-                m = self.recv_match(type=types)
+                m = self.recv_match(type=types, strict=True)
                 if m is None:
                     break
                 tstamp = m._timestamp

--- a/DFReader.py
+++ b/DFReader.py
@@ -848,9 +848,12 @@ class DFReader(object):
 
         # Try first for a fast lookup for a modern GPS time
         while True:
-            m = self.recv_match(type=['GPS'], strict=True)
+            # Add PARM messages so that we also initialize the param dict
+            m = self.recv_match(type=['GPS', 'PARM'], strict=True)
             if m is None:
                 break
+            if m.get_type() == 'PARM':
+                continue
             if getattr(m, "TimeUS", None) is None or \
                getattr(m, "GWk", None) is None or \
                getattr(m, "GMS", None) is None:


### PR DESCRIPTION
Forgot to make sure that the param dict initialized the same as before. This regression was due to the changes I made to recv_match to make it faster when you truly only care about one type (the so-called "strict" option that I introduced).

I've added back the original side-effects of param initialization to both init_clock and flightmodes_list.

I thought about building up the initial params explicitly by just doing a recv_match through all the 'PARM' messages, which would build a dict of the param values at the end of the log, which isn't the old behavior (the old behavior is "param values at the time of first GPS fix", or, if you call flightmodes_list, it's "param values at the end").

Similarly I don't think it's right to build up the first values seen for each param, since sometimes the first message shows the wrong param value due to the defaults not being fully set up yet. Getting the initial params correctly is somewhat complicated and I might come back to it later.