### PR TITLE
feat: Adding and implementing set_mavlink_version function in mavutil.py

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -134,6 +134,24 @@ def set_dialect(dialect, with_type_annotations=None):
     current_dialect = dialect
     mavlink = mod
 
+def set_mavlink_version(version):
+    '''set the MAVLink version to work with.
+    For example, set_mavlink_version(2.0)
+    '''
+    v = float(version)
+    if v == 2.0:
+        os.environ.pop('MAVLINK09', None)
+        os.environ['MAVLINK20'] = '1'
+    elif v == 1.0:
+        os.environ.pop('MAVLINK09', None)
+        os.environ.pop('MAVLINK20', None)
+    elif v == 0.9:
+        os.environ.pop('MAVLINK20', None)
+        os.environ['MAVLINK09'] = '1'
+    else:
+        raise ValueError("Wrong MAVLink version")
+    set_dialect(current_dialect)
+
 # Set the default dialect. This is done here as it needs to be after the function declaration
 set_dialect(os.environ['MAVLINK_DIALECT'])
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -314,15 +314,13 @@ class mavfile(object):
         self.first_byte = False
         if self.WIRE_PROTOCOL_VERSION == "0.9" and magic == 254:
             self.WIRE_PROTOCOL_VERSION = "1.0"
-            set_dialect(current_dialect)
+            set_mavlink_version(1.0)
         elif self.WIRE_PROTOCOL_VERSION == "1.0" and magic == 85:
             self.WIRE_PROTOCOL_VERSION = "0.9"
-            os.environ['MAVLINK09'] = '1'
-            set_dialect(current_dialect)
+            set_mavlink_version(0.9)
         elif self.WIRE_PROTOCOL_VERSION != "2.0" and magic == 253:
             self.WIRE_PROTOCOL_VERSION = "2.0"
-            os.environ['MAVLINK20'] = '1'
-            set_dialect(current_dialect)
+            set_mavlink_version(2.0)
         else:
             return
         # switch protocol 

--- a/mavutil.py
+++ b/mavutil.py
@@ -137,6 +137,11 @@ def set_dialect(dialect, with_type_annotations=None):
 def set_mavlink_version(version):
     '''set the MAVLink version to work with.
     For example, set_mavlink_version(2.0)
+
+    Warning: If the currently loaded dialect is specific to a single MAVLink 
+    version (e.g., a v2-only dialect) and you switch to an incompatible version,
+    this function will raise a FileNotFoundError because the underlying
+    set_dialect() call will fail to find the corresponding XML file
     '''
     v = float(version)
     if v == 2.0:

--- a/mavutil.py
+++ b/mavutil.py
@@ -139,6 +139,24 @@ def set_dialect(dialect: str, with_type_annotations: bool | None = None) -> None
     current_dialect = dialect
     mavlink = mod
 
+def set_mavlink_version(version):
+    '''set the MAVLink version to work with.
+    For example, set_mavlink_version(2.0)
+    '''
+    v = float(version)
+    if v == 2.0:
+        os.environ.pop('MAVLINK09', None)
+        os.environ['MAVLINK20'] = '1'
+    elif v == 1.0:
+        os.environ.pop('MAVLINK09', None)
+        os.environ.pop('MAVLINK20', None)
+    elif v == 0.9:
+        os.environ.pop('MAVLINK20', None)
+        os.environ['MAVLINK09'] = '1'
+    else:
+        raise ValueError("Wrong MAVLink version")
+    set_dialect(current_dialect)
+
 # Set the default dialect. This is done here as it needs to be after the function declaration
 set_dialect(os.environ['MAVLINK_DIALECT'])
 

