### PR TITLE
mavutil: fix mavtcp.recv() crashing when autoreconnect is disabled

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -1279,7 +1279,9 @@ class mavtcp(mavfile):
         self.port.setsockopt(socket.SOL_TCP, socket.TCP_NODELAY, 1)
 
     def close(self):
-        self.port.close()
+        if self.port is not None:
+            self.port.close()
+            self.port = None
 
     def handle_disconnect(self):
         print("Connection reset or closed by peer on TCP socket")
@@ -1290,9 +1292,24 @@ class mavtcp(mavfile):
         print("EOF on TCP socket")
         self.reconnect()
 
-    def recv(self,n=None):
+    def _ensure_port(self):
+        '''make sure self.port is usable, reconnecting if that was asked for
+
+        Raises OSError(ENOTCONN) when there is no socket and nothing is going to
+        reopen one: reconnect() is a no-op unless autoreconnect was requested, so
+        it can return with self.port still None. A failed reconnect attempt
+        raises its own, more specific error from do_connect() instead.
+        '''
         if self.port is None:
             self.reconnect()
+        if self.port is None:
+            raise OSError(errno.ENOTCONN, "TCP socket is closed")
+
+    def recv(self,n=None):
+        # a closed socket is a permanent condition, so it is reported rather
+        # than returned as b"": that value means "no data right now, retry",
+        # which is how the EAGAIN/EWOULDBLOCK path below uses it.
+        self._ensure_port()
         if n is None:
             n = self.mav.bytes_needed()
         try:
@@ -1309,12 +1326,12 @@ class mavtcp(mavfile):
         return data
 
     def write(self, buf):
-        if self.port is None:
-            try:
-                self.reconnect()
-            except socket.error as e:
-                pass
-        if self.port is None:
+        try:
+            self._ensure_port()
+        except OSError:
+            # unlike recv(), write() is fire-and-forget: callers are sending a
+            # mavlink message through self.mav and are not in a position to
+            # handle a dead link, so this stays silent as it always has.
             return
         try:
             self.port.send(buf)

