### PR TITLE
mavutil: remove unused retries parameter from mavwebsocket_client

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1885,7 +1885,6 @@ class mavwebsocket_client(mavfile):
                  device,
                  source_system=255,
                  source_component=0,
-                 retries=6,
                  use_native=default_native):
         self.resource = "/"
         a = device.split(':')


### PR DESCRIPTION
not used. 
Removed until someone create a proper retry mecanism