### PR TITLE
Replace deprecated argument with its new name

### DIFF
--- a/tools/mavtranslatelog.py
+++ b/tools/mavtranslatelog.py
@@ -84,7 +84,7 @@ def protocol_module(identifier, repository, dialect):
                     repo_path = tempfile.mkdtemp()
                     if args_verbosity >= 1:
                         print("Cloning from", repository, "to", repo_path)
-                    subprocess.check_call(['git', 'clone', '--recursive', repository, repo_path])
+                    subprocess.check_call(['git', 'clone', '--recurse-submodules', repository, repo_path])
 
             assert os.path.isdir(repo_path), "Has a local copy of mavlink repository"
             try:


### PR DESCRIPTION
A tiny improvement: `git clone --recurse-submodules` is preferred now, replacing old `--recursive`.

Related to https://github.com/ArduPilot/ardupilot/pull/32690

**Reviewers** I only tested this by confirming that I spelled it correctly. If that's insufficient, please either reject the PR or contribute additional desired testing to the PR via comments/editing this description.