### PR TITLE
Mavgen JS: Set encoding when opening generated files

### DIFF
--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -1367,7 +1367,7 @@ def generate(basename, xml):
 
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding="utf-8")
     generate_preamble(outf, msgs, filelist, xml[0])
     generate_enums(outf, enums, xml[0])
     generate_message_ids(outf, msgs, xml[0])
@@ -1379,7 +1379,7 @@ def generate(basename, xml):
 
     testfilename = filename.replace('.js','.tests.js')
     print("Generating TESTS %s" % testfilename)
-    outf = open(testfilename, "w")
+    outf = open(testfilename, "w", encoding="utf-8")
     generate_tests_preamble(outf, msgs, filelist, xml[0])
     generate_tests_mavlink_class(outf, msgs, xml[0])
     generate_tests_footer(outf, xml[0])


### PR DESCRIPTION
When trying to use mavgen.py with "JavaScript_NextGen" language, on Windows I was getting the following error:
```
Traceback (most recent call last):
  File "C:\Users\shanc\linkingdrones\mavlink\pymavlink\tools\mavgen.py", line 30, in <module>
    ok = mavgen.mavgen(args, args.definitions)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\shanc\linkingdrones\mavlink\pymavlink\generator\mavgen.py", line 267, in mavgen
    mavgen_javascript.generate(opts.output, xml)
  File "C:\Users\shanc\linkingdrones\mavlink\pymavlink\generator\mavgen_javascript.py", line 1371, in generate
    generate_preamble(outf, msgs, filelist, xml[0])
  File "C:\Users\shanc\linkingdrones\mavlink\pymavlink\generator\mavgen_javascript.py", line 177, in generate_preamble
    t.write(outf, """
  File "C:\Users\shanc\linkingdrones\mavlink\pymavlink\generator\mavtemplate.py", line 132, in write
    file.write(self.substitute(text, subvars=subvars, trim_leading_lf=trim_leading_lf))
  File "C:\Users\shanc\AppData\Local\Programs\Python\Python312\Lib\encodings\cp1252.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeEncodeError: 'charmap' codec can't encode character '\u03a3' in position 2079: character maps to <undefined>
```

It seems that on Windows the opened output file encoding defaults to cp1252 encoding, but mavgen is attempting to output some JS functions containing UTF8 characters, such as this one:
```
function Σ0(x) { return ROTR(2, x) ^ ROTR(13, x) ^ ROTR(22, x); }
```

The fix is to force the encoding of the output JS files to be UTF8.
Checked and seems to work in my local Windows environment, generating valid JS files.