### PR TITLE
CI: add python 3.14 wheels to build

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -41,13 +41,13 @@ jobs:
                   ("windows", "windows-latest", "auto64 auto32"),
                   ("windows-arm", "windows-11-arm", "auto"),
               ]
-              py_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+              py_versions = ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
           else:
               machines = [
                   ("linux", "ubuntu-latest", "native"),
                   ("windows", "windows-latest", "native"),
               ]
-              py_versions = ["3.8", "3.13"] # Chosing the two most likely to break in PRs
+              py_versions = ["3.8", "3.14"] # Chosing the two most likely to break in PRs
 
           matrix = {"include": []}
           for (name, runner, cibw_archs) in machines:


### PR DESCRIPTION
The dependabot PR was a good reminder for me to look into whether I should bump the max python version:

Building just the 3.14 wheels for all systems on my fork works:
https://github.com/robertlong13/pymavlink/actions/runs/23240088189