### PR TITLE
mavutil: remove unused n parameter from mavfile.close()

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -334,7 +334,7 @@ class mavfile(object):
         '''default recv method'''
         raise RuntimeError('no recv() method supplied')
 
-    def close(self, n=None):
+    def close(self):
         '''default close method'''
         raise RuntimeError('no close() method supplied')
 


### PR DESCRIPTION
not used in subclass