### PR TITLE
Tools: mavlogdump: preseve units allong with format when trimming logs

### DIFF
--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -235,6 +235,9 @@ while True:
         if (isbin or islog) and m_type == "FMT":
             output.write(m.get_msgbuf())
             continue
+        if (isbin or islog) and m_type == "FMTU":
+            output.write(m.get_msgbuf())
+            continue
         if (isbin or islog) and (m_type == "PARM" and args.parms):
             output.write(m.get_msgbuf())
             continue


### PR DESCRIPTION
Now were using instance messages extensively log parsers need the units to work out what should be shown as a instance. 