### PR TITLE
.github: Upgrade to pylint v3.3.7

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip
-        pip install requests 'pylint<=3.2.7'
+        pip install requests 'pylint<=3.3.7'
 
     - name: Analysing the code known to be pylint clean
       run: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,6 @@
+[DESIGN]
+max-positional-arguments=9
+
 [FORMAT]
 max-line-length=127
 


### PR DESCRIPTION
https://pypi.org/project/pylint

Increased `max-positional-arguments` from the default of 5 to 9.
https://pylint.readthedocs.io/en/latest/user_guide/messages/refactor/too-many-positional-arguments.html

### How was this tested?
```
uvx --with=requests --with=setuptools pylint==3.3.7 __init__.py dialects/__init__.py \
        dialects/v09/__init__.py dialects/v10/__init__.py dialects/v20/__init__.py \
        examples/__init__.py generator/__init__.py tests/test_mavxml.py tools/__init__.py \
        mavftp.py mavftp_op.py examples/mavftp_example.py examples/status_msg.py \
        tests/test_mavftp.py tests/test_mavxml.py
```