### PR TITLE
:apple: tests: release UDP port between MAVFTP tests

### DIFF
--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -39,6 +39,8 @@ class TestMAVFTPPayloadDecoding(unittest.TestCase):
         self.mav_ftp = MAVFTP(self.mock_master, target_system=1, target_component=1)
 
     def tearDown(self):
+        # Release the UDP socket so the next test can re-bind the port.
+        self.mock_master.close()
         self.log_stream.seek(0)
         self.log_stream.truncate(0)
 


### PR DESCRIPTION
`TestMAVFTPPayloadDecoding.setUp()` opens a `udp:localhost:14550` connection for every test, but `tearDown()` never closed it. Re-binding the same port in the next test's `setUp()` succeeds on Linux (the socket sets `SO_REUSEADDR`) but fails on macOS with `OSError: [Errno 48] Address already in use`, since macOS additionally requires `SO_REUSEPORT` to rebind.

This makes the test suite fail for anyone running it on macOS, while passing in CI (Linux).
