### PR TITLE
generator: schema: add decidegrees per second units

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -117,6 +117,7 @@
     <xs:enumeration value="mrad/s"/>   <!-- milli-radians per second -->
     <xs:enumeration value="deg"/>      <!-- degrees -->
     <xs:enumeration value="deg/2"/>    <!-- degrees/2 required from dagar for HIGH_LATENCY2 message-->
+    <xs:enumeration value="ddeg/s"/>   <!-- decidegrees per second, used to correct a mistake in the AIS_VESSEL message, not recommended elsewhere-->
     <xs:enumeration value="deg/s"/>    <!-- degrees per second -->
     <xs:enumeration value="cdeg"/>     <!-- centidegrees -->
     <xs:enumeration value="cdeg/s"/>   <!-- centidegrees per second -->


### PR DESCRIPTION
This is needed to fix a embarrassing issue with the AIS message, see: https://github.com/mavlink/mavlink/pull/2281