### PR TITLE
Stop testing on end-of-life versions of Node.js

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,8 +78,8 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
-      matrix:
-        node-version: ['12', '14', '16', '18', '20', 'lts/*']
+      matrix:  # Node.js 12 for Debian 11 and Ubuntu 22.04. Node.js 18 for Debian 12.
+        node-version: [latest, lts/*, lts/-1, lts/-2, 18, 12]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
`node-version: [latest, lts/*, lts/-1, lts/-2]`
 Currently:
tag | Node.js version
---:|---
latest | v25.9.0
lts/* | v24.14.1
lts/-1 | v22.22.2
lts/-2 | v20.20.2

https://nodejs.org/en/about/previous-releases
https://github.com/actions/setup-node?tab=readme-ov-file#supported-version-syntax

> [!NOTE]
> Debian GNU/Linux 11 (bullseye) defaults to v12.22.12
> Ubuntu 22.04.5 LTS (jammy) defaults to v12.22.9
> Debian GNU/Linux 12 (bookworm) defaults to v18.20.4

---
% `docker run -it ubuntu:22.04`
\# `apt update && DEBIAN_FRONTEND=noninteractive apt install --yes nodejs && node --version && exit`
