### PR TITLE
feat(generator): add m^2 unit to mavschema

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -97,6 +97,7 @@
     <xs:enumeration value="km"/>       <!-- kilometres -->
     <xs:enumeration value="dam"/>      <!-- decametres -->
     <xs:enumeration value="m"/>        <!-- metres -->
+    <xs:enumeration value="m^2"/>      <!-- metres squared (typically used in variance) -->
     <xs:enumeration value="m/s"/>      <!-- metres per second -->
     <xs:enumeration value="m/s/s"/>    <!-- metres per second per second -->
     <xs:enumeration value="m/s*5"/>    <!-- metres per second * 5 required from dagar for HIGH_LATENCY2 message -->


### PR DESCRIPTION
## Summary
Adds `m^2` (metres squared) to the allowed units enumeration in `mavschema.xsd`.

## Problem
The schema only allows `cm^2` for variance-type fields. New message definitions using float SI fields need variance in `m^2` (e.g. the proposed `DISTANCE_SENSOR_V2` in mavlink/mavlink `development.xml`), and `mavgen --strict-units` fails schema validation for them.

## Solution
Add an `m^2` enumeration entry next to the existing `cm^2` unit.

## Relevant other PR's

- [ ] https://github.com/mavlink/mavlink/pull/2551