### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -126,7 +126,7 @@ class DFFormat(object):
             if self.msg_fmts[i] == 'a':
                 self.a_indexes.append(i)
 
-        # If this format was alrady defined, copy over units and instance info
+        # If this format was already defined, copy over units and instance info
         if oldfmt is not None:
             self.units = oldfmt.units
             if oldfmt.instance_field is not None:
@@ -171,7 +171,7 @@ class DFFormat(object):
             # Get the unit multiplier from the lookup table
             if mult_ids[i] in mult_lookup:
                 unitmult = mult_lookup[mult_ids[i]]
-                # Combine the multipler and unit to derive the real unit
+                # Combine the multiplier and unit to derive the real unit
                 if unitmult in MULT_TO_PREFIX:
                     self.units[i] = MULT_TO_PREFIX[unitmult]+self.units[i]
                 else:
@@ -229,7 +229,7 @@ class DFMessage(object):
         except Exception:
             raise AttributeError(field)
         if self.fmt.msg_fmts[i] == 'Z' and self.fmt.name == 'FILE':
-            # special case for FILE contens as bytes
+            # special case for FILE contents as bytes
             return self._elements[i]
         if isinstance(self._elements[i], bytes):
             try:

--- a/examples/combine_logs.py
+++ b/examples/combine_logs.py
@@ -104,7 +104,7 @@ while True:
         break
 
     if m2 is None and m1 is not None:
-        # pass-thru m1
+        # pass through m1
         output.write(m1.get_msgbuf())
         m1 = None
         continue
@@ -116,7 +116,7 @@ while True:
         continue
 
     if m1._timestamp < m2._timestamp:
-        # m1 is older, pass-thru m1
+        # m1 is older, pass through m1
         #print("write m1", m2._timestamp - m1._timestamp)
         output.write(m1.get_msgbuf())
         m1 = None

--- a/examples/mavftp_example.py
+++ b/examples/mavftp_example.py
@@ -144,7 +144,7 @@ def get_last_log(mav_ftp):
         logging_error("File LASTLOG.TXT not found.")
         return
     except ValueError:
-        logging_error("Could not extract last log file number from LASTLOG.TXT contants %s", file_contents)
+        logging_error("Could not extract last log file number from LASTLOG.TXT contents %s", file_contents)
         return
     remote_filenumber = remote_filenumber - 1 # we do not want the very last log
     remote_filename = f'/APM/LOGS/{remote_filenumber:08}.BIN'

--- a/generator/javascript/test/make_tests.py
+++ b/generator/javascript/test/make_tests.py
@@ -194,7 +194,7 @@ def do_make_output(mt,v,lines):
             continue
         hexdata = line.strip().replace(' ',', 0x')
         hexdata = '0x'+hexdata
