### PR TITLE
Create output dir if it doesn't exist

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -241,6 +241,9 @@ def mavgen(opts, args):
 
     print("Found %u MAVLink message types in %u XML files" % (
         mavparse.total_msgs(xml), len(xml)))
+    
+    # ensure output directory exists
+    os.makedirs(opts.output, exist_ok=True)
 
     # convert language option to lowercase and validate
     opts.language = opts.language.lower()


### PR DESCRIPTION
Some generators do not automatically create the output directory which results in this cryptic error when running `mavgen` for JavaScript, Python and TypeScript.

```
remoteaero% python3 -m pymavlink.tools.mavgen --lang=Python --wire-protocol=2.0 --output=include/v2.0 message_definitions/v1.0/common.xml
Validating message_definitions/v1.0/common.xml
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/remote/Documents/git/pymavlink/tools/mavgen.py", line 30, in <module>
    ok = mavgen.mavgen(args, args.definitions)
  File "/Users/remote/Documents/git/pymavlink/generator/mavgen.py", line 229, in mavgen
    if not mavgen_validate(fname):
  File "/Users/remote/Documents/git/pymavlink/generator/mavgen.py", line 198, in mavgen_validate
    with open(xmlfile, 'r') as f:
FileNotFoundError: [Errno 2] No such file or directory: 'message_definitions/v1.0/common.xml'
```