### PR TITLE
Fix: specify UTF-8 encoding when opening XML files in mavgen

### DIFF
--- a/generator/mavgen.py
+++ b/generator/mavgen.py
@@ -56,7 +56,7 @@ def mavgen(opts, args):
     if opts.validate:
         try:
             from lxml import etree
-            with open(schemaFile, 'r') as f:
+            with open(schemaFile, 'r', encoding='utf-8') as f:
                 xmlschema_root = etree.parse(f)
                 if not opts.strict_units:
                     # replace the strict "SI_Unit" list of known unit strings with a more generic "xs:string" type
@@ -195,7 +195,7 @@ def mavgen(opts, args):
            here because it relies on the XML libs that were loaded in mavgen(), so it can't be called standalone"""
         xmlvalid = True
         try:
-            with open(xmlfile, 'r') as f:
+            with open(xmlfile, 'r', encoding='utf-8') as f:
                 xmldocument = etree.parse(f)
                 xmlschema.assertValid(xmldocument)
                 forbidden_names_re = re.compile("^(break$|case$|class$|catch$|const$|continue$|debugger$|default$|delete$|do$|else$|\

--- a/generator/mavgen_ada.py
+++ b/generator/mavgen_ada.py
@@ -344,7 +344,7 @@ def create_dialect_spec (directory, file_prefix, ver, x, xml, header=None):
     print("Generate " + dialect.title())
 
     # Create file
-    spec = open(os.path.join(directory, file_prefix + dialect + ".ads"), "w")
+    spec = open(os.path.join(directory, file_prefix + dialect + ".ads"), "w", encoding='utf-8')
     spec.write(GEN)
     if header: spec.write(header)
     spec.write("pragma Ada_2022;\n\n")
@@ -394,7 +394,7 @@ def create_types_spec (directory, file_prefix, ver, x, header=None):
     dialect = file_name(x)
 
     # Create file
-    spec = open(os.path.join(directory, file_prefix + dialect + "-types.ads"), "w")
+    spec = open(os.path.join(directory, file_prefix + dialect + "-types.ads"), "w", encoding='utf-8')
     spec.write(GEN)
     if header: spec.write(header)
     spec.write("pragma Ada_2022;\n\n")
@@ -405,7 +405,7 @@ def create_types_spec (directory, file_prefix, ver, x, header=None):
 
 # Create file for the message spec
 def create_message_pkg (x, f_name, p_name, ver, m, types_files, header=None):
-    spec = open(f_name + ".ads", "w")
+    spec = open(f_name + ".ads", "w", encoding='utf-8')
     spec.write(GEN)
     if header: spec.write(header)
     if m.deprecated:
@@ -429,7 +429,7 @@ def create_message_pkg (x, f_name, p_name, ver, m, types_files, header=None):
 
 # Create file for the message body
 def create_message_body (f_name, p_name):
-    body = open(f_name + ".adb", "w")
+    body = open(f_name + ".adb", "w", encoding='utf-8')
     body.write(GEN)
     body.write("package body %s is\n" % p_name)
     return body
@@ -837,7 +837,7 @@ def generate_test_project(directory, ver):
     dir = os.path.join(directory, 'tests')
     mavparse.mkdir_p(dir)
 
-    f = open(os.path.join(dir, "test.gpr"), "w")
+    f = open(os.path.join(dir, "test.gpr"), "w", encoding='utf-8')
     f.write("""with "../mavlink_%s.gpr";
 project Test is
 
@@ -865,7 +865,7 @@ def generate_test_v1(directory, xml, bitmasks):
     dir = os.path.join(directory, 'tests')
     generate_test_project(directory, "v1")
 
-    f = open(os.path.join(dir, "test.adb"), "w")
+    f = open(os.path.join(dir, "test.adb"), "w", encoding='utf-8')
     f.write("\npragma Warnings (Off); --  prevent `not used`\n")
     for x in xml:
         f.write("with %s.%s.Types;\n" % (v1, file_name(x).title()))
@@ -1128,7 +1128,7 @@ def generate_test_v2(directory, xml, bitmasks):
     dir = os.path.join(directory, 'tests')
     generate_test_project(directory, "v2")
 
-    f = open(os.path.join(dir, "test.adb"), "w")
+    f = open(os.path.join(dir, "test.adb"), "w", encoding='utf-8')
 
     f.write("\npragma Warnings (Off); --  prevent `not used`\n")
     for x in xml:
@@ -1425,7 +1425,7 @@ def generate_v2(directory, xml):
             for m in c.message:
                 f_name, p_name = get_pakage_name(x, m, directory, v2, "v2")
                 fc_name, pc_name = get_pakage_name(c, m, directory, v2, "v2")
-                spec = open(f_name + ".ads", "w")
+                spec = open(f_name + ".ads", "w", encoding='utf-8')
                 spec.write(GEN)
                 if m.deprecated:
                     spec.write(get_deprecated(m.deprecated, 0))

--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -13,7 +13,7 @@ t = mavtemplate.MAVTemplate()
 
 def generate_version_h(directory, xml):
     '''generate version.h'''
-    f = open(os.path.join(directory, "version.h"), mode='w')
+    f = open(os.path.join(directory, "version.h"), mode='w', encoding='utf-8')
     t.write(f,'''
 /** @file
  *  @brief MAVLink comm protocol built from ${basename}.xml
@@ -34,7 +34,7 @@ def generate_version_h(directory, xml):
 
 def generate_mavlink_h(directory, xml):
     '''generate mavlink.h'''
-    f = open(os.path.join(directory, "mavlink.h"), mode='w')
+    f = open(os.path.join(directory, "mavlink.h"), mode='w', encoding='utf-8')
     t.write(f,'''
 /** @file
  *  @brief MAVLink comm protocol built from ${basename}.xml
@@ -75,7 +75,7 @@ def generate_mavlink_h(directory, xml):
 
 def generate_main_h(directory, xml):
     '''generate main header per XML file'''
-    f = open(os.path.join(directory, xml.basename + ".h"), mode='w')
+    f = open(os.path.join(directory, xml.basename + ".h"), mode='w', encoding='utf-8')
     t.write(f, '''
 /** @file
  *  @brief MAVLink comm protocol generated from ${basename}.xml
@@ -166,7 +166,7 @@ def generate_message_h(directory, m):
         m.MSG_ATTRIBUTE = 'MAVLINK_WIP\n'
     else:
         m.MSG_ATTRIBUTE = ''
-    f = open(os.path.join(directory, 'mavlink_msg_%s.h' % m.name_lower), mode='w')
+    f = open(os.path.join(directory, 'mavlink_msg_%s.h' % m.name_lower), mode='w', encoding='utf-8')
     t.write(f, '''
 #pragma once
 // MESSAGE ${name} PACKING
@@ -464,7 +464,7 @@ ${{ordered_fields:    ${decode_left}mavlink_msg_${name_lower}_get_${name}(msg${d
 
 def generate_testsuite_h(directory, xml):
     '''generate testsuite.h per XML file'''
-    f = open(os.path.join(directory, "testsuite.h"), mode='w')
+    f = open(os.path.join(directory, "testsuite.h"), mode='w', encoding='utf-8')
     t.write(f, '''
 /** @file
  *    @brief MAVLink comm protocol testsuite generated from ${basename}.xml

--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -50,7 +50,7 @@ EType = collections.namedtuple('EType', ('type', 'max'))
 
 def generate_main_hpp(directory, xml):
     '''generate main header per XML file'''
-    f = open(os.path.join(directory, xml.basename + ".hpp"), mode='w')
+    f = open(os.path.join(directory, xml.basename + ".hpp"), mode='w', encoding='utf-8')
     t.write(f, '''
 /** @file
  *  @brief MAVLink comm protocol generated from ${basename}.xml
@@ -113,7 +113,7 @@ ${{include_list:#include "../${base}/${base}.hpp"
 
 def generate_message_hpp(directory, m):
     '''generate per-message header for a XML file'''
-    f = open(os.path.join(directory, 'mavlink_msg_%s.hpp' % m.name_lower), mode='w')
+    f = open(os.path.join(directory, 'mavlink_msg_%s.hpp' % m.name_lower), mode='w', encoding='utf-8')
     t.write(f, '''
 // MESSAGE ${name} support class
 
@@ -185,7 +185,7 @@ ${{ordered_fields:        map >> ${name};${ser_whitespace}// offset: ${wire_offs
 
 def generate_gtestsuite_hpp(directory, xml):
     '''generate gtestsuite.hpp per XML file'''
-    f = open(os.path.join(directory, "gtestsuite.hpp"), mode='w')
+    f = open(os.path.join(directory, "gtestsuite.hpp"), mode='w', encoding='utf-8')
     t.write(f, '''
 /** @file
  *  @brief MAVLink comm testsuite protocol generated from ${basename}.xml

--- a/generator/mavgen_cs.py
+++ b/generator/mavgen_cs.py
@@ -369,7 +369,7 @@ def generate(basename, xml_list):
     if not os.path.exists(directory): 
         os.makedirs(directory) 
 
-    f = open(os.path.join(directory, "mavlink.cs"), mode='w')
+    f = open(os.path.join(directory, "mavlink.cs"), mode='w', encoding='utf-8')
 
     generate_message_header(f, xml_list)
 

--- a/generator/mavgen_java.py
+++ b/generator/mavgen_java.py
@@ -16,7 +16,7 @@ def generate_enums(basename, xml):
     directory = os.path.join(basename, '''enums''')
     mavparse.mkdir_p(directory)
     for en in xml.enum:
-        f = open(os.path.join(directory, en.name+".java"), mode='w')
+        f = open(os.path.join(directory, en.name+".java"), mode='w', encoding='utf-8')
         t.write(f, '''
 /* AUTO-GENERATED FILE.  DO NOT MODIFY.
  *
@@ -54,7 +54,7 @@ def generate_CRC(directory, xml):
     for msgid, crc in sorted(xml.message_crcs.items()):
         xml.message_crcs_array += 'MAVLINK_MESSAGE_CRCS.put(%u, %u);\n        ' % (msgid, crc)
 
-    f = open(os.path.join(directory, "CRC.java"), mode='w')
+    f = open(os.path.join(directory, "CRC.java"), mode='w', encoding='utf-8')
     t.write(f,'''
 /* AUTO-GENERATED FILE.  DO NOT MODIFY.
  *
@@ -140,7 +140,7 @@ public class CRC {
 
 def generate_message_h(directory, m):
     '''generate per-message header for a XML file'''
-    f = open(os.path.join(directory, 'msg_%s.java' % m.name_lower), mode='w')
+    f = open(os.path.join(directory, 'msg_%s.java' % m.name_lower), mode='w', encoding='utf-8')
 
     (path_head, path_tail) = os.path.split(directory)
     if path_tail == "":
@@ -281,7 +281,7 @@ public class msg_${name_lower} extends MAVLinkMessage {
 
 
 def generate_MAVLinkMessage(directory, xml_list):
-    f = open(os.path.join(directory, "MAVLinkPacket.java"), mode='w')
+    f = open(os.path.join(directory, "MAVLinkPacket.java"), mode='w', encoding='utf-8')
 
     imports = []
 

--- a/generator/mavgen_javascript.py
+++ b/generator/mavgen_javascript.py
@@ -1367,7 +1367,7 @@ def generate(basename, xml):
 
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding='utf-8')
     generate_preamble(outf, msgs, filelist, xml[0])
     generate_enums(outf, enums, xml[0])
     generate_message_ids(outf, msgs, xml[0])
@@ -1379,7 +1379,7 @@ def generate(basename, xml):
 
     testfilename = filename.replace('.js','.tests.js')
     print("Generating TESTS %s" % testfilename)
-    outf = open(testfilename, "w")
+    outf = open(testfilename, "w", encoding='utf-8')
     generate_tests_preamble(outf, msgs, filelist, xml[0])
     generate_tests_mavlink_class(outf, msgs, xml[0])
     generate_tests_footer(outf, xml[0])

--- a/generator/mavgen_javascript_stable.py
+++ b/generator/mavgen_javascript_stable.py
@@ -704,7 +704,7 @@ def generate(basename, xml):
             m.order_map[i] = m.ordered_fieldnames.index(m.fieldnames[i])
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding='utf-8')
     generate_preamble(outf, msgs, filelist, xml[0])
     generate_enums(outf, enums, xml[0])
     generate_message_ids(outf, msgs, xml[0])

--- a/generator/mavgen_lua.py
+++ b/generator/mavgen_lua.py
@@ -35,7 +35,7 @@ def generate(basename, xml):
     # create the output directory if needed
     if not os.path.exists(basename):
         os.makedirs(basename)
-    outf = open("%s/mavlink_msgs.lua" % basename, "w")
+    outf = open("%s/mavlink_msgs.lua" % basename, "w", encoding='utf-8')
     if 'modules' not in basename:
         print("ERROR: mavlink_msgs.lua must be generated in the modules directory or subdirectory")
         return
@@ -47,7 +47,7 @@ def generate(basename, xml):
 
     # dump the actual symbol table
     for m in msgs:
-        mavlink_msg_file = open("%s/mavlink_msg_%s.lua" % (basename, m.name), "w")
+        mavlink_msg_file = open("%s/mavlink_msg_%s.lua" % (basename, m.name), "w", encoding='utf-8')
         mavlink_msg_file.write("local %s = {}\n" % m.name)
         mavlink_msg_file.write("%s.id = %u\n" % (m.name, m.id))
         mavlink_msg_file.write("%s.crc_extra = %u\n" % (m.name, m.crc_extra))

--- a/generator/mavgen_objc.py
+++ b/generator/mavgen_objc.py
@@ -12,7 +12,7 @@ t = mavtemplate.MAVTemplate()
 
 def generate_mavlink(directory, xml):
     '''generate MVMavlink header and implementation'''
-    f = open(os.path.join(directory, "MVMavlink.h"), mode='w')
+    f = open(os.path.join(directory, "MVMavlink.h"), mode='w', encoding='utf-8')
     t.write(f,'''
 //
 //  MVMavlink.h
@@ -75,7 +75,7 @@ ${{message_definition_files:#import "MV${name_camel_case}Messages.h"
 @end
 ''', xml)
     f.close()
-    f = open(os.path.join(directory, "MVMavlink.m"), mode='w')
+    f = open(os.path.join(directory, "MVMavlink.m"), mode='w', encoding='utf-8')
     t.write(f,'''
 //
 //  MVMavlink.m
@@ -113,7 +113,7 @@ ${{message_definition_files:#import "MV${name_camel_case}Messages.h"
 
 def generate_base_message(directory, xml):
     '''Generate base MVMessage header and implementation'''
-    f = open(os.path.join(directory, 'MVMessage.h'), mode='w')
+    f = open(os.path.join(directory, 'MVMessage.h'), mode='w', encoding='utf-8')
     t.write(f, '''
 //
 //  MVMessage.h
@@ -155,7 +155,7 @@ def generate_base_message(directory, xml):
 @end
 ''', xml)
     f.close()
-    f = open(os.path.join(directory, 'MVMessage.m'), mode='w')
+    f = open(os.path.join(directory, 'MVMessage.m'), mode='w', encoding='utf-8')
     t.write(f, '''
 //
 //  MVMessage.m
@@ -228,7 +228,7 @@ ${{message:      @${id} : [MVMessage${name_camel_case} class],
 
 def generate_message_definitions_h(directory, xml):
     '''generate headerfile containing includes for all messages'''
-    f = open(os.path.join(directory, "MV" + camel_case_from_underscores(xml.basename) + "Messages.h"), mode='w')
+    f = open(os.path.join(directory, "MV" + camel_case_from_underscores(xml.basename) + "Messages.h"), mode='w', encoding='utf-8')
     t.write(f, '''
 //
 //  MV${basename_camel_case}Messages.h
@@ -245,7 +245,7 @@ ${{message:#import "MVMessage${name_camel_case}.h"
 
 def generate_message(directory, m):
     '''generate per-message header and implementation file'''
-    f = open(os.path.join(directory, 'MVMessage%s.h' % m.name_camel_case), mode='w')
+    f = open(os.path.join(directory, 'MVMessage%s.h' % m.name_camel_case), mode='w', encoding='utf-8')
     t.write(f, '''
 //
 //  MVMessage${name_camel_case}.h
@@ -273,7 +273,7 @@ ${{fields://! ${description}
 @end
 ''', m)
     f.close()
-    f = open(os.path.join(directory, 'MVMessage%s.m' % m.name_camel_case), mode='w')
+    f = open(os.path.join(directory, 'MVMessage%s.m' % m.name_camel_case), mode='w', encoding='utf-8')
     t.write(f, '''
 //
 //  MVMessage${name_camel_case}.m

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -1196,7 +1196,7 @@ def generate(basename, xml):
             m.len_map[n] = m.fieldlengths[i]
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding='utf-8')
     xml = xml[0].__dict__
     generate_preamble(outf, msgs, basename, filelist, xml)
     generate_enums(outf, enums)

--- a/generator/mavgen_spin2.py
+++ b/generator/mavgen_spin2.py
@@ -780,7 +780,7 @@ def generate(basename, xml):
             m.len_map[n] = m.fieldlengths[i]
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding='utf-8')
     dialect = xml[0].filename
     dialect = dialect[dialect.rindex("/")+1:-4]  # remove .xml; we don't use os.sep here it's jank
     xml = xml[0].__dict__
@@ -793,6 +793,6 @@ def generate(basename, xml):
     print("Generated %s OK" % filename)
     # generates a handler skeleton
     handlername = filename[:-6] + "_handler.spin2"
-    outf = open(handlername, "w")   
+    outf = open(handlername, "w", encoding='utf-8')   
     generate_case(outf, msgs, dialect)
     generate_handler(outf, msgs)

--- a/generator/mavgen_swift.py
+++ b/generator/mavgen_swift.py
@@ -171,7 +171,7 @@ def append_static_code(filename, outf):
     
     print("Appending content of %s" % filename)
     
-    with open(filepath) as inf:
+    with open(filepath, encoding='utf-8') as inf:
         for line in inf:
             outf.write(line) 
 

--- a/generator/mavgen_swift.py
+++ b/generator/mavgen_swift.py
@@ -33,7 +33,7 @@ def generate_mavlink(directory, filelist, xml_list, msgs):
     mavparse.mkdir_p(directory)
     filename = 'MAVLink.swift'
     filepath = os.path.join(directory, filename)
-    outf = open(filepath, "w")
+    outf = open(filepath, "w", encoding='utf-8')
     generate_header(outf, filelist, xml_list, filename)
     append_static_code('MAVLink.swift', outf)
     generate_message_mappings_array(outf, msgs)
@@ -67,7 +67,7 @@ def generate_enums(directory, filelist, xml_list, enums):
             continue
         filename = "%s%sEnum.swift" % (enum.swift_name, enum.basename)
         filepath = os.path.join(directory, filename)
-        outf = open(filepath, "w")
+        outf = open(filepath, "w", encoding='utf-8')
         generate_header(outf, filelist, xml_list, filename)
         t.write(outf, """
 ${formatted_description}public enum ${swift_name}: ${raw_value_type} {
@@ -96,7 +96,7 @@ def generate_optionsets(directory, filelist, xml_list, enums):
             entry.parent_swift_name = enum.swift_name
         filename = "%s%sOptionSet.swift" % (enum.swift_name, enum.basename)
         filepath = os.path.join(directory, filename)
-        outf = open(filepath, "w")
+        outf = open(filepath, "w", encoding='utf-8')
         generate_header(outf, filelist, xml_list, filename)
         t.write(outf, """
 ${formatted_description}public struct ${swift_name}: OptionSet {
@@ -135,7 +135,7 @@ def generate_messages(directory, filelist, xml_list, msgs):
     for msg in msgs:
         filename = "%s%sMsg.swift" % (msg.swift_name, msg.basename)
         filepath = os.path.join(directory, filename)
-        outf = open(filepath, "w")
+        outf = open(filepath, "w", encoding='utf-8')
         generate_header(outf, filelist, xml_list, filename)
         t.write(outf, """
 import Foundation

--- a/generator/mavgen_typescript.py
+++ b/generator/mavgen_typescript.py
@@ -29,7 +29,7 @@ def generate_enums(dir, enums):
     for e in enums:
         filename = e.name.replace('_', '-')
         filename = filename.lower()
-        with open('{}/{}.ts'.format(dir, filename), "w") as f:
+        with open('{}/{}.ts'.format(dir, filename), "w", encoding='utf-8') as f:
             f.write("export enum {} {{\n".format(camelcase(e.name)))
             for entry in e.entry:
                 f.write(
@@ -47,7 +47,7 @@ def generate_classes(dir, registry, msgs, xml):
     if not os.path.isdir(dir):
         os.mkdir(dir)
 
-    with open(registry, "w") as registry_f:
+    with open(registry, "w", encoding='utf-8') as registry_f:
         registry_f.write(f"import {{MAVLinkMessage}} from '{NODE_MAVLINK_PACKAGE}';\n")
         for m in msgs:
             filename = m.name.replace('_', '-')
@@ -57,7 +57,7 @@ def generate_classes(dir, registry, msgs, xml):
             for i in range(0, len(m.fieldnames)):
                 m.order_map[i] = m.ordered_fieldnames.index(m.fieldnames[i])
 
-            with open('{}/{}.ts'.format(dir, filename), "w") as f:
+            with open('{}/{}.ts'.format(dir, filename), "w", encoding='utf-8') as f:
                 if xml.wire_protocol_version == '1.0':
                     raise Exception('WireProtocolException', 'Please use WireProtocol = 2.0 only.')
 
@@ -110,7 +110,7 @@ def generate_classes(dir, registry, msgs, xml):
 
 
 def generate_tsconfig(basename):
-    with open('{}/tsconfig.json'.format(basename), "w") as f:
+    with open('{}/tsconfig.json'.format(basename), "w", encoding='utf-8') as f:
         f.write(
             "{\n  \"compilerOptions\": {\n    \"target\": \"es5\",\n    \"module\": \"commonjs\","
             "\n    \"declaration\": true,\n    \"declarationMap\": true,\n    \"sourceMap\": true,"

--- a/generator/mavgen_wlua.py
+++ b/generator/mavgen_wlua.py
@@ -745,7 +745,7 @@ def generate(basename, xml):
             m.order_map[i] = m.ordered_fieldnames.index(m.fieldnames[i])
 
     print("Generating %s" % filename)
-    outf = open(filename, "w")
+    outf = open(filename, "w", encoding='utf-8')
     generate_preamble(outf)
     generate_msg_table(outf, msgs)
     generate_enum_table(outf, enums)


### PR DESCRIPTION
Fix: specify UTF-8 encoding when opening XML files in mavgen
potential encoding issues when opening XML files on different operating systems (especially Windows).