### PR TITLE
Robust parsing returns BAD_DATA up to the next magic byte

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -857,7 +857,10 @@ class MAVLink(object):
             magic = self.buf[self.buf_index]
             self.buf_index += 1
             if self.robust_parsing:
-                m = MAVLink_bad_data(bytearray([magic]), "Bad prefix")
+                invalid_prefix_start = self.buf_index - 1
+                while self.buf_len() >= 1 and self.buf[self.buf_index] != PROTOCOL_MARKER_V1 and self.buf[self.buf_index] != PROTOCOL_MARKER_V2:
+                    self.buf_index += 1
+                m = MAVLink_bad_data(self.buf[invalid_prefix_start : self.buf_index], "Bad prefix")
                 self.expected_length = header_len + 2
                 self.total_receive_errors += 1
                 return m


### PR DESCRIPTION
This PR updates the robust parsing mode of the Python MAVLink parser such that when it encounters garbage between the end of the previous message and the next MAVLink magic byte, it returns a single `MAVLink_bad_data` instance containing the entire garbage section instead of returning it byte-by-byte. This improves the performance of the parser significantly when the stream being parsed contains either a mixture of MAVLink and non-MAVLink messages, or when it contains lots of garbage data. A possible example is MAVLink-over-UDP when the underlying serial-to-UDP module is not aware of MAVLink's internal structure and may break MAVLink packets into multiple UDP packets. The loss of a UDP packet may then leave MAVLink packet fragments in the stream being parsed.

In a captured stream of MAVLink packets from ~1000 drones over UDP, this change improves the speed of the parser from ~95K packets per second to ~107K packets per second (BAD_DATA instances are not counted). It is not likely to have any significant effect on streams that consist of MAVLink packets only without additional noise.