### PR TITLE
generator/CPP11: Define message::LENGTH and ::MIN_LENGTH as uint8_t

### DIFF
--- a/generator/CPP11/include_v2.0/message.hpp
+++ b/generator/CPP11/include_v2.0/message.hpp
@@ -44,15 +44,15 @@ using msgid_t = uint32_t;
  */
 struct Message {
 	static constexpr msgid_t MSG_ID = UINT32_MAX;
-	static constexpr size_t LENGTH = 0;
-	static constexpr size_t MIN_LENGTH = 0;
+	static constexpr uint8_t LENGTH = 0;
+	static constexpr uint8_t MIN_LENGTH = 0;
 	static constexpr uint8_t CRC_EXTRA = 0;
 	static constexpr auto NAME = "BASE";
 
 	struct Info {
 		msgid_t id;
-		size_t length;
-		size_t min_length;
+		uint8_t length;
+		uint8_t min_length;
 		uint8_t crc_extra;
 	};
 

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -130,8 +130,8 @@ namespace msg {
  */
 struct ${name} : mavlink::Message {
     static constexpr msgid_t MSG_ID = ${id};
-    static constexpr size_t LENGTH = ${wire_length};
-    static constexpr size_t MIN_LENGTH = ${wire_min_length};
+    static constexpr uint8_t LENGTH = ${wire_length};
+    static constexpr uint8_t MIN_LENGTH = ${wire_min_length};
     static constexpr uint8_t CRC_EXTRA = ${crc_extra};
     static constexpr auto NAME = "${name}";
 


### PR DESCRIPTION
The mavlink wire format only allows payloads up to 255 bytes and no message has LENGTH or MIN_LENGTH set to a valuer greater than 255.  The mavlink_finalize_message*() family of functions to serialize a message expect the arguments `uint8_t min_length` and `uint8_t length`.  A developers  might be unsure why they're passing two size_t values to a function expecting uint8_ts and whether they need to manually check handle cases where truncation might occur.

With this change the types communicate no concern is needed.

Fixes #1181

I did not test this change.

Note: If you're concerned about future longer messages in the future where this change would create an overflow: C++11 added [list initializations](https://en.cppreference.com/w/cpp/language/list_initialization.html), which can be used to create compile errors, if the compile-time assigned value is larger than fits in the target type:
```
    static constexpr uint8_t LENGTH{256}; // this would not compile
```
The generator could be changed to use that instead of 
```
    static constexpr uint8_t LENGTH = 256; 
```