--- a/tests/test_mavtcp.py
+++ b/tests/test_mavtcp.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+
+"""
+test mavutil.mavtcp connect/close/recv behaviour against a real local listener
+"""
+
+import errno
+import socket
+import time
+import unittest
+
+from pymavlink import mavutil
+
+
+class MavtcpTest(unittest.TestCase):
+    '''mavutil.mavtcp tests using a real local TCP listener'''
+
+    TIMEOUT = 5.0
+
+    def setUp(self):
+        # bind port 0 and read back what the OS assigned, rather than probing
+        # for a free port and closing it again - that leaves a window for
+        # something else to take the port before we rebind it.
+        self.listener = mavutil.mavlink_connection('tcpin:127.0.0.1:0')
+        self.port_num = self.listener.listen.getsockname()[1]
+        self.conn = mavutil.mavlink_connection('tcp:127.0.0.1:%u' % self.port_num,
+                                               autoreconnect=False)
+
+    def tearDown(self):
+        self.conn.close()
+        self.listener.close()
+
+    def wait_for_listener(self):
+        '''drive the listener until it has accepted the connection
+
+        mavtcpin accepts inside recv(), so pumping recv() is how the accept is
+        driven through its own API. Its listening socket is non-blocking, so
+        this needs to be retried rather than called once.
+        '''
+        deadline = time.time() + self.TIMEOUT
+        while self.listener.port is None and time.time() < deadline:
+            self.listener.recv()
+            if self.listener.port is None:
+                time.sleep(0.01)
+        self.assertIsNotNone(self.listener.port,
+                             "listener did not accept within %.1fs" % self.TIMEOUT)
+
+    def recv_some(self, conn=None):
+        '''read until some data arrives or we run out of time'''
+        conn = conn if conn is not None else self.conn
+        deadline = time.time() + self.TIMEOUT
+        data = b""
+        while not data and time.time() < deadline:
+            data += conn.recv()
+            if not data:
+                time.sleep(0.01)
+        return data
+
+    def test_connect_sets_port_and_fd(self):
+        self.assertIsNotNone(self.conn.port)
+        self.assertEqual(self.conn.fd, self.conn.port.fileno())
+
+    def test_close_clears_port(self):
+        self.conn.close()
+        self.assertIsNone(self.conn.port)
+        # self.fd is deliberately not asserted on here: mavtcp does not maintain
+        # it across close()/do_connect(), and making that consistent (here and
+        # in the other mavfile subclasses) is a separate change.
+
+    def test_close_is_idempotent(self):
+        self.conn.close()
+        # second call must not raise now that self.port is already None
+        self.conn.close()
+        self.assertIsNone(self.conn.port)
+
+    def test_recv_after_close_reports_not_connected(self):
+        self.conn.close()
+        # close() nulls self.port and reconnect() is a no-op with
+        # autoreconnect=False, so there is no socket and nothing will reopen
+        # one. That is permanent, so it is reported rather than returned as
+        # b"" - which recv() uses for "no data right now, retry".
+        with self.assertRaises(OSError) as caught:
+            self.conn.recv()
+        self.assertEqual(caught.exception.errno, errno.ENOTCONN)
+        # ENOTCONN keeps errno inspectable; a bare ConnectionError would not
+        self.assertNotIsInstance(caught.exception, ConnectionError)
+
+    def test_recv_when_port_is_none(self):
+        # exercise the guard directly, without relying on close() being what
+        # produced the None. This is a unit test of _ensure_port() itself; the
+        # reachable route to this state is close(), covered above.
+        self.conn.port.close()
+        self.conn.port = None
+        with self.assertRaises(OSError) as caught:
+            self.conn.recv()
+        self.assertEqual(caught.exception.errno, errno.ENOTCONN)
+
+    def test_select_after_close_does_not_raise(self):
+        self.conn.close()
+        # self.fd is left holding a closed descriptor, so select.select()
+        # fails with EBADF; mavfile.select() catches that and reports "not
+        # readable" rather than propagating
+        self.assertFalse(self.conn.select(0))
+
+    def test_recv_receives_data(self):
+        self.wait_for_listener()
+        self.listener.write(b"hello")
+        self.assertEqual(self.recv_some(), b"hello")
+
+    def test_write_after_close_is_noop(self):
+        self.conn.close()
+        # must not raise; with autoreconnect=False there is nothing to write to
+        self.conn.write(b"test")
+
+    def test_autoreconnect_reestablishes_connection(self):
+        '''autoreconnect=True reconnects on recv() after the link is gone'''
+        # a plain socket listener rather than mavtcpin: this needs two
+        # successive server-side connections, and mavtcpin only tracks one at a
+        # time and re-accepts only after its own recv() hits an error. settimeout
+        # also makes accept() block up to TIMEOUT, so no polling is needed.
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.addCleanup(listener.close)
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        listener.bind(('127.0.0.1', 0))
+        listener.listen(2)
+        listener.settimeout(self.TIMEOUT)
+
+        conn = mavutil.mavlink_connection(
+            'tcp:127.0.0.1:%u' % listener.getsockname()[1], autoreconnect=True)
+        self.addCleanup(conn.close)
+        (first, _addr) = listener.accept()
+        self.addCleanup(first.close)
+
+        # drop the link from under it the way a peer restart would
+        conn.port.close()
+        conn.port = None
+
+        conn.recv()
+        self.assertIsNotNone(conn.port, "recv() should have reconnected")
+
+        (second, _addr) = listener.accept()
+        self.addCleanup(second.close)
+        second.send(b"again")
+        self.assertEqual(self.recv_some(conn), b"again")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
recv() called self.reconnect() when self.port was None, but reconnect() is a no-op unless autoreconnect=True was passed to the constructor. With the default autoreconnect=False, a lost connection left self.port as None and the very next self.port.recv(n) call crashed with AttributeError instead of a clear "no data" result.

write() already has this same guard a few lines down (checks self.port is None after attempting reconnect and returns early); recv() was just missing its equivalent.

Now returns b"" (matching the existing "no data available right now" convention on the EAGAIN/EWOULDBLOCK exception path a few lines below) when the socket is still unset after the reconnect attempt.

Done with Claude.
tested with 

```
#!/usr/bin/env python3

"""
test that mavtcp.recv() doesn't crash when the socket is gone and
autoreconnect is disabled (the default)
"""

import socket
import unittest

from pymavlink import mavutil


class MavtcpRecvNoAutoreconnectTest(unittest.TestCase):
    '''recv() must not raise when self.port is None and reconnect() is a no-op'''

    def test_recv_returns_empty_when_port_is_none(self):
        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
        listener.bind(('127.0.0.1', 0))
        listener.listen(1)
        port = listener.getsockname()[1]

        conn = mavutil.mavtcp('127.0.0.1:%d' % port, autoreconnect=False)
        try:
            # simulate a lost connection: no autoreconnect, so reconnect()
            # inside recv() is a no-op and self.port stays None
            conn.port.close()
            conn.port = None

            data = conn.recv()  # must not raise AttributeError
            self.assertEqual(data, b"")
        finally:
            conn.close()
            listener.close()


if __name__ == '__main__':
    unittest.main()

```