### PR TITLE
Remove future imports and python-future code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -96,7 +96,7 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          pip install future lxml
+          pip install lxml
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}

--- a/CSVReader.py
+++ b/CSVReader.py
@@ -20,8 +20,6 @@ MAV> graph CSV.GYRO_X
 in this case the GPS time was in seconds-since-week-start, so a conversion to ms is required
 
 '''
-from builtins import range
-from builtins import object
 
 import csv
 import struct

--- a/DFReader.py
+++ b/DFReader.py
@@ -7,8 +7,6 @@ Released under GNU GPL version 3 or later
 
 Partly based on SDLog2Parser by Anton Babushkin
 '''
-from builtins import range
-from builtins import object
 
 import array
 import math

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ The following instructions assume you are using a Debian-based (like Ubuntu) ins
 
 Pymavlink has several dependencies :
 
-    - [future](http://python-future.org/) : for interoperability
     - [lxml](http://lxml.de/installation.html) : for checking and parsing xml file 
 
 Optional :
@@ -48,12 +47,11 @@ sudo apt-get install python3-numpy python3-pytest
 Using pip you can install the required dependencies for pymavlink :
 
 ```bash
-sudo python3 -m pip install --upgrade future lxml
+sudo python3 -m pip install --upgrade lxml
 ```
 
 ### On Windows
 
-Use pip to install future as for Linux.
 Lxml can be installed with a Windows installer from here : https://pypi.org/project/lxml
 
 

--- a/examples/apmsetrate.py
+++ b/examples/apmsetrate.py
@@ -3,7 +3,6 @@
 '''
 set stream rate on an APM
 '''
-from builtins import range
 
 import sys
 

--- a/examples/mav_replay_estimator.py
+++ b/examples/mav_replay_estimator.py
@@ -3,7 +3,6 @@
 '''
 estimate attitude from an ArduPilot replay log using a python state estimator
 '''
-from builtins import range
 
 import os
 

--- a/examples/mavtest.py
+++ b/examples/mavtest.py
@@ -3,7 +3,6 @@
 """
 Generate a message using different MAVLink versions, put in a buffer and then read from it.
 """
-from builtins import object
 
 from pymavlink.dialects.v10 import ardupilotmega as mavlink1
 from pymavlink.dialects.v20 import ardupilotmega as mavlink2

--- a/examples/wptogpx.py
+++ b/examples/wptogpx.py
@@ -4,7 +4,6 @@
 example program to extract GPS data from a waypoint file, and create a GPX
 file, for loading into google earth
 '''
-from builtins import range
 
 import time
 

--- a/fgFDM.py
+++ b/fgFDM.py
@@ -4,8 +4,6 @@
 # Andrew Tridgell, November 2011
 # released under GNU GPL version 2 or later
 
-from builtins import range
-from builtins import object
 import struct, math
 
 class fgFDMError(Exception):

--- a/generator/mavcrc.py
+++ b/generator/mavcrc.py
@@ -5,7 +5,6 @@ Copyright Andrew Tridgell
 Released under GNU LGPL version 3 or later
 '''
 import sys
-from builtins import object
 
 try:
     import fastcrc

--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -22,11 +22,6 @@ General process:
 
 '''
 
-import sys
-if sys.version_info <= (3,10):
-    from future import standard_library
-    standard_library.install_aliases()
-from builtins import object
 import os
 import re
 import sys

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -5,8 +5,6 @@ Parse a MAVLink protocol XML file and generate a Java implementation
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
-from builtins import object
 
 import os
 from . import mavparse, mavtemplate

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -5,7 +5,6 @@ parse a MAVLink protocol XML file and generate a Node.js javascript module imple
 Based on original work Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
 
 import os
 import textwrap

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -5,7 +5,6 @@ parse a MAVLink protocol XML file and generate a Node.js javascript module imple
 Based on original work Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
 
 import os
 import textwrap

--- a/generator/mavgen_lua.py
+++ b/generator/mavgen_lua.py
@@ -2,7 +2,6 @@
 '''
 parse a MAVLink protocol XML file and generate a Ardupilot LUA mavlink module
 '''
-from builtins import range
 
 import os
 

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -5,7 +5,6 @@ parse a MAVLink protocol XML file and generate a python implementation
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 """
-from builtins import range
 
 import os
 import sys

--- a/generator/mavgen_spin2.py
+++ b/generator/mavgen_spin2.py
@@ -10,9 +10,7 @@ parse a MAVLink protocol XML file and generate a SPIN2 implementation
 Copyright Riley August 2025
 Released under GNU GPL version 3 or later
 """
-from __future__ import print_function
 
-from builtins import range
 
 import os
 import sys

--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -17,7 +17,6 @@ After doing this, Wireshark should be able to show details of MAVLink packets.
 Copyright Holger Steinhaus 2012
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
 
 import os
 from math import ceil

--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -5,8 +5,6 @@ mavlink python parse functions
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
-from builtins import object
 
 import errno
 import operator

--- a/generator/mavtemplate.py
+++ b/generator/mavtemplate.py
@@ -6,7 +6,6 @@ Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
 
-from builtins import object
 
 from .mavparse import MAVParseError
 

--- a/mavextra.py
+++ b/mavextra.py
@@ -5,8 +5,6 @@ useful extra functions for use by mavlink clients
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from __future__ import absolute_import
-from builtins import object
 from builtins import sum as builtin_sum
 
 from math import *

--- a/mavtestgen.py
+++ b/mavtestgen.py
@@ -5,7 +5,6 @@ generate a MAVLink test suite
 Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
-from builtins import range
 
 import sys
 from argparse import ArgumentParser

--- a/mavutil.py
+++ b/mavutil.py
@@ -5,7 +5,6 @@ mavlink python utility functions
 Copyright Andrew Tridgell 2011-2019
 Released under GNU LGPL version 3 or later
 '''
-from builtins import object
 
 import socket, math, struct, time, os, fnmatch, array, sys, errno
 import select

--- a/mavwp.py
+++ b/mavwp.py
@@ -4,8 +4,6 @@ module for loading/saving waypoints
 Copyright the ArduPilot Project
 Released under GNU LGPL version 3 or later
 '''
-from builtins import range
-from builtins import object
 
 import time, copy
 import logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 
-requires = [ "cython", "future", "setuptools>=42" ]
+requires = [ "cython", "setuptools>=42" ]
 
 [tool.ruff]
 lint.extend-ignore = [ "E4", "E7", "F40", "F523", "F601", "F811", "F841" ]

--- a/quaternion.py
+++ b/quaternion.py
@@ -5,9 +5,7 @@
 Quaternion implementation for use in pymavlink
 """
 
-from __future__ import absolute_import, division
 
-from builtins import object
 import numpy as np
 from .rotmat import Vector3, Matrix3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-lxml>=3.6.0
-future>=0.15.2
-wheel>=0.37.1
-setuptools>=42
 fastcrc
+lxml>=3.6.0
+setuptools>=42
+wheel>=0.37.1
 
 # dev dependencies:
 pytest<=7.4.4

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import
 from setuptools.command.build_py import build_py
-from io import open
 # Work around mbcs bug in distutils.
 # http://bugs.python.org/issue10945
 import codecs
@@ -192,7 +190,6 @@ setup (name = 'pymavlink',
                    'tools/magfit_WMM.py',
        ],
        install_requires=[
-            'future',
             'lxml',
        ],
        ext_modules=ext_modules,

--- a/test_generator.sh
+++ b/test_generator.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-# This requires the python future library
-# On MS windows, cygwin usually does not provide that.
-# The workaround is then to issue on a cygwin prompt:
-#   easy_install-2.7 pip
-#   pip install future
-
 set -e
 set -x
 
@@ -20,7 +14,8 @@ tools/mavgen.py --lang C++11 $MDEF/v1.0/all.xml -o generator/CPP11/include_v2.0 
 pushd generator/C/test/posix
 make clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega
 
-# these test tools emit the test packet as hexadecimal and human-readable, other tools consume it as a cross-reference, we ignore the hex here.
+# these test tools emit the test packet as hexadecimal and human-readable,
+# other tools consume it as a cross-reference, we ignore the hex here.
 ./testmav1.0_ardupilotmega | egrep -v '(^fe|^fd)'
 ./testmav2.0_ardupilotmega | egrep -v '(^fe|^fd)'
 popd

--- a/tests/test_quaternion.py
+++ b/tests/test_quaternion.py
@@ -5,7 +5,6 @@
 Unit tests for the quaternion library
 """
 
-from __future__ import absolute_import, division
 import unittest
 import numpy as np
 from pymavlink.quaternion import QuaternionBase, Quaternion

--- a/tests/test_rotmat.py
+++ b/tests/test_rotmat.py
@@ -5,7 +5,6 @@
 Unit tests for the rotmat library
 """
 
-from __future__ import absolute_import
 from math import radians, degrees
 import unittest
 import random

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -5,7 +5,6 @@
 test for trimming under Python 3
 """
 
-from __future__ import absolute_import
 import unittest
 import os
 import pkg_resources

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -4,7 +4,6 @@
 regression tests for mavwp.py
 """
 
-from __future__ import absolute_import
 import unittest
 import os
 import pkg_resources

--- a/tools/magfit.py
+++ b/tools/magfit.py
@@ -3,7 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from builtins import range
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/magfit_compassmot.py
+++ b/tools/magfit_compassmot.py
@@ -3,7 +3,6 @@
 '''
 estimate COMPASS_MOT_* parameters for throttle based compensation
 '''
-from builtins import range
 import math
 
 from argparse import ArgumentParser

--- a/tools/magfit_delta.py
+++ b/tools/magfit_delta.py
@@ -4,7 +4,6 @@
 fit best estimate of magnetometer offsets using the algorithm from
 Bill Premerlani
 '''
-from builtins import range
 
 import sys
 

--- a/tools/magfit_gps.py
+++ b/tools/magfit_gps.py
@@ -3,7 +3,6 @@
 '''
 fit best estimate of magnetometer offsets
 '''
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/magfit_motors.py
+++ b/tools/magfit_motors.py
@@ -3,7 +3,6 @@
 '''
 fit best estimate of magnetometer offsets, trying to take into account motor interference
 '''
-from builtins import range
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/magfit_rotation_gps.py
+++ b/tools/magfit_rotation_gps.py
@@ -3,8 +3,6 @@
 '''
 fit best estimate of magnetometer rotation to GPS data
 '''
-from builtins import range
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/magfit_rotation_gyro.py
+++ b/tools/magfit_rotation_gyro.py
@@ -3,8 +3,6 @@
 '''
 fit best estimate of magnetometer rotation to gyro data
 '''
-from builtins import range
-from builtins import object
 
 from argparse import ArgumentParser
 parser = ArgumentParser(description=__doc__)

--- a/tools/mavgps_CEP.py
+++ b/tools/mavgps_CEP.py
@@ -5,7 +5,6 @@ calculate GPS CEP from DF or mavlink log for all present GPS modules
 
 This assumes the GPS modules were not moving during the test
 '''
-from builtins import range
 
 import os
 

--- a/tools/mavgpslag.py
+++ b/tools/mavgpslag.py
@@ -14,7 +14,6 @@ The code really only works when there is significant acceleration as well.
 You'll need to fly quite aggressively on a copter to get a result.
 
 '''
-from builtins import range
 
 import os
 

--- a/tools/mavgraph.py
+++ b/tools/mavgraph.py
@@ -3,8 +3,6 @@
 graph a MAVLink log file
 Andrew Tridgell August 2011
 '''
-from builtins import input
-from builtins import range
 
 import datetime
 import matplotlib

--- a/tools/mavkml.py
+++ b/tools/mavkml.py
@@ -4,7 +4,6 @@
 simple kml export for logfiles
 Thomas Gubler <thomasgubler@gmail.com>
 '''
-from builtins import range
 
 from argparse import ArgumentParser
 import simplekml

--- a/tools/mavplayback.py
+++ b/tools/mavplayback.py
@@ -6,11 +6,6 @@ realtime mavlink stream
 
 Useful for visualising flights
 '''
-from future import standard_library
-standard_library.install_aliases()
-
-from builtins import object
-
 import os
 import sys
 import time

--- a/tools/mavsummarize.py
+++ b/tools/mavsummarize.py
@@ -3,7 +3,6 @@
 '''
 Summarize MAVLink logs. Useful for identifying which log is of interest in a large set.
 '''
-from builtins import object
 
 import glob
 import time

--- a/tools/mavtelemetry_datarates.py
+++ b/tools/mavtelemetry_datarates.py
@@ -9,10 +9,6 @@ Copyright IAV GmbH 2017
 Released under GNU GPL version 3 or later
 '''
 
-from future import standard_library
-standard_library.install_aliases()
-from builtins import str
-
 ## Generate window for calculating the datasize
 from tkinter import Tk, Text, TOP, BOTH, X, Y, N, LEFT,RIGHT, CENTER, RIDGE, VERTICAL, END, IntVar, IntVar, Scrollbar
 from tkinter.ttk import Frame, Label, Entry, Combobox, Checkbutton

--- a/tools/mavtomfile.py
+++ b/tools/mavtomfile.py
@@ -3,7 +3,6 @@
 '''
 convert a MAVLink tlog file to a MATLab mfile
 '''
-from builtins import range
 
 import os
 import re


### PR DESCRIPTION
Related to
* #120
* #976

Completes
* #1000
* #1003
* #1048
> ### the future is here

https://python-future.org/whatsnew.html
> The new version number of 1.0.0 indicates that the `python-future` project, like Python 2, is now done.

Start with `ruff rule UP010` [unnecessary-future-import](https://docs.astral.sh/ruff/rules/unnecessary-future-import) and `ruff rule UP029` [unnecessary-builtin-import](https://docs.astral.sh/ruff/rules/unnecessary-builtin-import).

% `ruff check --select=UP --statistics`
```
641	UP031	[ ] printf-string-formatting
 57	UP004	[*] useless-object-inheritance
 48	UP029	[ ] unnecessary-builtin-import  # <-- This pull request
 48	UP032	[*] f-string
 27	UP008	[ ] super-call-with-parameters
 21	UP024	[*] os-error-alias
 18	UP030	[ ] format-literals
 13	UP006	[ ] non-pep585-annotation
 13	UP015	[*] redundant-open-modes
  8	UP010	[*] unnecessary-future-import  # <-- This pull request
  5	UP035	[ ] deprecated-import
  3	UP018	[*] native-literals
  2	UP009	[*] utf8-encoding-declaration
  2	UP039	[*] unnecessary-class-parentheses
  1	UP020	[*] open-alias
  1	UP021	[*] replace-universal-newlines
  1	UP022	[ ] replace-stdout-stderr
Found 909 errors.
[*] 156 fixable with the `--fix` option (530 hidden fixes can be enabled with the `--unsafe-fixes` option).
```
1. `ruff check --select=UP010 --fix  # from __future__ import ...`
2. `ruff check --select=UP029 --fix --unsafe-fixes  # from builtins import ...`
3. `git grep future ` # Remove instances related to the python-future dependency.

### How was this tested?
localhost:
```bash
source .venv/bin/activate
python -m pytest  # 1 failed, 50 passed, 8 skipped, 1 warning in 16.02s -- tests/test_mavftp.py OSError: Address already in use
python -m pip uninstall future
python -m pytest  # 1 failed, 50 passed, 8 skipped, 1 warning in 16.02s -- tests/test_mavftp.py OSError: Address already in use
```
___What other testing approaches should be considered?___