### PR TITLE
Fix buffer alignment issues on ESP32 and ARM platforms

### DIFF
--- a/generator/C/include_v2.0/protocol.h
+++ b/generator/C/include_v2.0/protocol.h
@@ -17,6 +17,18 @@
 #define MAVLINK_STACK_BUFFER 0
 #endif
 
+/* aligned buffer macro for platforms that require it */
+#ifndef MAVLINK_ALIGNED_BUF
+  #if defined(__GNUC__) && (defined(__arm__) || defined(__XTENSA__))
+    // ESP32 (Xtensa) and ARM platforms need aligned buffers for float/int access
+    #include <stdalign.h>
+    #define MAVLINK_ALIGNED_BUF(name, size) alignas(4) char name[size]
+  #else
+    // Default: no special alignment needed
+    #define MAVLINK_ALIGNED_BUF(name, size) char name[size]
+  #endif
+#endif
+
 #ifndef MAVLINK_AVOID_GCC_STACK_BUG
 # define MAVLINK_AVOID_GCC_STACK_BUG defined(__GNUC__)
 #endif

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -217,7 +217,7 @@ static inline uint16_t mavlink_msg_${name_lower}_pack(uint8_t system_id, uint8_t
                               ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
-    char buf[MAVLINK_MSG_ID_${name}_LEN];
+    MAVLINK_ALIGNED_BUF(buf, MAVLINK_MSG_ID_${name}_LEN);
 ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
@@ -251,7 +251,7 @@ static inline uint16_t mavlink_msg_${name_lower}_pack_status(uint8_t system_id, 
                               ${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
-    char buf[MAVLINK_MSG_ID_${name}_LEN];
+    MAVLINK_ALIGNED_BUF(buf, MAVLINK_MSG_ID_${name}_LEN);
 ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
@@ -289,7 +289,7 @@ static inline uint16_t mavlink_msg_${name_lower}_pack_chan(uint8_t system_id, ui
                                    ${{arg_fields:${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
-    char buf[MAVLINK_MSG_ID_${name}_LEN];
+    MAVLINK_ALIGNED_BUF(buf, MAVLINK_MSG_ID_${name}_LEN);
 ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});
@@ -361,7 +361,7 @@ ${{arg_fields: * @param ${name} ${units} ${description}
 static inline void mavlink_msg_${name_lower}_send(mavlink_channel_t chan,${{arg_fields: ${array_const}${type} ${array_prefix}${name},}})
 {
 #if MAVLINK_NEED_BYTE_SWAP || !MAVLINK_ALIGNED_FIELDS
-    char buf[MAVLINK_MSG_ID_${name}_LEN];
+    MAVLINK_ALIGNED_BUF(buf, MAVLINK_MSG_ID_${name}_LEN);
 ${{scalar_fields:    _mav_put_${type}(buf, ${wire_offset}, ${putname});
 }}
 ${{array_fields:    _mav_put_${type}_array(buf, ${wire_offset}, ${name}, ${array_length});


### PR DESCRIPTION
## Summary
This PR fixes buffer alignment issues that cause MAVLink message corruption on ESP32 (Xtensa) and ARM platforms.

## Problem
ESP32 and ARM processors require proper memory alignment when accessing multi-byte values (float, int32, etc.) through char buffers. Without proper alignment, these platforms can experience:
- Data corruption when reading/writing values
- Stack corruption leading to incorrect message lengths
- ATTITUDE messages reporting 385 bytes instead of 28 bytes

## Solution
- Added `MAVLINK_ALIGNED_BUF` macro that uses `alignas(4)` for ESP32/ARM platforms
- Updated code generator to use `MAVLINK_ALIGNED_BUF` instead of plain `char[]` arrays
- Included `stdalign.h` when alignment is needed

## Changes
1. **generator/C/include_v2.0/protocol.h**: Added MAVLINK_ALIGNED_BUF macro definition
2. **generator/mavgen_c.py**: Updated all buffer declarations to use the new macro

## Testing
- Tested on ESP32-S3 hardware where the issue was originally observed
- Verified MAVLink messages are now correctly sized and uncorrupted
- No impact on other platforms (macro defaults to plain char[] on non-ARM/ESP32)

## Related Issues
This resolves MAVLink corruption issues observed in ArduPilot on ESP32 platforms.