### PR TITLE
CI Speedup and More Wheels

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,6 +2,10 @@ name: Pylint
 
 on: [push, pull_request]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,38 +14,51 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy:
+  wheels:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ["ubuntu-latest"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+    name: ${{ matrix.os }} ${{ matrix.python }}
+    runs-on: ${{ matrix.os }}
 
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install mavlink messages
+      run: |
+        git clone https://github.com/ArduPilot/mavlink.git
+        ln -s $PWD/mavlink/message_definitions
+    - name: Set CIBW_BUILD
+      run: echo "CIBW_BUILD=cp${PYTHON/./}-*" >> $GITHUB_ENV
+      env:
+        PYTHON: ${{ matrix.python }}
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v2.23.3
+      env:
+        CIBW_BEFORE_BUILD_LINUX: >
+          if [ "$(uname -m)" = "i686" ] && grep -q musl /lib/libc.musl-*; then
+            apk add --no-cache libxml2-dev libxslt-dev;
+          fi
+    - name: Upload wheels
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-${{ matrix.os }}-cp${{ matrix.python }}
+        path: wheelhouse/*.whl
+        if-no-files-found: error
+
+  sdist:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.9'
-    - name: Install mavlink message
+        python-version: "3.9"
+    - name: Install mavlink messages
       run: |
         git clone https://github.com/ArduPilot/mavlink.git
         ln -s $PWD/mavlink/message_definitions
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23.3
-      env:
-        CIBW_SKIP: "cp36-* cp37-* pp*"
-        CIBW_BEFORE_BUILD_LINUX: >
-          if [ "$(uname -m)" = "i686" ] && grep -q musl /lib/libc.musl-*; then
-            apk add --no-cache libxml2-dev libxslt-dev;
-          fi
-    - name: Check existence of at least one wheel
-      run: |
-        if [ ! -d wheelhouse ] || [ -z "$(ls -A wheelhouse/*.whl 2>/dev/null)" ]; then
-          echo "No wheels found in wheelhouse"
-          exit 1
-        fi
-    - name: Move wheels to dist
-      run: |
-        mkdir -p dist
-        cp wheelhouse/* dist/
     - name: Install dependencies
       run: |
         python -m pip install -U pip
@@ -54,12 +67,33 @@ jobs:
         pip install -U .
     - name: Build sdist
       run: pipx run build --sdist
-    - name: Upload artifacts
+    - name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: sdist
+        path: dist/*.tar.gz
+        if-no-files-found: error
+
+  publish:
+    needs: [wheels, sdist]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        merge-multiple: true
+
+    - name: Verify dist contents
+      run: ls -lh dist/
+
+    - name: Upload final dist artifact
       uses: actions/upload-artifact@v4
       with:
         name: dist
         path: dist/*
         if-no-files-found: error
+
     - name: Publish package
       if: github.event_name == 'release' && github.event.action == 'published'
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,6 +9,10 @@ on:
   release:
     types: [published]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,7 @@ name: Build and Optionally Publish
 on:
   push:
   pull_request:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -14,28 +15,78 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  wheels:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      # This allows us to save the more expensive full build for the main branch
+      # and releases, while using a lighter build for PRs
+      - name: Set build matrix
+        id: set-matrix
+        shell: python
+        run: |
+          import json
+          import os
+
+          ref = os.environ.get("GITHUB_REF", "")
+          event = os.environ.get("GITHUB_EVENT_NAME", "")
+
+          if ref in ("refs/heads/main", "refs/heads/master") or event in ("release", "workflow_dispatch"):
+              machines = [
+                  ("linux", "ubuntu-latest", "auto"),
+                  ("linux-arm", "ubuntu-24.04-arm", "auto"),
+                  ("macos", "macos-latest", "arm64 x86_64 universal2"),
+                  ("windows", "windows-latest", "auto"),
+                  # ("windows-arm", "windows-11-arm", "auto"), # Can't do this one yet, as lxml doesn't have Windows ARM wheels, and the runner doesn't have libxml2 pre-installed
+              ]
+              py_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+          else:
+              machines = [
+                  ("linux", "ubuntu-latest", "native"),
+                  ("windows", "windows-latest", "native"),
+              ]
+              py_versions = ["3.8", "3.13"] # Chosing the two most likely to break in PRs
+
+          matrix = {"include": []}
+          for (name, runner, cibw_archs) in machines:
+              for py in py_versions:
+                  matrix["include"].append({
+                      "name": f"python{py}-{name}",
+                      "os": runner,
+                      "python_version": py,
+                      "cibw_build": f"cp{py.replace('.', '')}-*",
+                      "cibw_archs": cibw_archs,
+                  })
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"matrix={json.dumps(matrix)}\n")
+
+  build-wheels:
+    needs: prepare
     strategy:
       fail-fast: false
-      matrix:
-        os: ["ubuntu-latest"]
-        python: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
-    name: ${{ matrix.os }} ${{ matrix.python }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
-
+    env:
+      PYTHON_VERSION: ${{ matrix.python_version }}
     steps:
     - uses: actions/checkout@v2
-    - name: Install mavlink messages
+    - name: Install mavlink definitions
+      shell: bash
       run: |
         git clone https://github.com/ArduPilot/mavlink.git
         ln -s $PWD/mavlink/message_definitions
     - name: Set CIBW_BUILD
-      run: echo "CIBW_BUILD=cp${PYTHON/./}-*" >> $GITHUB_ENV
-      env:
-        PYTHON: ${{ matrix.python }}
+      shell: bash
+      run: echo "CIBW_BUILD=cp${PYTHON_VERSION/./}-*" >> $GITHUB_ENV
     - name: Build wheels
       uses: pypa/cibuildwheel@v2.23.3
       env:
+        PYMAVLINK_FAST_INDEX: "1"
+        CIBW_BUILD: ${{ matrix.cibw_build }}
+        CIBW_ARCHS: ${{ matrix.cibw_archs }}
         CIBW_BEFORE_BUILD_LINUX: >
           if [ "$(uname -m)" = "i686" ] && grep -q musl /lib/libc.musl-*; then
             apk add --no-cache libxml2-dev libxslt-dev;
@@ -43,11 +94,11 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: wheels-${{ matrix.os }}-cp${{ matrix.python }}
+        name: ${{ matrix.name }}
         path: wheelhouse/*.whl
         if-no-files-found: error
 
-  sdist:
+  build-sdist:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -75,7 +126,7 @@ jobs:
         if-no-files-found: error
 
   publish:
-    needs: [wheels, sdist]
+    needs: [build-wheels, build-sdist]
     runs-on: ubuntu-latest
     steps:
     - name: Download all artifacts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,10 @@
 name: test pymavlink
 
 on: [push, pull_request]
-# paths:
-# - "*"
-# - "!README.md" <-- don't rebuild on doc change
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Brought the time from 30m to 8m, which I think we can live with. Also added Linux ARM, Windows, and Mac (x86, ARM, and universal). Funny enough, the bottleneck is still Linux x86. The Linux builds use docker, and the musl 32-bit wheel takes most of the time.

I've set it so that it only builds everything on push to master or release. PRs get only a fraction of the full build, and take about 3 minutes instead of 8. On PRs, I build Linux and Windows, 64-bit only, and for only 3.8 and 3.13 (which I deemed most likely to accidentally break in a PR). I could honestly leave all the python versions and all the OS and just disable 32-bit and it'd likely still be about 3 minutes, but I think I'll keep it the way I have it. We're still building everything after we merge, so we should be quick to catch any regressions. I also added the ability to manually trigger a run in case you see a PR that you think is risky enough to try a full build before merging.

The only wheels we're missing now are Windows ARM, because the Windows ARM runner doesn't come with enough stuff to compile lxml and lxml doesn't supply wheels WinARM. I'll just wait until lxml adds wheels for that, much to the dismay of all 0 people asking me for Windows ARM wheels.

I added concurrency rules so that subsequent PR pushes, or even rapid merging of several PRs, don't bog down CI.

Tested everything pretty thoroughly on my fork before opening.