### PR TITLE
OOB write mavlink_frame_char_buffer()

### DIFF
--- a/generator/C/include_v2.0/mavlink_helpers.h
+++ b/generator/C/include_v2.0/mavlink_helpers.h
@@ -760,9 +760,15 @@ MAVLINK_HELPER uint8_t mavlink_frame_char_buffer(mavlink_message_t* rxmsg,
 			}
 			rxmsg->ck[0] = c;
 
-			// zero-fill the packet to cope with short incoming packets
-				if (e && status->packet_idx < e->max_msg_len) {
-					memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, e->max_msg_len - status->packet_idx);
+			// zero-fill the packet to cope with short incoming packets, clamped to
+			// the actual payload buffer size (max_msg_len is per-message-type and
+			// may exceed the buffer if MAVLINK_MAX_PAYLOAD_LEN has been reduced)
+			uint8_t max_len = e->max_msg_len;
+			if (max_len > (uint8_t)sizeof(rxmsg->payload64)) {
+				max_len = (uint8_t)sizeof(rxmsg->payload64);
+			}
+			if (status->packet_idx < max_len) {
+				memset(&_MAV_PAYLOAD_NON_CONST(rxmsg)[status->packet_idx], 0, max_len - status->packet_idx);
 			}
 		}
 		break;

--- a/generator/C/test/posix/Makefile
+++ b/generator/C/test/posix/Makefile
@@ -14,7 +14,7 @@ test:
 valgrindtest:
 	for p in ${ALLPROTOCOLS}; do make -f Makefile valgrindprogs TESTPROTOCOL=$$p || exit 1; done
 
-build: testmav2.0_${TESTPROTOCOL} testmav1.0_${TESTPROTOCOL} test_issues
+build: testmav2.0_${TESTPROTOCOL} testmav1.0_${TESTPROTOCOL} test_issues test_issue_2555
 
 testprogs: testmav2.0_${TESTPROTOCOL} testmav1.0_${TESTPROTOCOL}
 	./testmav2.0_${TESTPROTOCOL}
@@ -25,7 +25,7 @@ valgrindprogs: testmav2.0_${TESTPROTOCOL} testmav1.0_${TESTPROTOCOL}
 	valgrind -q ./testmav1.0_${TESTPROTOCOL}
 
 clean:
-	rm -rf *.o *~ testmav1.0* testmav2.0* sha256_test test_issues
+	rm -rf *.o *~ testmav1.0* testmav2.0* sha256_test test_issues test_issue_2555
 
 testmav1.0_${TESTPROTOCOL}: testmav.c $(COMMON)
 	$(CC) $(CFLAGS) -I../../include_v1.0 -I../../include_v1.0/${TESTPROTOCOL} -o $@ testmav.c
@@ -56,3 +56,6 @@ parse_tlog: parse_tlog.c
 
 test_issues: test_issues.c
 	$(CC) $(CFLAGS) -I../../include_v2.0 -I../../include_v2.0/all -o $@ test_issues.c
+
+test_issue_2555: test_issue_2555.c
+	$(CC) $(CFLAGS) -I../../include_v2.0 -I../../include_v2.0/common -o $@ test_issue_2555.c

--- a/test_generator.sh
+++ b/test_generator.sh
@@ -12,13 +12,14 @@ tools/mavgen.py --lang C $MDEF/v1.0/all.xml -o generator/C/include_v2.0 --wire-p
 tools/mavgen.py --lang C++11 $MDEF/v1.0/all.xml -o generator/CPP11/include_v2.0 --wire-protocol=2.0
 
 pushd generator/C/test/posix
-make clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega test_issues
+make clean testmav1.0_ardupilotmega testmav2.0_ardupilotmega test_issues test_issue_2555
 
 # these test tools emit the test packet as hexadecimal and human-readable,
 # other tools consume it as a cross-reference, we ignore the hex here.
 ./testmav1.0_ardupilotmega | egrep -v '(^fe|^fd)'
 ./testmav2.0_ardupilotmega | egrep -v '(^fe|^fd)'
 ./test_issues
+./test_issue_2555
 popd
 
 pushd generator/CPP11/test/posix


### PR DESCRIPTION
Fixes https://github.com/mavlink/mavlink/issues/2555

From Claude:

The zero-fill memset in `mavlink_frame_char_buffer()` (generator/C/include_v2.0/mavlink_helpers.h:764-765) used `e->max_msg_len` (up to 255, a per-message-type constant unrelated to buffer size) without clamping it to the actual payload64 buffer, which shrinks when MAVLINK_MAX_PAYLOAD_LEN is reduced — a documented, intentional option for memory-constrained targets.

But was introduced in 2016 (db810c93). 

Fix applied:
- generator/C/include_v2.0/mavlink_helpers.h — clamps the zero-fill extent to sizeof(rxmsg->payload64) before the memset.
- Added a regression test generator/C/test/posix/test_issue_2555.c that heap-allocates the receive buffer with   canary bytes after it and feeds a short frame for a real message (msgid 131, max_msg_len==255) while MAVLINK_MAX_PAYLOAD_LEN is set to 32 — reproducing the exact mismatch from the report.
- Wired it into the Makefile and test_generator.sh alongside the existing test_issues test.

-Verified: the new test fails (catches the OOB write) against the original code, and passes against the fix. Existing testmav1.0_ardupilotmega/testmav2.0_ardupilotmega regression tests still pass — no regressions. 