### PR TITLE
mavlink_helpers: clamp payload zero-fill to MAVLINK_MAX_PAYLOAD_LEN

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -760,9 +760,14 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 			}
 			rxmsg->ck[0] = c;
 
-			// zero-fill the packet to cope with short incoming packets
-				if (e && status->packet_idx < e->max_msg_len) {
-					memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, e->max_msg_len - status->packet_idx);
+			// zero-fill the packet to cope with short incoming packets.
+			// Clamp to MAVLINK_MAX_PAYLOAD_LEN: e->max_msg_len comes from the
+			// message table and can exceed the payload buffer size when the
+			// buffer has been shrunk via MAVLINK_MAX_PAYLOAD_LEN, which would
+			// otherwise overflow the buffer.
+				uint8_t fill_len = e->max_msg_len < MAVLINK_MAX_PAYLOAD_LEN ? e->max_msg_len : MAVLINK_MAX_PAYLOAD_LEN;
+				if (e && status->packet_idx < fill_len) {
+					memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, fill_len - status->packet_idx);
 			}
 		}
 		break;


### PR DESCRIPTION
Disclaimer: found by Claude.

The zero-fill in mavlink_frame_char_buffer() filled the payload buffer up to e->max_msg_len (from the message table, up to 255), but the payload buffer is sized to MAVLINK_MAX_PAYLOAD_LEN, which can be reduced below the dialect's largest message (an explicitly supported configuration). A short/truncated frame for such a message passes the GOT_STX length guard and then triggers a memset past the end of the payload buffer, a remote-triggerable out-of-bounds write.

Clamp the fill length to MAVLINK_MAX_PAYLOAD_LEN, matching the bound the GOT_STX guard already enforces on the received length. No change in the default build (MAVLINK_MAX_PAYLOAD_LEN == 255).