### PR TITLE
Add set_mavlink_version helper to manually select MAVLink version

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -310,22 +310,15 @@ class mavfile(object):
             magic = ord(buf[0])
         except:
             magic = buf[0]
-        if not magic in [ 85, 254, 253 ]:
-            return
-        self.first_byte = False
-        if self.WIRE_PROTOCOL_VERSION == "0.9" and magic == 254:
-            self.WIRE_PROTOCOL_VERSION = "1.0"
-            set_dialect(current_dialect)
-        elif self.WIRE_PROTOCOL_VERSION == "1.0" and magic == 85:
-            self.WIRE_PROTOCOL_VERSION = "0.9"
-            os.environ['MAVLINK09'] = '1'
-            set_dialect(current_dialect)
-        elif self.WIRE_PROTOCOL_VERSION != "2.0" and magic == 253:
-            self.WIRE_PROTOCOL_VERSION = "2.0"
-            os.environ['MAVLINK20'] = '1'
-            set_dialect(current_dialect)
+        if magic == 254:
+            set_mavlink_version(1.0)
+        elif magic == 85:
+            set_mavlink_version(0.9)
+        elif magic == 253:
+            set_mavlink_version(2.0)
         else:
             return
+        self.first_byte = False
         # switch protocol 
         (callback, callback_args, callback_kwargs) = (self.mav.callback,
                                                       self.mav.callback_args,


### PR DESCRIPTION
## Summary
New `set_mavlink_version` function in `mavutil.py` allows users to manually select the MAVLink protocol version to use. This new function is implemented in the `auto_mavlink_version` method of the `mavfile` class.

## Details
- I had issues using `set_dialect` for my custom dialect before receiving any MAVLink message, because by default, it uses MAVLink 1.0 (and my dialect is only for MAVLink 2.0). So I had to understand the source code of mavutil.py, and I thought that a dedicated function might be more user-friendly.
- I created a simple `set_mavlink_version`, which changes the environment variables and set the current dialect after.
- After that, I thought that implementing this in the `auto_mavlink_version` method of the `mavfile` class might be clearer.

## Testing
To be honest, I haven't tested it, but those changes are likely to be correct.

## Compatibility
The syntax `os.environ.pop('MAVLINK20', None)` is compatible with all Python versions supported by pymavlink, as `os.environ` behaves like a standard dictionary and `dict.pop(key, default)` has existed since Python 2.3.