### PR TITLE
mavutil: fix interpret_px4_mode for OFFBOARD on PX4 v1.12+ (#793)

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2538,40 +2538,41 @@ px4_map = { "MANUAL":        (mavlink.MAV_MODE_FLAG_CUSTOM_MODE_ENABLED | mavlin
 
 
 def interpret_px4_mode(base_mode, custom_mode):
+    # Dispatch on custom_main_mode (authoritative per PX4's px4_custom_mode.h);
+    # base_mode is no longer reliable for mode identity on PX4 v1.12+ (#793).
+    del base_mode
     custom_main_mode = (custom_mode & 0xFF0000)   >> 16
     custom_sub_mode  = (custom_mode & 0xFF000000) >> 24
 
-    if base_mode & mavlink.MAV_MODE_FLAG_MANUAL_INPUT_ENABLED != 0: #manual modes
-        if custom_main_mode == PX4_CUSTOM_MAIN_MODE_MANUAL:
-            return "MANUAL"
-        elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_ACRO:
-            return "ACRO"
-        elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_RATTITUDE:
-            return "RATTITUDE"
-        elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_STABILIZED:
-            return "STABILIZED"
-        elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_ALTCTL:
-            return "ALTCTL"
-        elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_POSCTL:
-            return "POSCTL"
-    elif (base_mode & auto_mode_flags) == auto_mode_flags: #auto modes
-        if custom_main_mode & PX4_CUSTOM_MAIN_MODE_AUTO != 0:
-            if custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_MISSION:
-                return "MISSION"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF:
-                return "TAKEOFF"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_LOITER:
-                return "LOITER"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET:
-                return "FOLLOWME"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_RTL:
-                return "RTL"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_LAND:
-                return "LAND"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_RTGS:
-                return "RTGS"
-            elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_OFFBOARD:
-                return "OFFBOARD"
+    if custom_main_mode == PX4_CUSTOM_MAIN_MODE_MANUAL:     
+        return "MANUAL"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_ACRO:       
+        return "ACRO"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_RATTITUDE:  
+        return "RATTITUDE"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_STABILIZED: 
+        return "STABILIZED"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_ALTCTL:     
+        return "ALTCTL"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_POSCTL:     
+        return "POSCTL"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_OFFBOARD:   
+        return "OFFBOARD"
+    elif custom_main_mode == PX4_CUSTOM_MAIN_MODE_AUTO:
+        if custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_MISSION:       
+            return "MISSION"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_TAKEOFF:       
+            return "TAKEOFF"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_LOITER:        
+            return "LOITER"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_FOLLOW_TARGET: 
+            return "FOLLOWME"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_RTL:           
+            return "RTL"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_LAND:          
+            return "LAND"
+        elif custom_sub_mode == PX4_CUSTOM_SUB_MODE_AUTO_RTGS:          
+            return "RTGS"
     return "UNKNOWN"
 
 def mode_mapping_byname(mav_type):

--- a/tests/test_interpret_px4_mode.py
+++ b/tests/test_interpret_px4_mode.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+
+
+"""Unit tests for mavutil.interpret_px4_mode -- regression coverage for #793."""
+
+import unittest
+
+from pymavlink import mavutil
+
+
+class InterpretPX4ModeTest(unittest.TestCase):
+
+    def test_offboard_decoded_correctly(self):
+        # #793: pre-fix this returned "UNKNOWN" because PX4 v1.12+ stopped
+        # setting MAV_MODE_FLAG_AUTO_ENABLED in base_mode for OFFBOARD.
+        custom_mode = mavutil.PX4_CUSTOM_MAIN_MODE_OFFBOARD << 16
+        assert mavutil.interpret_px4_mode(0, custom_mode) == "OFFBOARD"
+
+    def test_base_mode_ignored(self):
+        # Locks in the post-fix contract that base_mode is no longer consulted.
+        custom_mode = mavutil.PX4_CUSTOM_MAIN_MODE_OFFBOARD << 16
+        assert mavutil.interpret_px4_mode(0x00, custom_mode) == "OFFBOARD"
+        assert mavutil.interpret_px4_mode(0xFF, custom_mode) == "OFFBOARD"
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #793. PX4's [`px4_custom_mode.h`][1] is the authoritative spec for
HEARTBEAT.custom_mode, but `mavutil.interpret_px4_mode` ignores it and
gates on `base_mode` flags instead -- which PX4 v1.12+ no longer sets
reliably for OFFBOARD. Result: OFFBOARD heartbeats decode as `"UNKNOWN"`.

[1]: https://github.com/PX4/PX4-Autopilot/blob/v1.14.3/src/modules/commander/px4_custom_mode.h

## Fix

Dispatch on `custom_main_mode` first (matches QGroundControl, MAVSDK, and
mavros, all of which copy `px4_custom_mode.h` from PX4 firmware). Only
descend into `custom_sub_mode` for `MAIN_MODE_AUTO`. `base_mode` stays in
the signature for API stability but is no longer consulted.

This is the inverse of the existing `px4_map` encoder table in the same
file -- the two sides now agree by inspection.

## Test plan

- [x] Added `tests/test_interpret_px4_mode.py` -- regression test for #793
      plus a contract test confirming `base_mode` is ignored.
- [x] `python3 -m pytest tests/test_interpret_px4_mode.py` passes.
- [x] `flake8 . --select=E9,F63,F7,F82` clean.
- [x] Single rebased commit, no merge or fixup commits.