### PR TITLE
cibuildwheel updates

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -38,7 +38,7 @@ jobs:
                   ("linux-arm", "ubuntu-24.04-arm", "auto"),
                   ("macos", "macos-latest", "arm64 x86_64 universal2"),
                   ("windows", "windows-latest", "auto"),
-                  # ("windows-arm", "windows-11-arm", "auto"), # Can't do this one yet, as lxml doesn't have Windows ARM wheels, and the runner doesn't have libxml2 pre-installed
+                  ("windows-arm", "windows-11-arm", "auto"),
               ]
               py_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
           else:
@@ -51,6 +51,8 @@ jobs:
           matrix = {"include": []}
           for (name, runner, cibw_archs) in machines:
               for py in py_versions:
+                  if name == "windows-arm" and py == "3.8": # The windows arm runner does not support Python 3.8
+                      continue
                   matrix["include"].append({
                       "name": f"python{py}-{name}",
                       "os": runner,

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -87,10 +87,6 @@ jobs:
         PYMAVLINK_FAST_INDEX: "1"
         CIBW_BUILD: ${{ matrix.cibw_build }}
         CIBW_ARCHS: ${{ matrix.cibw_archs }}
-        CIBW_BEFORE_BUILD_LINUX: >
-          if [ "$(uname -m)" = "i686" ] && grep -q musl /lib/libc.musl-*; then
-            apk add --no-cache libxml2-dev libxslt-dev;
-          fi
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,10 +34,10 @@ jobs:
 
           if ref in ("refs/heads/main", "refs/heads/master") or event in ("release", "workflow_dispatch"):
               machines = [
-                  ("linux", "ubuntu-latest", "auto"),
+                  ("linux", "ubuntu-latest", "auto64 auto32"),
                   ("linux-arm", "ubuntu-24.04-arm", "auto"),
                   ("macos", "macos-latest", "arm64 x86_64 universal2"),
-                  ("windows", "windows-latest", "auto"),
+                  ("windows", "windows-latest", "auto64 auto32"),
                   ("windows-arm", "windows-11-arm", "auto"),
               ]
               py_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -84,7 +84,7 @@ jobs:
       shell: bash
       run: echo "CIBW_BUILD=cp${PYTHON_VERSION/./}-*" >> $GITHUB_ENV
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.23.3
+      uses: pypa/cibuildwheel@v3.0.0
       env:
         PYMAVLINK_FAST_INDEX: "1"
         CIBW_BUILD: ${{ matrix.cibw_build }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 # you need to drop setup_requires from setup.py as well.
 # https://peps.python.org/pep-0518/#rationale
 [build-system]
-requires = ["setuptools>=42","future","lxml","cython"]
+requires = ["setuptools>=42","future","cython"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This PR contains two fixes:

## Remove "lxml" from pyproject.toml
This is necessary to fix a [recent build failure](https://github.com/ArduPilot/pymavlink/actions/runs/16010298504). lxml just released a new version 6.0.0, which does not have a wheel for cp38-manylinux_aarch64, where the previous version did. The thing is, there's really no reason for us to need to pip install lxml into the isolated build environment; it's a runtime dependency only. `pyproject.toml` does not need this in there.

This also lets me build the windows-arm wheels now (surely few, if any, care about that yet).

I'm pretty sure it doesn't need "future" in there either, but I didn't bother removing that as it isn't hurting anything like the lxml thing is.

## Update cibuildwheel to 3.0.0
Split out from #1072

I went through the [change log](https://cibuildwheel.pypa.io/en/stable/changelog/) and it looks like the only change that impacts us was that they dropped 32-bit linux from the "auto" group. I have changed that to "auto64 auto32". They mentioned that they are considering doing the same to windows in the future, so I added that to the windows line too to cover us when that happens.

[I have tested the build on my fork, using workflow-dispatch to make sure all archs/versions build](https://github.com/robertlong13/pymavlink/actions/runs/16015744853)