### PR TITLE
mavgen_python: emit per-param label attribute on EnumEntry

### DIFF
--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -387,6 +387,7 @@ class EnumEntry(object):
         self.name = name
         self.description = description
         self.param: Dict[int, str] = {}
+        self.label: Dict[int, str] = {}
         self.has_location = False
 
 class Enum(Dict[int, EnumEntry]):
@@ -428,6 +429,11 @@ enums: Dict[str, Enum] = {}
                     outf.write(
                         'enums["%s"][%d].param[%d] = """%s"""\n'
                         % (e.name, int(entry.value), int(param.index), description)
+                    )
+                if param.label:
+                    outf.write(
+                        'enums["%s"][%d].label[%d] = """%s"""\n'
+                        % (e.name, int(entry.value), int(param.index), param.label)
                     )
 
 


### PR DESCRIPTION
The XML <param label="..."> attribute was parsed by mavparse into MAVEnumParam.label but never emitted into the generated dialect modules, so consumers (e.g. mission editors) had no way to read the short label at runtime and had to fall back to fuzzy-matching the description.

Add a label dict on EnumEntry alongside param, and emit
    enums["MAV_CMD"][N].label[i] = """..."""
for each <param> that carries a label= attribute.