### PR TITLE
mavutil: dump both in-link (from timestamp bits) and out-link (if sig…

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2718,7 +2718,20 @@ def dump_message_verbose(f, m):
         timestamp = "%s.%02u: " % (
             time.strftime("%Y-%m-%d %H:%M:%S", time.localtime(timestamp)),
             int(timestamp*100.0)%100)
-    f.write("%s%s (id=%u) (link=%s) (signed=%s) (seq=%u) (src=%u/%u)\n" % (timestamp, m.get_type(), m.get_msgId(), str(m.get_link_id()), str(m.get_signed()), m.get_seq(), m.get_srcSystem(), m.get_srcComponent()))
+    if m.get_signed():
+        signed = f"Yes; out-link={str(m.get_link_id())}"
+    else:
+        signed = "No"
+
+    inbound_link = getattr(m, '_link', None)
+    f.write(
+        f"{timestamp}{m.get_type()} (id={m.get_msgId()}) "
+        f"(seq={m.get_seq()}) "
+        f"(src={m.get_srcSystem()}/{m.get_srcComponent()}) "
+        f"(in-link={inbound_link}) "
+        f"(signed={signed})\n"
+    )
+
     for fieldname in m.get_fieldnames():
 
         # format in those most boring way possible:


### PR DESCRIPTION
…ned)

```
2025-07-21 06:03:18.19: SIMSTATE (id=164) (seq=47) (src=1/1) (in-link=2) (signed=No)
    roll: -0.0014606562908738852rad (-0.08368944078630676deg)
    pitch: -0.2355131208896637rad (-13.493907846932073deg)
    yaw: -0.8118184804916382rad (-46.513772662894425deg)
    xacc: -2.070394992828369m/s/s
    yacc: 0.11628096550703049m/s/s
    zacc: -8.375968933105469m/s/s
    xgyro: -0.0009880589786916971rad/s (-0.056611609389040786deg/s)
    ygyro: -0.046041302382946014rad/s (-2.6379723098284265deg/s)
    zgyro: 0.0010819832095876336rad/s (0.061993071413390194deg/s)
    lat: -35.3388622deg
    lng: 149.1320697deg
```