### PR TITLE
Improve error handling in scan_offsets function by replacing panic

### DIFF
--- a/dfindexer/dfindexer.c
+++ b/dfindexer/dfindexer.c
@@ -106,8 +106,7 @@ OffsetArray* scan_offsets(const uint8_t *data, size_t len,
                 if (len - i >= 528 || len < 528) {
                     fprintf(stderr, "Invalid length in FMT message at %zu\n", i);
                 }
-                i++;
-                continue;
+                break;
             }
             lengths[type_in_fmt] = len_in_fmt;
         }
@@ -117,8 +116,7 @@ OffsetArray* scan_offsets(const uint8_t *data, size_t len,
             if (len - i >= 528 || len < 528) {
                 fprintf(stderr, "unknown msg type 0x%02x (%u) at %zu\n", mtype, mtype, i);
             }
-            i++;
-            continue;
+            break;
         }
 
         OffsetArray *arr = &results[mtype];


### PR DESCRIPTION
Hi

Its my first contribution here :)

I have an app that run on multiple bin files and I've noticed that when one of the files is corrupted the app exits with 

```
bad header 0x2211 at 18054
bad header 0x1118 at 18055
bad header 0x186c at 18056
bad header 0x6ced at 18057
bad header 0xed50 at 18058
bad header 0x50a3 at 18059
Invalid length in FMT message at 18060
```

What I've noticed it that the C code dfinex.c is exitsing when it has issue with the header or format
But when I am using "PYMAVLINK_FAST_INDEX=0" and using the python code the behavior is changed and it only print message -

`DFFormat: Unsupported format char: '' in message M\xa4
`
 
So I've changed the code to print only
Let me know if thats OK or you would want to see something else