### PR TITLE
WLua: Only truncate hex dump lines for test case output checks

### DIFF
--- a/tests/snapshottests/__snapshots__/test_wlua.ambr
+++ b/tests/snapshottests/__snapshots__/test_wlua.ambr
@@ -4,10 +4,10 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, 
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, Ack: 1, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -32,10 +32,10 @@
               param7 (float): 0
           Message CRC: 0xdb93
       
-      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) o
+      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, 
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, Ack: 46, Len: 82
       MAVLink Protocol (82)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -65,10 +65,10 @@
               text (char): Mode change to LOITER failed: requires position
           Message CRC: 0x647a
       
-      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706, Ack: 12611, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -93,10 +93,10 @@
               param7 (float): 0
           Message CRC: 0xf9df
       
-      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) o
+      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 126
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 12611, Ack: 751, Len: 88
       MAVLink Protocol (88)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -152,10 +152,10 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, 
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, Ack: 1, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -180,10 +180,10 @@
               param7 (float): 0
           Message CRC: 0xdb93
       
-      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) o
+      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, 
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, Ack: 46, Len: 82
       MAVLink Protocol (82)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -213,10 +213,10 @@
               text (char): Mode change to LOITER failed: requires position
           Message CRC: 0x647a
       
-      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706, Ack: 12611, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -241,10 +241,10 @@
               param7 (float): 0
           Message CRC: 0xf9df
       
-      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) o
+      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 126
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 12611, Ack: 751, Len: 88
       MAVLink Protocol (88)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -300,10 +300,10 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 1: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, 
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 1, Ack: 1, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -321,10 +321,10 @@
           Unparsable payload: 0000803f0000a04000000000000000000000000000000000
           Message CRC: 0xdb93
       