--- a/mavutil.py
+++ b/mavutil.py
@@ -142,6 +142,11 @@ def set_dialect(dialect: str, with_type_annotations: bool | None = None) -> None
 def set_mavlink_version(version):
     '''set the MAVLink version to work with.
     For example, set_mavlink_version(2.0)
+
+    Warning: If the currently loaded dialect is specific to a single MAVLink 
+    version (e.g., a v2-only dialect) and you switch to an incompatible version,
+    this function will raise a FileNotFoundError because the underlying
+    set_dialect() call will fail to find the corresponding XML file
     '''
     v = float(version)
     if v == 2.0:

--- a/mavutil.py
+++ b/mavutil.py
@@ -147,22 +147,18 @@ def set_mavlink_version(version):
     version (e.g., a v2-only dialect) and you switch to an incompatible version,
     this function will raise a FileNotFoundError because the underlying
     set_dialect() call will fail to find the corresponding XML file
+
+    Deprecated: 0.9 is no longer supported
     '''
     v = float(version)
 
-    old_m09 = os.environ.get('MAVLINK09', None)
     old_m20 = os.environ.get('MAVLINK20', None)
 
     # Apply new environment variables
     if v == 2.0:
-        os.environ.pop('MAVLINK09', None)
         os.environ['MAVLINK20'] = '1'
     elif v == 1.0:
-        os.environ.pop('MAVLINK09', None)
         os.environ.pop('MAVLINK20', None)
-    elif v == 0.9:
-        os.environ.pop('MAVLINK20', None)
-        os.environ['MAVLINK09'] = '1'
     else:
         raise ValueError("Wrong MAVLink version")
 
@@ -170,10 +166,6 @@ def set_mavlink_version(version):
     try:
         set_dialect(current_dialect)
     except Exception as e:
-        if old_m09 is not None:
-            os.environ['MAVLINK09'] = old_m09
-        else:
-            os.environ.pop('MAVLINK09', None)
         if old_m20 is not None:
             os.environ['MAVLINK20'] = old_m20
         else:

--- a/mavutil.py
+++ b/mavutil.py
@@ -149,6 +149,11 @@ def set_mavlink_version(version):
     set_dialect() call will fail to find the corresponding XML file
     '''
     v = float(version)
+
+    old_m09 = os.environ.get('MAVLINK09', None)
+    old_m20 = os.environ.get('MAVLINK20', None)
+
+    # Apply new environment variables
     if v == 2.0:
         os.environ.pop('MAVLINK09', None)
         os.environ['MAVLINK20'] = '1'
@@ -160,7 +165,21 @@ def set_mavlink_version(version):
         os.environ['MAVLINK09'] = '1'
     else:
         raise ValueError("Wrong MAVLink version")
-    set_dialect(current_dialect)
+
+    # Try to set the dialect, rollback if it fails
+    try:
+        set_dialect(current_dialect)
+    except Exception as e:
+        if old_m09 is not None:
+            os.environ['MAVLINK09'] = old_m09
+        else:
+            os.environ.pop('MAVLINK09', None)
+        if old_m20 is not None:
+            os.environ['MAVLINK20'] = old_m20
+        else:
+            os.environ.pop('MAVLINK20', None)
+            
+        raise e
 
 # Set the default dialect. This is done here as it needs to be after the function declaration
 set_dialect(os.environ['MAVLINK_DIALECT'])

--- a/mavutil.py
+++ b/mavutil.py
@@ -312,8 +312,7 @@ class mavfile:
         self.first_byte = False
         if self.WIRE_PROTOCOL_VERSION != "2.0" and magic == 253:
             self.WIRE_PROTOCOL_VERSION = "2.0"
-            os.environ['MAVLINK20'] = '1'
-            set_dialect(current_dialect)
+            set_mavlink_version(2.0)
         else:
             return
         # switch protocol 


### PR DESCRIPTION
Hi! I thought having a simple function capable of changing the MAVLink version could be useful. For example, if you create a custom MAVLink dialect for MAVLink 2 only and don't change the version before setting the dialect, the script will try to import the default MAVLink 1 dialect, which will crash.

I've tested it, and it works as expected.

I also implemented it in mavfile.auto_mavlink_version for better readability.