### PR TITLE
Add missing include

### DIFF
--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -171,6 +171,8 @@ def generate_message_h(directory, m):
 #pragma once
 // MESSAGE ${name} PACKING
 
+#include <stdint.h>
+
 #define MAVLINK_MSG_ID_${name} ${id}
 
 ${MAVPACKED_START}


### PR DESCRIPTION
Messages use types such as uint8_t but those are not defined unless you include cstdint.