-      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) o
+      Frame 2: 138 bytes on wire (1104 bits), 138 bytes captured (1104 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, 
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 1, Ack: 46, Len: 82
       MAVLink Protocol (82)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -342,10 +342,10 @@
           Unparsable payload: b000040000000000fafa9276fd300000db0101fd0000044d
           Message CRC: 0x647a
       
-      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on 
+      Frame 3: 101 bytes on wire (808 bits), 101 bytes captured (808 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706
+      Transmission Control Protocol, Src Port: 62025, Dst Port: 5760, Seq: 706, Ack: 12611, Len: 45
       MAVLink Protocol (45)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -363,10 +363,10 @@
           Unparsable payload: 000000000000000000000000000000000000000000000000
           Message CRC: 0xf9df
       
-      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) o
+      Frame 4: 144 bytes on wire (1152 bits), 144 bytes captured (1152 bits) on interface lo0, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 126
+      Transmission Control Protocol, Src Port: 5760, Dst Port: 62025, Seq: 12611, Ack: 751, Len: 88
       MAVLink Protocol (88)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -393,7 +393,7 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 131 bytes on wire (1048 bits), 131 bytes captured (1048 bits) o
+      Frame 1: 131 bytes on wire (1048 bits), 131 bytes captured (1048 bits) on interface lo, id 0
       Ethernet II, Src: 00:00:00:00:00:00, Dst: 00:00:00:00:00:00
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
       User Datagram Protocol, Src Port: 34942, Dst Port: 18570
@@ -408,25 +408,25 @@
               Component id: MAV_COMP_ID_AUTOPILOT1 (1)
               Message id: AUTOPILOT_VERSION (148)
           Payload: AUTOPILOT_VERSION (148)
-              capabilities (MAV_PROTOCOL_CAPABILITY): 0x000000000000f36f (6231
-                  .... .... .... .... ...1 = MAV_PROTOCOL_CAPABILITY_MISSION_F
-                  .... .... .... .... ..1. = MAV_PROTOCOL_CAPABILITY_PARAM_FLO
-                  .... .... .... .... .1.. = MAV_PROTOCOL_CAPABILITY_MISSION_I
-                  .... .... .... .... 1... = MAV_PROTOCOL_CAPABILITY_COMMAND_I
-                  .... .... .... ...0 .... = MAV_PROTOCOL_CAPABILITY_PARAM_ENC
+              capabilities (MAV_PROTOCOL_CAPABILITY): 0x000000000000f36f (62319)
+                  .... .... .... .... ...1 = MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT: True
+                  .... .... .... .... ..1. = MAV_PROTOCOL_CAPABILITY_PARAM_FLOAT: True
+                  .... .... .... .... .1.. = MAV_PROTOCOL_CAPABILITY_MISSION_INT: True
+                  .... .... .... .... 1... = MAV_PROTOCOL_CAPABILITY_COMMAND_INT: True
+                  .... .... .... ...0 .... = MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_BYTEWISE: False
                   .... .... .... ..1. .... = MAV_PROTOCOL_CAPABILITY_FTP: True
-                  .... .... .... .1.. .... = MAV_PROTOCOL_CAPABILITY_SET_ATTIT
-                  .... .... .... 0... .... = MAV_PROTOCOL_CAPABILITY_SET_POSIT
-                  .... .... ...1 .... .... = MAV_PROTOCOL_CAPABILITY_SET_POSIT
-                  .... .... ..1. .... .... = MAV_PROTOCOL_CAPABILITY_TERRAIN: 
-                  .... .... .0.. .... .... = MAV_PROTOCOL_CAPABILITY_SET_ACTUA
-                  .... .... 0... .... .... = MAV_PROTOCOL_CAPABILITY_FLIGHT_TE
-                  .... ...1 .... .... .... = MAV_PROTOCOL_CAPABILITY_COMPASS_C
-                  .... ..1. .... .... .... = MAV_PROTOCOL_CAPABILITY_MAVLINK2:
-                  .... .1.. .... .... .... = MAV_PROTOCOL_CAPABILITY_MISSION_F
-                  .... 1... .... .... .... = MAV_PROTOCOL_CAPABILITY_MISSION_R
-                  ...0 .... .... .... .... = MAV_PROTOCOL_CAPABILITY_RESERVED2
-                  ..0. .... .... .... .... = MAV_PROTOCOL_CAPABILITY_PARAM_ENC
+                  .... .... .... .1.. .... = MAV_PROTOCOL_CAPABILITY_SET_ATTITUDE_TARGET: True
+                  .... .... .... 0... .... = MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_LOCAL_NED: False
+                  .... .... ...1 .... .... = MAV_PROTOCOL_CAPABILITY_SET_POSITION_TARGET_GLOBAL_INT: True
+                  .... .... ..1. .... .... = MAV_PROTOCOL_CAPABILITY_TERRAIN: True
+                  .... .... .0.. .... .... = MAV_PROTOCOL_CAPABILITY_SET_ACTUATOR_TARGET: False
+                  .... .... 0... .... .... = MAV_PROTOCOL_CAPABILITY_FLIGHT_TERMINATION: False
+                  .... ...1 .... .... .... = MAV_PROTOCOL_CAPABILITY_COMPASS_CALIBRATION: True
+                  .... ..1. .... .... .... = MAV_PROTOCOL_CAPABILITY_MAVLINK2: True
+                  .... .1.. .... .... .... = MAV_PROTOCOL_CAPABILITY_MISSION_FENCE: True
+                  .... 1... .... .... .... = MAV_PROTOCOL_CAPABILITY_MISSION_RALLY: True
+                  ...0 .... .... .... .... = MAV_PROTOCOL_CAPABILITY_RESERVED2: False
+                  ..0. .... .... .... .... = MAV_PROTOCOL_CAPABILITY_PARAM_ENCODE_C_CAST: False
               flight_sw_version (uint32_t): 67307007
               middleware_sw_version (uint32_t): 0
               os_sw_version (uint32_t): 0
@@ -469,7 +469,7 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 70 bytes on wire (560 bits), 70 bytes captured (560 bits) on in
+      Frame 1: 70 bytes on wire (560 bits), 70 bytes captured (560 bits) on interface lo, id 0
       Ethernet II, Src: 00:00:00:00:00:00, Dst: 00:00:00:00:00:00
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
       User Datagram Protocol, Src Port: 57304, Dst Port: 14550
@@ -498,10 +498,10 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 115 bytes on wire (920 bits), 115 bytes captured (920 bits) on 
+      Frame 1: 115 bytes on wire (920 bits), 115 bytes captured (920 bits) on interface lo, id 0
       Ethernet II, Src: 00:00:00:00:00:00, Dst: 00:00:00:00:00:00
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
-      Transmission Control Protocol, Src Port: 54026, Dst Port: 5760, Seq: 1, 
+      Transmission Control Protocol, Src Port: 54026, Dst Port: 5760, Seq: 1, Ack: 1, Len: 49
       MAVLink Protocol (49)
           Header
               Magic value / version: MAVLink 2.0 (0xfd)
@@ -520,7 +520,7 @@
               command (MAV_CMD): MAV_CMD_NAV_VTOL_LAND (85)
               current (uint8_t): 0
               autocontinue (uint8_t): 1
-              param1: Land Options (NAV_VTOL_LAND_OPTIONS): NAV_VTOL_LAND_OPTI
+              param1: Land Options (NAV_VTOL_LAND_OPTIONS): NAV_VTOL_LAND_OPTIONS_DEFAULT (0)
               param2 (float): 0
               param3: Approach Altitude (float) m: 0
               param4: Yaw (float) deg: 0
@@ -538,7 +538,7 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 97 bytes on wire (776 bits), 97 bytes captured (776 bits) on in
+      Frame 1: 97 bytes on wire (776 bits), 97 bytes captured (776 bits) on interface lo, id 0
       Ethernet II, Src: 00:00:00:00:00:00, Dst: 00:00:00:00:00:00
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
       User Datagram Protocol, Src Port: 52752, Dst Port: 14550
@@ -574,7 +574,7 @@
     'returncode': 0,
     'stderr': '',
     'stdout': '''
-      Frame 1: 139 bytes on wire (1112 bits), 139 bytes captured (1112 bits) o
+      Frame 1: 139 bytes on wire (1112 bits), 139 bytes captured (1112 bits) on interface \Device\NPF_Loopback, id 0
       Null/Loopback
       Internet Protocol Version 4, Src: 127.0.0.1, Dst: 127.0.0.1
       User Datagram Protocol, Src Port: 50261, Dst Port: 14550

--- a/tests/snapshottests/test_wlua.py
+++ b/tests/snapshottests/test_wlua.py
@@ -3,7 +3,7 @@
 """
 Test that the wlua generator works in Wireshark
 """
-import os
+import os, re
 import shutil
 import subprocess
 
@@ -94,8 +94,11 @@ def test_wlua(request, tmp_path, snapshot, mdef, pcap):
     # note that, with text output, tshark truncates hex dump lines at 80-ish or 100-ish characters.
     # Truncate them preemptively so this isn't reflected in the diff.
     # This doesn't lose any info we really care about.
-    truncated_stdout = ''.join([line[:72]+"\n" for line in actual.stdout.splitlines()])
-    
+    stdout_lines = actual.stdout.splitlines()
+    for i in range(len(stdout_lines)):
+        if re.search(r"[0-9a-f]{60}", stdout_lines[i]):
+            stdout_lines[i] = stdout_lines[i][:72]
+    truncated_stdout = '\n'.join(stdout_lines) + '\n'
     props_to_match = {
         "stdout": truncated_stdout,
         "stderr": actual.stderr,


### PR DESCRIPTION
Currently the Wireshark LUA test cases truncate all lines at 72 characters because the tshark output for byte-stream lines gets truncated with a '...' at one point.
This change alters the logic so that _only_ byte-stream lines are truncated, rather than _all_ lines.
Byte-steam lines are recognised by matching a regular expression of at least 60-consecutive [0-9a-z] characters.

This ensures that relevant parts of the test output are not lost. For example:
```
.... .... .... .... ...1 = MAV_PROTOCOL_CAPABILITY_MISSION_F
vs
.... .... .... .... ...1 = MAV_PROTOCOL_CAPABILITY_MISSION_FLOAT: True
```

This becomes even more relevant for a test case I plan to add for 64-bit bitfields in an upcoming PR fix for issue #895.

Tested via local running of pytest and CI.