### PR TITLE
gitignore: remove generator/C/ from ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ build*
 .nfs*
 share/
 __pycache__
-generator/C/
 generator/CPP11/include_v2.0
 generator/python/
 generator/message_definitions


### PR DESCRIPTION
This PR updates .gitignore so that the generator/C directory is no longer ignored and will be included in the source distribution (sdist).

Currently, files under generator/C are skipped during sdist creation because of the ignore rules, which results in an incomplete source package. This can cause issues when installing from source (e.g. from PyPI or Linux distributions) where the full generator code is required.

With this change, the generator sources will always be shipped as part of the distribution, ensuring consistent and reproducible builds.