### PR TITLE
MAV_CMD missionOnly attribute - should default to false

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -198,7 +198,7 @@
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
 <xs:attribute name="hasLocation" type="xs:boolean" default="true"/>    <!-- entry has lat/lon/alt location -->
 <xs:attribute name="isDestination" type="xs:boolean" default="true"/>  <!-- entry is a destination -->
-<xs:attribute name="missionOnly" type="xs:boolean" default="true"/>  <!-- entry only makes sense in missions, not commands -->
+<xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->
 
 <!-- definition of complex elements -->
 <xs:element name="param">


### PR DESCRIPTION
When looking at https://github.com/mavlink/mavlink/pull/1871 I realised that this means all MAV_CMD are only intended to be used for missions. That's not correct - we want to apply this to a subset.

Note, this hasn't been applied anywhere yet, but I am about to do so. It might reasonably be changed to commandsOnly since that at least implies command protocol. With mission only, you might think you couldn't apply this to a fence command.