### PR TITLE
Ignore test output artifacts and local mavlink dependency clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,10 @@ include/mavlink/v1.0
 dfindexer/dfindexer_cy.c
 dfindexer/*.so
 dfindexer/*.pyd
+
+# test output artifacts
+.tmp/
+tmp.dump
+prms.txt
+test_wp-wp.txt
+test_wp-wp2.txt


### PR DESCRIPTION
Test runs leave behind tmp.dump, prms.txt, test_wp-wp*.txt and a .tmp/ directory in the working tree (from test_mavlogdump, test_mavparm, test_wp and test_mavgen_typescript). The mavlink/ directory is a local clone of ArduPilot/mavlink used as the message_definitions source. None of these belong in version control.