### PR TITLE
XSD: Remove display attribute from fields

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -20,7 +20,6 @@
 <xs:attribute name="id" type="mavlinkMsgId"/> <!-- used in message elements -->
 <xs:attribute name="print_format" type="xs:string"/> <!-- used in field elements -->
 <xs:attribute name="enum" type="xs:string"/> <!-- used in field,param elements -->
-<xs:attribute name="display" type="xs:string"/> <!-- used in field elements -->
 <xs:attribute name="units" type="SI_Unit"/> <!-- this will get changed on the fly to xs:string if no strict-units command line option is used -->
 <xs:attribute name="multiplier" type="factor"/>
 <xs:attribute name="instance" type="xs:boolean"/>
@@ -243,7 +242,6 @@
         <xs:attribute ref="name" use="required"/>
         <xs:attribute ref="print_format" />
         <xs:attribute ref="enum" />
-        <xs:attribute ref="display" />
         <xs:attribute ref="units" />
         <xs:attribute ref="increment"/>
         <xs:attribute ref="minValue"/>


### PR DESCRIPTION
This removes the XSD to allow `display="bitmask"` on a field. We now expect the bitmask attribute to be set on the enum itself.

The trigger for this was the accidental reintroduction of the attribute in https://github.com/mavlink/mavlink/pull/2289/ 

My concern about this is that it might break other systems that aren't directly managed by MAVLink org.