### PR TITLE
Send heartbeat to start MAVLink

### DIFF
--- a/mavftp.py
+++ b/mavftp.py
@@ -403,6 +403,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         '''handle OP_ListDirectory reply'''
         output: List[DirectoryEntry] = []
         if op.opcode == OP_Ack and op.payload is not None:
+            if self.ftp_settings.debug > 0:
+                logging.info("FTP: Processing ListDirectory with %uB payload", len(op.payload))
             dentries = sorted(op.payload.split(b"\x00"))
             for d in dentries:
                 if len(d) == 0:
@@ -411,7 +413,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 try:
                     dir_entry = str(d, "ascii")
                 except Exception as error:  # pylint: disable=broad-exception-caught
-                    logging.debug(error)
+                    logging.debug("FTP: Failed to decode entry: %s", error)
                     continue
                 if dir_entry[0] == "D":
                     output.append(DirectoryEntry(name=dir_entry[1:], is_dir=True, size_b=0))
@@ -1673,6 +1675,17 @@ if __name__ == "__main__":
 
         if args.command in ['get', 'put', 'getparams']:
             ret = mav_ftp.process_ftp_reply(args.command, timeout=500)
+
+        if args.command == 'list':
+            if ret.error_code in [FtpError.Success, FtpError.EndOfFile]:
+                if mav_ftp.list_result:
+                    for entry in mav_ftp.list_result:
+                        if entry.is_dir:
+                            print(f"{entry.name}/")
+                        else:
+                            print(f"{entry.name:<30} {entry.size_b:>10} bytes")
+                else:
+                    print("Directory is empty")
 
         if isinstance(ret, str):
             logging.error("Command returned: %s, but it should return a MAVFTPReturn instead", ret)


### PR DESCRIPTION
Send a heartbeat so `cdcacm_autostart` starts MAVLink. Necessary on some flight controllers if you don't explicitly run `mavlink start`

```
INFO  [cdcacm_autostart] Starting CDC/ACM autostart
...
INFO  [cdcacm_autostart] /dev/ttyACM0: launching mavlink (HEARTBEAT v1 from SYSID:255 COMPID:0)
INFO  [mavlink] mode: Onboard, data rate: 100000 B/s on /dev/ttyACM0 @ 2000000B
```

Adds `--poke` to demo CLI. Works for me