-        # ckeck if signing bit is set on this packet: 0xfd, 0x09, 0x01 <-- that 1
+        # check if signing bit is set on this packet: 0xfd, 0x09, 0x01 <-- that 1
         signchar = hexdata[15]
         signint = int(signchar,16)
         signbit = signint % 2; # lowest bit to true/false

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -393,7 +393,7 @@ static inline void mavlink_msg_${name_lower}_send_struct(mavlink_channel_t chan,
 
 #if MAVLINK_MSG_ID_${name}_LEN <= MAVLINK_MAX_PAYLOAD_LEN
 /*
-  This variant of _send() can be used to save stack space by re-using
+  This variant of _send() can be used to save stack space by reusing
   memory from the receive buffer.  The caller provides a
   mavlink_message_t which is the size of a full mavlink message. This
   is usually the receive buffer for the channel, and allows a reply to an

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -425,7 +425,7 @@ def generate_one(basename, xml):
             underlying_type = types[-1]
 
         # template do not support "if"
-        # filter out ENUM_END, it often > than unterlying type may handle
+        # filter out ENUM_END, it often > than underlying type may handle
         e.entry_flt = []
         for f in e.entry:
             f.name_trim = enum_remove_prefix(e.name, f.name)

--- a/generator/mavgen_swift.py
+++ b/generator/mavgen_swift.py
@@ -119,7 +119,7 @@ extension ${swift_name}: MAVLinkBitmask {
         outf.close()
 
 def get_enum_raw_type(enum, msgs):
-    """Search appropirate raw type for enums in messages fields"""
+    """Search appropriate raw type for enums in messages fields"""
 
     for msg in msgs:
         for field in msg.fields:

--- a/generator/mavtemplate.py
+++ b/generator/mavtemplate.py
@@ -69,7 +69,7 @@ class MAVTemplate(object):
         if checkmissing is None:
             checkmissing = self.checkmissing
 
-        # handle repititions
+        # handle repetitions
         while True:
             subidx = text.find(self.start_rep_token)
             if subidx == -1:

--- a/generator/swift/Tests/MAVLinkTests/Testdata/common.xml
+++ b/generator/swift/Tests/MAVLinkTests/Testdata/common.xml
@@ -2594,7 +2594,7 @@
       <field type="uint8_t" name="target_component">Component ID</field>
       <field type="char[16]" name="param_id">Onboard parameter id, terminated by NULL if the length is less than 16 human-readable chars and WITHOUT null termination (NULL) byte if the length is exactly 16 chars - applications have to provide 16+1 bytes storage if the ID is stored as string</field>
       <field type="int16_t" name="param_index">Parameter index. Send -1 to use the param ID field as identifier (else the param id will be ignored), send -2 to disable any existing map for this rc_channel_index.</field>
-      <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically correpsonds to a potentiometer-knob on the RC.</field>
+      <field type="uint8_t" name="parameter_rc_channel_index">Index of parameter RC channel. Not equal to the RC channel id. Typically corresponds to a potentiometer-knob on the RC.</field>
       <field type="float" name="param_value0">Initial parameter value</field>
       <field type="float" name="scale">Scale, maps the RC range [-1, 1] to a parameter value</field>
       <field type="float" name="param_value_min">Minimum param value. The protocol does not define if this overwrites an onboard minimum value. (Depends on implementation)</field>
@@ -3397,7 +3397,7 @@
     </message>
     <message id="142" name="RESOURCE_REQUEST">
       <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
-      <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
+      <field type="uint8_t" name="request_id">Request ID. This ID should be reused when sending back URI contents</field>
       <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
       <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
       <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
@@ -3474,7 +3474,7 @@
       <description>The location of a landing area captured from a downward facing camera</description>
       <field type="uint64_t" name="time_usec">Timestamp (micros since boot or Unix epoch)</field>
       <field type="uint8_t" name="target_num">The ID of the target if multiple targets are present</field>
-      <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following feilds are earth-frame, body-frame, etc.</field>
+      <field type="uint8_t" name="frame">MAV_FRAME enum specifying the whether the following fields are earth-frame, body-frame, etc.</field>
       <field type="float" name="angle_x">X-axis angular offset (in radians) of the target from the center of the image</field>
       <field type="float" name="angle_y">Y-axis angular offset (in radians) of the target from the center of the image</field>
       <field type="float" name="distance">Distance to the target from the vehicle in meters</field>

--- a/mavftpfs.py
+++ b/mavftpfs.py
@@ -12,7 +12,7 @@ from pymavlink import mavutil
 
 from mavftp import MAVFTP
 
-# this allows us to support acessing the special files
+# this allows us to support accessing the special files
 base_file_paths = ["/", "@ROMFS", "@SYS"]
 
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -1794,7 +1794,7 @@ class mavwebsocket(mavfile):
             # Should probbily raise a exception of some sort
             return ''
 
-        # Read in some data and pass it to the WebSocket handeler
+        # Read in some data and pass it to the WebSocket handler
         RECEIVE_BYTES = 4096
         try:
             in_data = self.port.recv(RECEIVE_BYTES)
@@ -1808,7 +1808,7 @@ class mavwebsocket(mavfile):
             self.close_port()
             return ''
 
-        # Procces WebSocket events
+        # Process WebSocket events
         data = b""
         reply = b""
         keep_running = True
@@ -1827,7 +1827,7 @@ class mavwebsocket(mavfile):
                 data += event.data
 
         if len(reply) > 0:
-            # Send any reply to incomming requests
+            # Send any reply to incoming requests
             self.port.send(reply)
 
         if not keep_running:
@@ -2302,7 +2302,7 @@ except Exception:
 # map from a PX4 "main_state" to a string; see msg/commander_state.msg
 # This allows us to map sdlog STAT.MainState to a simple "mode"
 # string, used in DFReader and possibly other places.  These are
-# related but distict from what is found in mavlink messages; see
+# related but distinct from what is found in mavlink messages; see
 # "Custom mode definitions", below.
 mainstate_mapping_px4 = {
     0 : 'MANUAL',

--- a/mavwp.py
+++ b/mavwp.py
@@ -28,7 +28,7 @@ class MAVWPError(Exception):
 
 
 class MissionItemProtocol(object):
-    '''Base class for transfering items based on the MISSION_ITEM protocol'''
+    '''Base class for transferring items based on the MISSION_ITEM protocol'''
     def __init__(self, target_system=0, target_component=0):
         self.wpoints = []
         self.target_system = target_system

--- a/tests/snapshottests/resources/common.xml
+++ b/tests/snapshottests/resources/common.xml
@@ -23,7 +23,7 @@
       </entry>
     </enum>
     <enum name="HL_FAILURE_FLAG" bitmask="true">
-      <description>Flags to report failure cases over the high latency telemtry.</description>
+      <description>Flags to report failure cases over the high latency telemetry.</description>
       <entry value="1" name="HL_FAILURE_FLAG_GPS">
         <description>GPS failure.</description>
       </entry>
@@ -1989,7 +1989,7 @@
         <description>Set the interval between messages for a particular MAVLink message ID. This interface replaces REQUEST_DATA_STREAM.</description>
         <param index="1" label="Message ID" minValue="0" maxValue="16777215" increment="1">The MAVLink message ID</param>
         <param index="2" label="Interval" units="us" minValue="-1" increment="1">The interval between two messages. -1: disable. 0: request default rate (which may be zero).</param>
-        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requestor, 2: broadcast.</param>
+        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address of message stream (if message has target address fields). 0: Flight-stack default (recommended), 1: address of requester, 2: broadcast.</param>
       </entry>
       <entry value="512" name="MAV_CMD_REQUEST_MESSAGE" hasLocation="false" isDestination="false">
         <description>Request the target system(s) emit a single instance of a specified message (i.e. a "one-shot" version of MAV_CMD_SET_MESSAGE_INTERVAL).</description>
@@ -1999,7 +1999,7 @@
         <param index="4" label="Req Param 3">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="5" label="Req Param 4">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
         <param index="6" label="Req Param 5">The use of this parameter (if any), must be defined in the requested message. By default assumed not used (0).</param>
-        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requestor, 2: broadcast.</param>
+        <param index="7" label="Response Target" minValue="0" maxValue="2" increment="1">Target address for requested message (if message has target address fields). 0: Flight-stack default, 1: address of requester, 2: broadcast.</param>
       </entry>
       <entry value="519" name="MAV_CMD_REQUEST_PROTOCOL_VERSION" hasLocation="false" isDestination="false">
         <deprecated since="2019-08" replaced_by="MAV_CMD_REQUEST_MESSAGE"/>
@@ -5922,7 +5922,7 @@
         The request is sent with `ts1=syncing component timestamp` and `tc1=0`, and may be broadcast or targeted to a specific system/component.
         The response is sent with `ts1=syncing component timestamp` (mirror back unchanged), and `tc1=responding component timestamp`, with the `target_system` and `target_component` set to ids of the original request.
         Systems can determine if they are receiving a request or response based on the value of `tc`.
-        If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync; the requestor may report an error.
+        If the response has `target_system==target_component==0` the remote system has not been updated to use the component IDs and cannot reliably timesync; the requester may report an error.
         Timestamps are UNIX Epoch time or time since system boot in nanoseconds (the timestamp format can be inferred by checking for the magnitude of the number; generally it doesn't matter as only the offset is used).
         The message sequence is repeated numerous times with results being filtered/averaged to estimate the offset.
       </description>
@@ -6247,7 +6247,7 @@
     </message>
     <message id="142" name="RESOURCE_REQUEST">
       <description>The autopilot is requesting a resource (file, binary, other type of data)</description>
-      <field type="uint8_t" name="request_id">Request ID. This ID should be re-used when sending back URI contents</field>
+      <field type="uint8_t" name="request_id">Request ID. This ID should be reused when sending back URI contents</field>
       <field type="uint8_t" name="uri_type">The type of requested URI. 0 = a file via URL. 1 = a UAVCAN binary</field>
       <field type="uint8_t[120]" name="uri">The requested unique resource identifier (URI). It is not necessarily a straight domain name (depends on the URI type enum)</field>
       <field type="uint8_t" name="transfer_type">The way the autopilot wants to receive the URI. 0 = MAVLink FTP. 1 = binary stream.</field>
@@ -7498,7 +7498,7 @@
       <field type="int16_t" name="speed_vertical" units="cm/s">The vertical speed. Up is positive. If unknown: 6300 cm/s. If speed is larger than 6200 cm/s, use 6200 cm/s. If lower than -6200 cm/s, use -6200 cm/s.</field>
       <field type="int32_t" name="latitude" units="degE7" invalid="0">Current latitude of the unmanned aircraft. If unknown: 0 (both Lat/Lon).</field>
       <field type="int32_t" name="longitude" units="degE7" invalid="0">Current longitude of the unmanned aircraft. If unknown: 0 (both Lat/Lon).</field>
-      <field type="float" name="altitude_barometric" units="m" invalid="-1000">The altitude calculated from the barometric pressue. Reference is against 29.92inHg or 1013.2mb. If unknown: -1000 m.</field>
+      <field type="float" name="altitude_barometric" units="m" invalid="-1000">The altitude calculated from the barometric pressure. Reference is against 29.92inHg or 1013.2mb. If unknown: -1000 m.</field>
       <field type="float" name="altitude_geodetic" units="m" invalid="-1000">The geodetic altitude as defined by WGS84. If unknown: -1000 m.</field>
       <field type="uint8_t" name="height_reference" enum="MAV_ODID_HEIGHT_REF">Indicates the reference point for the height field.</field>
       <field type="float" name="height" units="m" invalid="-1000">The current height of the unmanned aircraft above the take-off location or the ground as indicated by height_reference. If unknown: -1000 m.</field>

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -204,7 +204,7 @@ class MAVWPTest(unittest.TestCase):
         self.assertTrue(loader.is_location_command(mavutil.mavlink.MAV_CMD_NAV_LOITER_TURNS))
 
 class RallyTest(unittest.TestCase):
-    '''tests functions related to loading waypoints and transfering them
+    '''tests functions related to loading waypoints and transferring them
     via the mission-item-protocol'''
     def test_rally_load(self):
         '''test loading rally points from old RALLY style file'''


### PR DESCRIPTION
Use https://github.com/codespell-project/codespell to discover and fix common typos across the codebase.
```bash
% codespell --ignore-words-list="bu,delt,inout,mot,ned,od,ody,parm,parms,pevent,rin,sitl,siz,ue,upto" \
            --quiet-level=2 --skip="*.adb,*.json" --write-changes
```
Like:
* #557
* #559