### PR TITLE
generator/C: clamp asin argument in mavlink_dcm_to_euler

### DIFF
--- a/generator/C/include_v1.0/mavlink_conversions.h
+++ b/generator/C/include_v1.0/mavlink_conversions.h
@@ -70,7 +70,9 @@ MAVLINK_HELPER void mavlink_quaternion_to_dcm(const float quaternion[4], float d
 MAVLINK_HELPER void mavlink_dcm_to_euler(const float dcm[3][3], float* roll, float* pitch, float* yaw)
 {
     float phi, theta, psi;
-    theta = asin(-dcm[2][0]);
+    /* Clamp to [-1, 1] so floating-point rounding in
+       mavlink_quaternion_to_dcm() cannot drive asin() into NaN. */
+    theta = asin(fmin(1.0, fmax(-1.0, -dcm[2][0])));
 
     if (fabsf(theta - (float)M_PI_2) < 1.0e-3f) {
         phi = 0.0f;

--- a/generator/C/include_v2.0/mavlink_conversions.h
+++ b/generator/C/include_v2.0/mavlink_conversions.h
@@ -69,7 +69,9 @@ MAVLINK_HELPER void mavlink_quaternion_to_dcm(const float quaternion[4], float d
 MAVLINK_HELPER void mavlink_dcm_to_euler(const float dcm[3][3], float* roll, float* pitch, float* yaw)
 {
     float phi, theta, psi;
-    theta = asinf(-dcm[2][0]);
+    /* Clamp to [-1, 1] so floating-point rounding in
+       mavlink_quaternion_to_dcm() cannot drive asinf() into NaN. */
+    theta = asinf(fminf(1.0f, fmaxf(-1.0f, -dcm[2][0])));
 
     if (fabsf(theta - (float)M_PI_2) < 1.0e-3f) {
         phi = 0.0f;


### PR DESCRIPTION
Closes mavlink/mavlink#2389.

`asin(-dcm[2][0])` returns NaN when FP rounding pushes the argument outside [-1, 1]. Clamps the argument in both v1.0 and v2.0 helpers, matching the existing clamp in `pymavlink/quaternion.py`.
