### PR TITLE
pyproject.toml: Add tool.ruff.lint.extend-ignore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,11 @@
 # modern build tools use this file: https://packaging.python.org/en/latest/tutorials/packaging-projects/
 # you need to drop setup_requires from setup.py as well.
 # https://peps.python.org/pep-0518/#rationale
+
 [build-system]
-requires = ["setuptools>=42","future","cython"]
 build-backend = "setuptools.build_meta"
+
+requires = [ "cython", "future", "setuptools>=42" ]
+
+[tool.ruff]
+lint.extend-ignore = [ "E4", "E7", "F40", "F523", "F601", "F811", "F841" ]


### PR DESCRIPTION
% `echo '\n[tool.ruff]\nlint.extend-ignore=["E4","E7","F40","F523","F601","F811","F841"]' >> pyproject.toml`
% `uvx pyproject-fmt pyproject.toml`
% `uvx validate-pyproject pyproject.toml`
```
Valid file: pyproject.toml
```
% `uvx ruff check`
```
All checks passed!
```
As discussed at:
* mavlink/mavlink#2303

As tested at:
* mavlink/mavlink#2307