### PR TITLE
mavgen_c.py: make MAVLINK_*_XML_HASH deterministic

### DIFF
--- a/generator/mavgen_c.py
+++ b/generator/mavgen_c.py
@@ -6,6 +6,7 @@ Copyright Andrew Tridgell 2011
 Released under GNU GPL version 3 or later
 '''
 
+import hashlib
 import os
 from . import mavparse, mavtemplate
 
@@ -761,11 +762,18 @@ def generate_one(basename, xml):
     generate_testsuite_h(directory, xml)
 
 
+def xml_name_hash(basename):
+    '''deterministic 64-bit signed hash of a dialect name; the builtin
+    hash() is randomised per interpreter run (PYTHONHASHSEED), which
+    makes regenerated headers differ even for identical XML'''
+    digest = hashlib.sha256(basename.encode('utf-8')).digest()
+    return int.from_bytes(digest[:8], 'little', signed=True)
+
 def generate(basename, xml_list):
     '''generate complete MAVLink C implemenation'''
 
     for idx in range(len(xml_list)):
         xml = xml_list[idx]
-        xml.xml_hash = hash(xml.basename)        
+        xml.xml_hash = xml_name_hash(xml.basename)
         generate_one(basename, xml)
     copy_fixed_headers(basename, xml_list[0])


### PR DESCRIPTION
xml_hash was computed with Python's builtin hash(), which is salted per interpreter run since Python 3.3 (PYTHONHASHSEED), so each generator run emits different MAVLINK_*_XML_HASH values for identical XML.  The hash only needs to be distinct per dialect name (see PR #537, which replaced the order-dependent iterating index); it does not need to be random.

Nondeterministic values churn every dialect header in checked-in generated libraries (e.g. mavlink/c_library_v2) and defeat ccache's direct mode for any source file that includes a generated header: an ArduPilot SITL clean rebuild goes from 42% to 100% direct hits with this change, dropping warm-cache rebuild time from 19s to 5.6s.

Replace it with the first 8 bytes of sha256 of the dialect name, which is stable across runs, Python versions and platforms.