### PR TITLE
DFReader, mavutil: support use as context managers

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1093,6 +1093,12 @@ class DFReader(object):
         self.data_map.close()
         self.filehandle.close()
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
 
 class DFReader_binary(DFReader):
     '''parse a binary dataflash file'''

--- a/mavutil.py
+++ b/mavutil.py
@@ -335,6 +335,12 @@ class mavfile(object):
         '''default close method'''
         raise RuntimeError('no close() method supplied')
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.close()
+
     def write(self, buf):
         '''default write method'''
         raise RuntimeError('no write() method supplied')

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+"""
+test that log readers and mavlink connections work as context managers
+"""
+
+import os
+import unittest
+
+from pymavlink import DFReader
+from pymavlink import mavutil
+
+
+class ContextManagerTest(unittest.TestCase):
+    '''with-statement support releases file handles and sockets on exit'''
+
+    def dataflash_path(self):
+        return os.path.join(os.path.dirname(__file__), 'test.BIN')
+
+    def test_dfreader_binary(self):
+        with DFReader.DFReader_binary(self.dataflash_path()) as dflog:
+            self.assertIsNotNone(dflog.recv_msg())
+        self.assertTrue(dflog.filehandle.closed)
+        self.assertTrue(dflog.data_map.closed)
+
+    def test_mavlink_connection_dataflash(self):
+        with mavutil.mavlink_connection(self.dataflash_path()) as mlog:
+            self.assertIsNotNone(mlog.recv_msg())
+        self.assertTrue(mlog.filehandle.closed)
+
+    def test_mavfile(self):
+        with mavutil.mavlink_connection('udpout:127.0.0.1:14550') as conn:
+            self.assertNotEqual(conn.port.fileno(), -1)
+        self.assertEqual(conn.port.fileno(), -1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### What

Adds `__enter__`/`__exit__` to the two base classes that already have a
`close()` contract:

- `DFReader.DFReader` — covers `DFReader_binary` and `DFReader_text`
- `mavutil.mavfile` — covers every connection type and log reader
  returned by `mavlink_connection()`

so callers can scope a reader or connection with a plain `with`
statement:

```python
with DFReader_binary(path) as dflog:
    ...
# filehandle and mmap released here, even on exception
```

### Why

`DFReader_binary.__init__` opens the log file and mmaps its descriptor,
so each reader pins a filehandle until `close()` is called. Since there
is no context manager support, callers either remember to call `close()`
manually, wrap the reader in `contextlib.closing`, or — most commonly —
just leak the handle. ArduPilot's own autotest suite and Replay checker
did the latter for years (ArduPilot/ardupilot#32533, fixed in
ArduPilot/ardupilot#33839. It had to use `contextlib.closing` because this class can't be used in a `with` block).

This PR fixes the issue for all subclasses and downstream consumers. 

### Testing

New `tests/test_context_manager.py` (runs in the existing pytest suite,
no new fixtures — reuses `tests/test.BIN`):

- `DFReader_binary` used in a `with` block: reads a message, then both
  `filehandle` and `data_map` report closed on exit.
- `mavlink_connection()` on a dataflash log: same via the dispatch path.
- `mavlink_connection('udpout:...')`: socket is open inside the block,
  closed (fileno == -1) on exit.

All three pass locally on Python 3.13 (macOS); `flake8` clean with the
repo config.

No behavior change for existing callers — `close()` semantics are
untouched, and `__exit__` returns `None` so exceptions propagate.
