### PR TITLE
mavgen_lua.py: Emit message entry metadata

### DIFF
--- a/generator/mavgen_lua.py
+++ b/generator/mavgen_lua.py
@@ -196,12 +196,15 @@ function mavlink_msgs.decode(message, msg_map)
   return result
 end
 
----Encode the payload section of a given message
+---Encode the payload section of a given message and return metadata
 ---@param msgname string -- name of message to encode
 ---@param message table -- table containing key value pairs representing the data fields in the message
 ---@return integer -- message id
 ---@return string -- encoded payload
-function mavlink_msgs.encode(msgname, message)
+---@return integer -- min message length
+---@return integer -- max message length
+---@return integer -- crc extra byte
+function mavlink_msgs.encode_full(msgname, message)
   local message_map = require("{module_root_rel}mavlink_msg_" .. msgname)
   if not message_map then
     -- we don't know how to encode this message, bail on it
@@ -227,7 +230,21 @@ function mavlink_msgs.encode(msgname, message)
       packedIndex = packedIndex + 1
     end
   end
-  return message_map.id, string.pack(packString, table.unpack(packedTable))
+  return message_map.id,
+         string.pack(packString, table.unpack(packedTable)),
+         message_map.min_msg_len,
+         message_map.max_msg_len,
+         message_map.crc_extra
+end
+
+---Encode the payload section of a given message
+---@param msgname string -- name of message to encode
+---@param message table -- table containing key value pairs representing the data fields in the message
+---@return integer -- message id
+---@return string -- encoded payload
+function mavlink_msgs.encode(msgname, message)
+  local message_id, encoded_message, _, _, _ = mavlink_msgs.encode_full(msgname, message)
+  return message_id, encoded_message
 end
 
 return mavlink_msgs


### PR DESCRIPTION
Adds `min_msg_len`, `max_msg_len`, `flags`, `target_system_ofs` and `target_component_ofs` to emitted message files for Lua.

Allows constructing the full `mavlink_msg_entry_t` struct within ArduPilot to enable sending messages from Lua that are not known at ArduPilot compile time.

Additionally adds an `encode_full` function to return this additional metadata and refactors the existing `encode` function as a wrapper of this.

I don't know Lua so would appreciate any feedback if there is a better way to pack up the multiple returns / wrap a function.

Diffs of generated files for `minimal.xml`:

```diff
diff --git a/mavlink_orig/modules/mavlink_msg_HEARTBEAT.lua b/mavlink/modules/mavlink_msg_HEARTBEAT.lua
index 2e89c2c8..bd8fe7b3 100644
--- a/mavlink_orig/modules/mavlink_msg_HEARTBEAT.lua
+++ b/mavlink/modules/mavlink_msg_HEARTBEAT.lua
@@ -1,6 +1,11 @@
 local HEARTBEAT = {}
 HEARTBEAT.id = 0
 HEARTBEAT.crc_extra = 50
+HEARTBEAT.min_msg_len = 9
+HEARTBEAT.max_msg_len = 9
+HEARTBEAT.flags = 0
+HEARTBEAT.target_system_ofs = 0
+HEARTBEAT.target_component_ofs = 0
 HEARTBEAT.fields = {
              { "custom_mode", "<I4" },
              { "type", "<B" },
```

```diff
diff --git a/mavlink_orig/modules/mavlink_msgs.lua b/mavlink/modules/mavlink_msgs.lua
index 321d8509..1df1708c 100644
--- a/mavlink_orig/modules/mavlink_msgs.lua
+++ b/mavlink/modules/mavlink_msgs.lua
@@ -124,12 +124,15 @@ function mavlink_msgs.decode(message, msg_map)
   return result
 end
 
----Encode the payload section of a given message
+---Encode the payload section of a given message and return metadata
 ---@param msgname string -- name of message to encode
 ---@param message table -- table containing key value pairs representing the data fields in the message
 ---@return integer -- message id
 ---@return string -- encoded payload
-function mavlink_msgs.encode(msgname, message)
+---@return integer -- min message length
+---@return integer -- max message length
+---@return integer -- crc extra byte
+function mavlink_msgs.encode_full(msgname, message)
   local message_map = require("mavlink_msg_" .. msgname)
   if not message_map then
     -- we don't know how to encode this message, bail on it
@@ -155,7 +158,21 @@ function mavlink_msgs.encode(msgname, message)
       packedIndex = packedIndex + 1
     end
   end
-  return message_map.id, string.pack(packString, table.unpack(packedTable))
+  return message_map.id,
+         string.pack(packString, table.unpack(packedTable)),
+         message_map.min_msg_len,
+         message_map.max_msg_len,
+         message_map.crc_extra
+end
+
+---Encode the payload section of a given message
+---@param msgname string -- name of message to encode
+---@param message table -- table containing key value pairs representing the data fields in the message
+---@return integer -- message id
+---@return string -- encoded payload
+function mavlink_msgs.encode(msgname, message)
+  local message_id, encoded_message, _, _, _ = mavlink_msgs.encode_full(msgname, message)
+  return message_id, encoded_message
 end
 
 return mavlink_msgs
```