### PR TITLE
mavutil: fix type error in cache

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -89,7 +89,10 @@ def add_message(messages, mtype, msg):
         messages[mtype] = msg
         return
     instance_value = getattr(msg, msg._instance_field)
-    if not mtype in messages:
+    if not mtype in messages or messages[mtype]._instances is None:
+        # first instance-valued message for this type, or a previous message
+        # of this type was stored without an instance value (._instances is
+        # None), so the per-instance dict was never created
         messages[mtype] = copy.copy(msg)
         messages[mtype]._instances = {}
         messages[mtype]._instances[instance_value] = msg


### PR DESCRIPTION
This fixes an error when a connection upgrades from MAVLink v1 to v2:

```
  File ".../mavutil.py", line 98, in add_message
    messages[mtype]._instances[instance_value] = msg
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object does not support item assignment
```

Some messages (e.g. HIGHRES_IMU, RAW_IMU) gain an instance field only in v2, where the field is a v2-only extension. A message of such a type received before the v1->v2 switch is cached via the non-instance path, leaving its ._instances attribute as None. After the switch, the same type is treated as instanced and add_message assumes ._instances is a dict, causing the crash.

Guard against ._instances being None and (re)create the dict instead of erroring out.