### PR TITLE
mavlink_helpers delete the always false condition: 'status->msg_received'

### DIFF
--- a/generator/C/include_v0.9/mavlink_helpers.h
+++ b/generator/C/include_v0.9/mavlink_helpers.h
@@ -262,13 +262,10 @@ the headers.
 		break;
 
 	case MAVLINK_PARSE_STATE_GOT_STX:
-			if (status->msg_received 
 /* Support shorter buffers than the
    default maximum packet size */
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
-				|| c > MAVLINK_MAX_PAYLOAD_LEN
-#endif
-				)
+		if (c > MAVLINK_MAX_PAYLOAD_LEN)
 		{
 			status->buffer_overrun++;
 			status->parse_error++;
@@ -276,6 +273,7 @@ the headers.
 			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
 		}
 		else
+#endif
 		{
 			// NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
 			rxmsg->len = c;

--- a/generator/C/include_v1.0/mavlink_helpers.h
+++ b/generator/C/include_v1.0/mavlink_helpers.h
@@ -304,13 +304,10 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		break;
 
 	case MAVLINK_PARSE_STATE_GOT_STX:
-			if (status->msg_received 
 /* Support shorter buffers than the
    default maximum packet size */
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
-				|| c > MAVLINK_MAX_PAYLOAD_LEN
-#endif
-				)
+		if (c > MAVLINK_MAX_PAYLOAD_LEN)
 		{
 			status->buffer_overrun++;
 			status->parse_error++;
@@ -318,6 +315,7 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
 		}
 		else
+#endif
 		{
 			// NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
 			rxmsg->len = c;

--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -622,13 +622,10 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 		break;
 
 	case MAVLINK_PARSE_STATE_GOT_STX:
-			if (status->msg_received 
 /* Support shorter buffers than the
    default maximum packet size */
 #if (MAVLINK_MAX_PAYLOAD_LEN < 255)
-				|| c > MAVLINK_MAX_PAYLOAD_LEN
-#endif
-				)
+		if (c > MAVLINK_MAX_PAYLOAD_LEN)
 		{
 			status->buffer_overrun++;
 			_mav_parse_error(status);
@@ -636,6 +633,7 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 			status->parse_state = MAVLINK_PARSE_STATE_IDLE;
 		}
 		else
+#endif
 		{
 			// NOT counting STX, LENGTH, SEQ, SYSID, COMPID, MSGID, CRC1 and CRC2
 			rxmsg->len = c;


### PR DESCRIPTION
The variable `status->msg_received` is set to zero at the beginning of function `mavlink_frame_char_buffer()` as below:

`	status->msg_received = MAVLINK_FRAMING_INCOMPLETE;`

So the condition expression ` if (status->msg_received)`  in the following switch case statement is always false,  which could be deleted.