### PR TITLE
Add --force-pack option for ESP32 and platforms with non-standard alignment

### DIFF
--- a/tools/mavgen.py
+++ b/tools/mavgen.py
@@ -24,6 +24,7 @@ parser.add_argument("--lang", dest="language", choices=mavgen.supportedLanguages
 parser.add_argument("--wire-protocol", choices=[mavparse.PROTOCOL_0_9, mavparse.PROTOCOL_1_0, mavparse.PROTOCOL_2_0], default=mavgen.DEFAULT_WIRE_PROTOCOL, help="MAVLink protocol version. [default: %(default)s]")
 parser.add_argument("--no-validate", action="store_false", dest="validate", default=mavgen.DEFAULT_VALIDATE, help="Do not perform XML validation. Can speed up code generation if XML files are known to be correct.")
 parser.add_argument("--strict-units", action="store_true", dest="strict_units", default=mavgen.DEFAULT_STRICT_UNITS, help="Perform validation of units attributes.")
+parser.add_argument("--force-pack", action="store_true", dest="force_pack", default=False, help="Force struct packing on all messages (useful for platforms with different alignment like ESP32).")
 parser.add_argument("definitions", metavar="XML", nargs="+", help="MAVLink definitions")
 args = parser.parse_args()
 


### PR DESCRIPTION
Add --force-pack option for ESP32 and platforms with non-standard alignment

This adds support for forcing struct packing on all MAVLink messages,
which is necessary for platforms like ESP32 that have different default
struct alignment than x86/ARM platforms.

Problem:
ESP32 can add unexpected padding between struct fields even when the
MAVLink wire protocol layout is perfectly aligned. The existing needs_pack
mechanism only detects misalignment in the wire format itself, but cannot
predict platform-specific struct layout differences.

For example, ATTITUDE message fields are perfectly aligned in wire format:
- time_boot_ms at offset 0 (4-byte aligned)
- roll at offset 4 (4-byte aligned)
- pitch at offset 8 (4-byte aligned)
- etc.

So needs_pack = False. But ESP32 compiler may still add padding due to
platform-specific alignment rules, causing:
- Different struct sizes (28 vs 32 bytes)
- Fields at wrong offsets when using sizeof() in memcpy operations
- Message corruption when parsing received data

The wire-protocol alignment test cannot detect this because it only
checks wire format offsets, not platform-specific compiler behavior.

Solution:
--force-pack allows platforms to override the automatic detection and
force MAVPACKED on all message structures, ensuring identical layout
across platforms regardless of compiler alignment preferences.

Changes:
- Add --force-pack command line option to tools/mavgen.py
- Modify mavgen_c.py to accept opts parameter and check force_pack
- Apply MAVPACKED to all messages when force_pack is enabled
- Use mav_array_memcpy instead of type-specific assignment for safer
  memory handling with packed structures

The mav_array_memcpy change is applied universally (not architecture-specific)
to ensure consistent behavior. The old mav_array_assign_* functions still exist
but are now implemented as macros that call mav_array_memcpy, making this a
backward-compatible improvement that avoids alignment assumptions.

This ensures cross-platform compatibility while maintaining the existing
selective packing behavior for standard platforms.

Fixes struct alignment issues on ESP32 that caused MAVLink message
corruption due to unexpected padding bytes in struct layouts.