### PR TITLE
mavutil: fix missing socket.bind under Windows in udpout connections

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1068,6 +1068,9 @@ class mavudp(mavfile):
             if broadcast:
                 self.port.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
                 self.broadcast = True
+            # On Windows, be need to bind on 0.0.0.0 first, to avoid socket exceptions
+            if platform.system() == "Windows":
+                self.port.bind(('0.0.0.0', int(a[1])))
         set_close_on_exec(self.port.fileno())
         self.port.setblocking(0)
         self.last_address = None


### PR DESCRIPTION
Fix for #882.

Under Windows, a udpout connection needs to be first initialised with ``socket.bind(0.0.0.0, port)``, to avoid a ``OSError: [WinError 10022] An invalid argument was supplied`` error.

If a packet is transmitted before a ``recv_match()``, this error does not occur as a data transmission seemingly calls ``socket.bind()`` anyway.

Tested on Windows with a CubeOrange (via serial->udpout MAVProxy)