### PR TITLE
mavutil: fix mavchildexec.close() crashing

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1729,8 +1729,8 @@ class mavmmaplog(mavlogfile):
 class mavchildexec(mavfile):
     '''a MAVLink child processes reader/writer'''
     def __init__(self, filename, source_system=255, source_component=0, use_native=default_native):
-        from subprocess import Popen, PIPE
         import fcntl
+        from subprocess import PIPE, Popen, TimeoutExpired
         
         self.filename = filename
         self.child = Popen(filename, shell=False, stdout=PIPE, stdin=PIPE, bufsize=0)
@@ -1745,7 +1745,18 @@ class mavchildexec(mavfile):
         mavfile.__init__(self, self.fd, filename, source_system=source_system, source_component=source_component, use_native=use_native)
 
     def close(self):
-        self.child.close()
+        from subprocess import TimeoutExpired
+
+        try:
+            self.child.stdin.close()
+            self.child.stdout.close()
+        finally:
+            self.child.terminate()
+            try:
+                self.child.wait(timeout=5)
+            except TimeoutExpired:
+                self.child.kill()
+                self.child.wait()
 
     def recv(self,n=None):
         try:


### PR DESCRIPTION
close() called self.child.close(), but subprocess.Popen has never had a close() method - this raises AttributeError if close() is ever invoked on a mavchildexec connection. Now closes the child's stdin/ stdout pipes, terminates the process, and waits on it, matching how close() is implemented on every other mavfile subclass (release resources, don't leave the child process running).

The wait() after terminate() matters: terminate() only sends SIGTERM and returns immediately - without a wait(), the child becomes a zombie (confirmed via /proc/<pid>/stat showing state "Z") until something else eventually reaps it. Popen.stdin/self.fd are not a separate resource to close: self.fd is just
self.child.stdout.fileno(), the same underlying descriptor already closed by self.child.stdout.close() - closing it again would be a double-close.

Deliberately not using Popen's own context-manager protocol (`with self.child:` / __exit__) here: Popen.__exit__ closes the pipes but then calls self.wait() with no signal sent first, which assumes the child notices EOF and exits on its own - it can hang indefinitely if the child doesn't. terminate() + wait() actively asks the child to stop rather than passively waiting for it to notice EOF.

obviously used Claude to correct this properly. 

test with : 
```
cd /home/pierre/Workspace/ardupilot/pymavlink
.venv/bin/python3 -c "
from pymavlink import mavutil
import time

conn = mavutil.mavchildexec('cat')
pid = conn.child.pid
conn.close()
time.sleep(0.2)
try:
    with open(f'/proc/{pid}/stat') as f:
        state = f.read().split()[2]
    print('process state after close():', state)
except FileNotFoundError:
    print('process fully reaped (no /proc entry) - correct')
"
```