### PR TITLE
tests: use importlib in place of pkg_resources

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -221,6 +221,8 @@ setup (name = 'pymavlink',
        install_requires=[
             'lxml',
             'fastcrc',
+            # importlib.resources.files() requires Python 3.9+; use backport for older versions
+            'importlib_resources; python_version < "3.9"',
        ],
        ext_modules=ext_modules,
        cmdclass={'build_py': custom_build_py},

--- a/tests/test_mavlogdump.py
+++ b/tests/test_mavlogdump.py
@@ -6,7 +6,11 @@ regression tests for mavlogdump.py
 """
 import unittest
 import os
-import pkg_resources
+try:
+    from importlib.resources import files as importlib_files
+except ImportError:
+    # importlib.resources.files() requires Python 3.9+; use backport for older versions
+    from importlib_resources import files as importlib_files
 import sys
 
 class MAVLogDumpTest(unittest.TestCase):
@@ -22,8 +26,7 @@ class MAVLogDumpTest(unittest.TestCase):
     def test_dump_same(self):
         """Test dump of file is what we expect"""
         test_filename = "test.BIN"
-        test_filepath = pkg_resources.resource_filename(__name__,
-                                                        test_filename)
+        test_filepath = importlib_files(__spec__.parent).joinpath(test_filename)
         dump_filename = "tmp.dump"
         os.system("mavlogdump.py %s >%s" % (test_filepath, dump_filename))
         with open(dump_filename) as f:
@@ -33,8 +36,7 @@ class MAVLogDumpTest(unittest.TestCase):
                      "test.BIN.dumped"]
         success = False
         for expected in possibles:
-            expected_filepath = pkg_resources.resource_filename(__name__,
-                                                                expected)
+            expected_filepath = importlib_files(__spec__.parent).joinpath(expected)
             with open(expected_filepath) as e:
                 expected = e.read()
 

--- a/tests/test_mavxml.py
+++ b/tests/test_mavxml.py
@@ -4,7 +4,11 @@ Module to test MAVXML
 """
 
 import unittest
-import pkg_resources
+try:
+    from importlib.resources import files as importlib_files
+except ImportError:
+    # importlib.resources.files() requires Python 3.9+; use backport for older versions
+    from importlib_resources import files as importlib_files
 
 from pymavlink.generator.mavparse import MAVXML
 from pymavlink.generator.mavparse import MAVParseError
@@ -17,15 +21,13 @@ class MAVXMLTest(unittest.TestCase):
     def test_fields_number(self):
         """Test that a message can have at most 64 fields"""
         test_filename = "64-fields.xml"
-        test_filepath = pkg_resources.resource_filename(__name__,
-                                                        test_filename)
+        test_filepath = importlib_files(__spec__.parent).joinpath(test_filename)
         xml = MAVXML(test_filepath)
         count = len(xml.message[0].fields)
         self.assertEqual(count, 64)
 
         test_filename = "65-fields.xml"
-        test_filepath = pkg_resources.resource_filename(__name__,
-                                                        test_filename)
+        test_filepath = importlib_files(__spec__.parent).joinpath(test_filename)
         with self.assertRaises(MAVParseError):
             _ = MAVXML(test_filepath)
 

--- a/tests/test_trim.py
+++ b/tests/test_trim.py
@@ -7,7 +7,6 @@ test for trimming under Python 3
 
 import unittest
 import os
-import pkg_resources
 import sys
 from pymavlink import mavutil
 

--- a/tests/test_wp.py
+++ b/tests/test_wp.py
@@ -6,7 +6,11 @@ regression tests for mavwp.py
 
 import unittest
 import os
-import pkg_resources
+try:
+    from importlib.resources import files as importlib_files
+except ImportError:
+    # importlib.resources.files() requires Python 3.9+; use backport for older versions
+    from importlib_resources import files as importlib_files
 import sys
 
 os.environ["MAVLINK20"] = "1"
@@ -213,13 +217,13 @@ class RallyTest(unittest.TestCase):
         self.assertTrue(loader.is_location_command(mavutil.mavlink.MAV_CMD_NAV_RALLY_POINT))
 
         # test loading a QGC WPL 110 file:
-        rally_filepath = pkg_resources.resource_filename(__name__, "rally-110.txt")
+        rally_filepath = importlib_files(__spec__.parent).joinpath("rally-110.txt")
         loader.load(rally_filepath)
         self.assertEqual(loader.count(), 2)
         self.assertEqual(loader.wp(0).command, mavutil.mavlink.MAV_CMD_NAV_RALLY_POINT)
 
         # test loading tradition "RALLY" style format:
-        rally_filepath = pkg_resources.resource_filename(__name__, "rally.txt")
+        rally_filepath = importlib_files(__spec__.parent).joinpath("rally.txt")
         loader.load(rally_filepath)
         self.assertEqual(loader.count(), 2)
         self.assertEqual(loader.wp(0).command, mavutil.mavlink.MAV_CMD_NAV_RALLY_POINT)
@@ -233,15 +237,13 @@ class FenceTest(unittest.TestCase):
         self.assertTrue(loader.is_location_command(mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_EXCLUSION))
 
         # test loading a QGC WPL 110 file:
-        fence_filepath = pkg_resources.resource_filename(__name__,
-                                                         "fence-110.txt")
+        fence_filepath = importlib_files(__spec__.parent).joinpath("fence-110.txt")
         loader.load(fence_filepath)
         self.assertEqual(loader.count(), 10)
         self.assertEqual(loader.wp(3).command, mavutil.mavlink.MAV_CMD_NAV_FENCE_POLYGON_VERTEX_INCLUSION)
 
         # test loading tradition lat/lng-pair style format:
-        fence_filepath = pkg_resources.resource_filename(__name__,
-                                                         "fence.txt")
+        fence_filepath = importlib_files(__spec__.parent).joinpath("fence.txt")
         loader.load(fence_filepath)
         # there are 6 lines in the file - one return point, four fence
         # points and a "fence closing point".  We don't store the


### PR DESCRIPTION
CI is currently failing on 3.12 and 3.x:


```
______________________ ERROR collecting tests/test_wp.py _______________________
ImportError while importing test module '/home/runner/work/pymavlink/pymavlink/tests/test_wp.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.12.12/x64/lib/python3.12/importlib/__init__.py:90: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
tests/test_wp.py:9: in <module>
    import pkg_resources
E   ModuleNotFoundError: No module named 'pkg_resources'
```

... we knew this was coming...
