### PR TITLE
mavgen_python: accept str for char and char[] message fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ include/mavlink/v1.0
 /.vscode
 .idea/
 .venv/
+.tmp/
 dfindexer/dfindexer_cy.c
 dfindexer/*.so
 dfindexer/*.pyd

--- a/generator/mavgen_python.py
+++ b/generator/mavgen_python.py
@@ -83,6 +83,23 @@ except Exception:
 
 BytesLike = Union[List[int], Tuple[int], bytes, bytearray, str]
 
+# char and char[] fields are bytes on the wire, but callers have always been
+# allowed to pass a str for them (e.g. mav.statustext_send(sev, "hello")).
+CharFieldLike = Union[bytes, bytearray, str]
+
+
+def char_field_to_bytes(value: CharFieldLike) -> bytes:
+    """Normalise a char/char[] field value to bytes.
+
+    str is encoded as ascii to match the decoding done on the receiving side;
+    characters outside ascii are replaced rather than raising.
+    """
+    if isinstance(value, bytes):
+        return value
+    if isinstance(value, str):
+        return value.encode("ascii", errors="replace")
+    return bytes(value)
+
 
 class _x25crc_slow(object):
     """CRC-16/MCRF4XX - based on checksum.h from mavlink library"""
@@ -517,8 +534,8 @@ def generate_classes(outf, msgs, enums):
         init_fields = []
         for f in m.fields:
             if f.type == "char":
-                init_fields.append("self._%s_raw = %s" % (f.name, f.name))
-                init_fields.append('self.%s = %s.split(b"\\x00", 1)[0].decode("ascii", errors="replace")' % (f.name, f.name))
+                init_fields.append("self._%s_raw = char_field_to_bytes(%s)" % (f.name, f.name))
+                init_fields.append('self.%s = self._%s_raw.split(b"\\x00", 1)[0].decode("ascii", errors="replace")' % (f.name, f.name))
             else:
                 init_fields.append("self.%s = %s" % (f.name, f.name))
 
@@ -646,7 +663,7 @@ def mavpytype(field):
     c_type_to_py = {
         "float": "float",
         "double": "float",
-        "char": "bytes",
+        "char": "CharFieldLike",
         "int8_t": "int",
         "uint8_t": "int",
         "uint8_t_mavlink_version": "int",
@@ -660,7 +677,7 @@ def mavpytype(field):
 
     if field.array_length:
         if field.type == "char":
-            return "bytes"
+            return "CharFieldLike"
         return "Sequence[{}]".format(c_type_to_py[field.type])
     return c_type_to_py[field.type]
 

--- a/tests/test_mavgen_python.py
+++ b/tests/test_mavgen_python.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Tests for the Python generator.
+"""
+
+import importlib.util
+from pathlib import Path
+import shutil
+import sys
+
+try:
+    from pymavlink.generator import mavgen
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from generator import mavgen
+
+
+_common_dialect = None
+
+
+def common_dialect():
+    """Generate the common dialect once and import it as a module."""
+    global _common_dialect
+    if _common_dialect is not None:
+        return _common_dialect
+
+    xml_filepath = Path(__file__).parent / "snapshottests" / "resources" / "common.xml"
+    output_dir = Path(__file__).resolve().parents[1] / ".tmp" / "python-generator"
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_filepath = output_dir / "generated_common.py"
+
+    ok = mavgen.mavgen(
+        mavgen.Opts(
+            output=str(output_filepath),
+            language="Python3",
+            wire_protocol="2.0",
+            validate=False,
+        ),
+        [str(xml_filepath)],
+    )
+    assert ok is True
+
+    spec = importlib.util.spec_from_file_location("generated_common", output_filepath)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    _common_dialect = module
+    return module
+
+
+def test_char_array_field_accepts_str_bytes_and_bytearray():
+    """char[] fields accept str as well as bytes/bytearray. See issue #1225."""
+    dialect = common_dialect()
+    mav = dialect.MAVLink(None, srcSystem=1, srcComponent=1)
+    expected = dialect.MAVLink_statustext_message(6, b"hello world").pack(mav)
+
+    for text in ("hello world", b"hello world", bytearray(b"hello world")):
+        msg = dialect.MAVLink_statustext_message(6, text)
+        assert msg.text == "hello world"
+        assert msg._text_raw == b"hello world"
+        assert msg.pack(mav) == expected
+
+
+def test_param_id_accepts_str_bytes_and_bytearray():
+    dialect = common_dialect()
+    mav = dialect.MAVLink(None, srcSystem=1, srcComponent=1)
+    expected = dialect.MAVLink_param_value_message(b"P", 1.0, 9, 1, 0).pack(mav)
+
+    for param_id in ("P", b"P", bytearray(b"P")):
+        msg = dialect.MAVLink_param_value_message(param_id, 1.0, 9, 1, 0)
+        assert msg.param_id == "P"
+        assert msg.pack(mav) == expected
+
+
+def test_char_array_field_is_truncated_at_first_null():
+    dialect = common_dialect()
+    msg = dialect.MAVLink_statustext_message(6, b"abc\x00def")
+
+    assert msg.text == "abc"
+    assert msg._text_raw == b"abc\x00def"
+
+
+def test_char_array_field_replaces_non_ascii():
+    dialect = common_dialect()
+    msg = dialect.MAVLink_statustext_message(6, "café")
+
+    assert msg.text == "caf?"
+    assert msg._text_raw == b"caf?"
+
+
+def test_statustext_round_trips_through_the_parser():
+    dialect = common_dialect()
+    mav = dialect.MAVLink(None, srcSystem=1, srcComponent=1)
+    buf = dialect.MAVLink_statustext_message(6, "round trip").pack(mav)
+
+    decoded = dialect.MAVLink(None).decode(bytearray(buf))
+
+    assert decoded.get_type() == "STATUSTEXT"
+    assert decoded.text == "round trip"


### PR DESCRIPTION
Passing a str for a char/char[] field raised

    TypeError: must be str or None, not bytes

from the generated message constructor, e.g.

    mav.statustext_send(mavutil.mavlink.MAV_SEVERITY_NOTICE, "hello")

as MAVProxy's example module does. Commit 667cfcd4 started splitting the raw value on b"\x00" in __init__, which only works for bytes-like input, so every caller that had been passing a str broke.

Add a char_field_to_bytes() helper to the generated module and route char field assignment through it, so str, bytes and bytearray are all accepted and normalised to bytes before the NUL split and before being handed to struct.pack. str is encoded as ascii with errors="replace", matching the decode already performed on the same line.

The constructor and *_encode/*_send annotations for char fields are widened from bytes to the new CharFieldLike alias so the generated dialects still type-check.

The second case mentioned in the issue, mavftp.py's op.payload.split(b"\x00"), is not affected: op.payload is a bytearray and bytearray.split() accepts a bytes separator.

Adds tests/test_mavgen_python.py, which generates the common dialect and exercises str/bytes/bytearray input, NUL truncation, non-ascii handling and a full pack/parse round trip.

Fixes #1225