### PR TITLE
Remove miscellaneous Python 2 anachronisms

### DIFF
--- a/mavftp.py
+++ b/mavftp.py
@@ -1238,7 +1238,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
         count = 0
         pad_byte = 0
-        last_name = bytes()
+        last_name = b''
         while True:
             while len(data) > 0 and data[0] == pad_byte:
                 data = data[1:]  # skip pad bytes

--- a/mavutil.py
+++ b/mavutil.py
@@ -937,7 +937,7 @@ def set_close_on_exec(fd):
     except Exception:
         pass
 
-class FakeSerial():
+class FakeSerial:
     def __init__(self):
         pass
     def read(self, len):

--- a/tests/snapshottests/test_wlua.py
+++ b/tests/snapshottests/test_wlua.py
@@ -88,7 +88,7 @@ def test_wlua(request, tmp_path, snapshot, mdef, pcap):
         env=env,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-        universal_newlines=True,
+        text=True,
         check=False,
     )
     # note that, with text output, tshark truncates hex dump lines at 80-ish or 100-ish characters.

--- a/tools/mavfft_isb.py
+++ b/tools/mavfft_isb.py
@@ -72,7 +72,7 @@ class PlotData(object):
     def __str__(self):
         return "%s[%u]" % (self.prefix(), self.instance)
 
-class mavfft_fttd():
+class mavfft_fttd:
     '''display fft for raw ACC data in logfile'''
     def __init__(self, cond=None, scale='db', win='hanning', overlap=False, output='psd', ntch_param=False, peak=0, axis='XYZ', fmax=None):
         self.condition = cond # Select packets by condition

--- a/tools/mavftpdecode.py
+++ b/tools/mavftpdecode.py
@@ -30,7 +30,7 @@ class Transfer(object):
 
     def extract(self):
         self.blocks.sort(key = lambda x: x.offset)
-        data = bytes()
+        data = b""
         for b in self.blocks:
             if b.offset != len(data):
                 print("gap at %u" % len(data))
@@ -61,7 +61,7 @@ def param_decode(data):
     params = []
 
     pad_byte = 0
-    last_name = bytes()
+    last_name = b""
     ret = []
 
     while True:

--- a/tools/python_array_test_recv.py
+++ b/tools/python_array_test_recv.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 from pymavlink import mavutil
 

--- a/tools/python_array_test_send.py
+++ b/tools/python_array_test_send.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 
 import time
 from pymavlink import mavutil


### PR DESCRIPTION
% `ruff check --select=UP009,UP018,UP021,UP039 --output-format=concise`
```
mavftp.py:1241:21: UP018 [*] Unnecessary `bytes` call (rewrite as a literal)
mavutil.py:940:17: UP039 [*] Unnecessary parentheses after class definition
tests/snapshottests/test_wlua.py:91:9: UP021 [*] `universal_newlines` is deprecated, use `text`
tools/mavfft_isb.py:75:18: UP039 [*] Unnecessary parentheses after class definition
tools/mavftpdecode.py:33:16: UP018 [*] Unnecessary `bytes` call (rewrite as a literal)
tools/mavftpdecode.py:64:17: UP018 [*] Unnecessary `bytes` call (rewrite as a literal)
tools/python_array_test_recv.py:2:1: UP009 [*] UTF-8 encoding declaration is unnecessary
tools/python_array_test_send.py:2:1: UP009 [*] UTF-8 encoding declaration is unnecessary
Found 8 errors.
[*] 8 fixable with the `--fix` option.`
```
### How was this tested?
localhost:
```bash
source .venv/bin/activate
python -m pytest  # 1 failed, 50 passed, 8 skipped, 1 warning in 16.02s -- tests/test_mavftp.py OSError: Address already in use
```
___What other testing approaches should be considered?___
___What is our minimal supported Python? Python 3.7?___

---
% `ruff rule UP021`
# replace-universal-newlines (UP021)

Derived from the **pyupgrade** linter.

Fix is always available.

## What it does
Checks for uses of `subprocess.run` that set the `universal_newlines`
keyword argument.

## Why is this bad?
As of Python 3.7, the `universal_newlines` keyword argument has been
renamed to `text`, and now exists for backwards compatibility. The
`universal_newlines` keyword argument may be removed in a future version of
Python. Prefer `text`, which is more explicit and readable.

## Example
```python
import subprocess

subprocess.run(["foo"], universal_newlines=True)
```

Use instead:
```python
import subprocess

subprocess.run(["foo"], text=True)
```

## References
- [Python 3.7 release notes](https://docs.python.org/3/whatsnew/3.7.html#subprocess)
- [Python documentation: `subprocess.run`](https://docs.python.org/3/library/subprocess.html#subprocess.run)
