### PR TITLE
mavtcp: mark closed sockets as disconnected without autoreconnect

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1264,20 +1264,34 @@ class mavtcp(mavfile):
         self.port.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
 
     def close(self):
-        self.port.close()
+        if self.port is not None:
+            self.port.close()
+            self.port = None
+
+    def _mark_socket_disconnected(self):
+        if self.port is not None:
+            try:
+                self.port.close()
+            except OSError:
+                pass
+            self.port = None
 
     def handle_disconnect(self):
         print("Connection reset or closed by peer on TCP socket")
+        self._mark_socket_disconnected()
         self.reconnect()
 
     def handle_eof(self):
         # EOF
         print("EOF on TCP socket")
+        self._mark_socket_disconnected()
         self.reconnect()
 
     def recv(self,n=None):
         if self.port is None:
             self.reconnect()
+            if self.port is None:
+                raise ConnectionError("TCP socket is not connected")
         if n is None:
             n = self.mav.bytes_needed()
         try:

--- a/tests/test_mavtcp.py
+++ b/tests/test_mavtcp.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import errno
+import unittest
+from pathlib import Path
+import sys
+import importlib.util
+
+try:
+    from pymavlink import mavutil
+except ModuleNotFoundError:
+    repo_root = Path(__file__).resolve().parents[1]
+    pkg_spec = importlib.util.spec_from_file_location(
+        "pymavlink",
+        repo_root / "__init__.py",
+        submodule_search_locations=[str(repo_root)],
+    )
+    assert pkg_spec is not None and pkg_spec.loader is not None
+    pymavlink_pkg = importlib.util.module_from_spec(pkg_spec)
+    sys.modules["pymavlink"] = pymavlink_pkg
+    pkg_spec.loader.exec_module(pymavlink_pkg)
+    from pymavlink import mavutil
+
+
+class DummyMav:
+    @staticmethod
+    def bytes_needed():
+        return 1
+
+
+class FakeSocket:
+    def __init__(self, recv_data=b"", recv_error=None):
+        self._recv_data = recv_data
+        self._recv_error = recv_error
+        self.closed = False
+        self.sent = []
+
+    def recv(self, _n):
+        if self._recv_error is not None:
+            raise self._recv_error
+        return self._recv_data
+
+    def send(self, buf):
+        self.sent.append(buf)
+        return len(buf)
+
+    def close(self):
+        self.closed = True
+
+
+def build_mavtcp(port, autoreconnect=False):
+    tcp = object.__new__(mavutil.mavtcp)
+    tcp.port = port
+    tcp.autoreconnect = autoreconnect
+    tcp.mav = DummyMav()
+    return tcp
+
+
+class TestMavTcpDisconnectHandling(unittest.TestCase):
+    def test_recv_raises_connection_error_when_disconnected_without_autoreconnect(self):
+        tcp = build_mavtcp(port=None, autoreconnect=False)
+
+        with self.assertRaises(ConnectionError):
+            tcp.recv()
+
+    def test_eof_marks_socket_disconnected(self):
+        sock = FakeSocket(recv_data=b"")
+        tcp = build_mavtcp(port=sock, autoreconnect=False)
+
+        data = tcp.recv(1)
+
+        self.assertEqual(b"", data)
+        self.assertTrue(sock.closed)
+        self.assertIsNone(tcp.port)
+
+        with self.assertRaises(ConnectionError):
+            tcp.recv(1)
+
+    def test_connection_reset_marks_socket_disconnected(self):
+        sock = FakeSocket(recv_error=OSError(errno.ECONNRESET, "connection reset"))
+        tcp = build_mavtcp(port=sock, autoreconnect=False)
+
+        with self.assertRaises(OSError):
+            tcp.recv(1)
+
+        self.assertTrue(sock.closed)
+        self.assertIsNone(tcp.port)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mavtcp.py
+++ b/tests/test_mavtcp.py
@@ -2,24 +2,7 @@
 
 import errno
 import unittest
-from pathlib import Path
-import sys
-import importlib.util
-
-try:
-    from pymavlink import mavutil
-except ModuleNotFoundError:
-    repo_root = Path(__file__).resolve().parents[1]
-    pkg_spec = importlib.util.spec_from_file_location(
-        "pymavlink",
-        repo_root / "__init__.py",
-        submodule_search_locations=[str(repo_root)],
-    )
-    assert pkg_spec is not None and pkg_spec.loader is not None
-    pymavlink_pkg = importlib.util.module_from_spec(pkg_spec)
-    sys.modules["pymavlink"] = pymavlink_pkg
-    pkg_spec.loader.exec_module(pymavlink_pkg)
-    from pymavlink import mavutil
+from pymavlink import mavutil
 
 
 class DummyMav:


### PR DESCRIPTION
## Summary
- mark TCP sockets as disconnected when EOF or connection-reset is observed, even when `autoreconnect=False`
- make `mavtcp.recv()` raise `ConnectionError` if no socket is available after reconnect logic
- keep reconnect behavior unchanged for `autoreconnect=True`
- add regression tests for EOF and `ECONNRESET` disconnect handling

## Why
`mavtcp` currently leaves `self.port` set after disconnect events when auto-reconnect is disabled.  
That makes disconnect detection difficult and can cause repeated EOF handling without a stable disconnected state.

## Testing
- `python -m pytest C:\Users\woshe\Documents\Playground\pymavlink-git\tests\test_mavtcp.py -q`
- `python -m py_compile C:\Users\woshe\Documents\Playground\pymavlink-git\mavutil.py C:\Users\woshe\Documents\Playground\pymavlink-git\tests\test_mavtcp.py`

Closes #742
