### PR TITLE
XSD: add scaling value 2E-3

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -182,6 +182,7 @@
 <xs:simpleType name="factor">
   <xs:restriction base="xs:string">
     <xs:enumeration value="1E-2"/>        <!-- actual value = stated value / 100 -->
+    <xs:enumeration value="2E-3"/>        <!-- actual value = stated value / 500 -->
     <xs:enumeration value="360/255"/>     <!-- actual value = stated value * 360/255, as used for GPS_STATUS.satellite_azimuth -->
   </xs:restriction>
 </xs:simpleType>


### PR DESCRIPTION
Allow efficient scaling of a % value in UINT16 value. With this, 0 to 100 is represented by 50000.

This is needed for https://github.com/mavlink/mavlink/pull/2526/changes#r3465455513 - but would do no harm anyway.