### PR TITLE
Fixing message reading in Ada

### DIFF
--- a/generator/Ada/mavlink-v1.adb
+++ b/generator/Ada/mavlink-v1.adb
@@ -230,8 +230,8 @@ package body MAVLink.V1 is
         Address => Incoming.In_Buf'Address;
       Last_Data : constant Positive := Incoming.In_Buf'First +
         Packet_Payload_First +
-          Natural (Header.Len - 1);
-      Last : constant Natural := Buffer'First + Natural (Header.Len - 1);
+          Natural (Header.Len) - 1;
+      Last : constant Natural := Buffer'First + Natural (Header.Len) - 1;
    begin
       Buffer (Buffer'First .. Last) := Incoming.In_Buf
         (Incoming.In_Buf'First + Packet_Payload_First .. Last_Data);

--- a/generator/Ada/v2/mavlink-v2.adb
+++ b/generator/Ada/v2/mavlink-v2.adb
@@ -123,8 +123,8 @@ package body MAVLink.V2 is
       if Incoming.Last = 0 then
          Incoming.Last := Incoming.Income_Buffer'First +
            Packet_Payload_First + --  header
-             Natural (Header.Len - 1) + --  data len
-           2; --  x25crc checksum
+             Natural (Header.Len) + --  data len
+           1; --  x25crc checksum
 
          if (Header.Inc_Flags and 1) > 0 then
             Incoming.Last := Incoming.Last + 13; --  SHA256 signature
@@ -411,7 +411,7 @@ package body MAVLink.V2 is
         Address => Incoming.Income_Buffer
           (Incoming.Income_Buffer'First +
              Packet_Payload_First +
-               Natural (Header.Len - 1) + 3)'Address;
+               Natural (Header.Len) + 2)'Address;
    begin
       if (Header.Inc_Flags and 1) > 0 then
          return Sig.Link_Id;
@@ -458,7 +458,7 @@ package body MAVLink.V2 is
          declare
             Last_Data   : constant Positive := Incoming.Income_Buffer'First +
               Packet_Payload_First +
-                Natural (Header.Len - 1);
+                Natural (Header.Len) - 1;
             Sig         : constant MAVLink.V2.MAV_Signature with Import,
               Address => Incoming.Income_Buffer (Last_Data + 3)'Address;
             Message_SHA : SHA_Digest;
@@ -649,16 +649,18 @@ package body MAVLink.V2 is
       Buffer   : out Data_Buffer;
       Last     : out Natural)
    is
-      Header    : constant V2_Header with Import,
+      Header     : constant V2_Header with Import,
         Address => Incoming.Income_Buffer'Address;
-      Last_Data : constant Positive := Incoming.Income_Buffer'First +
-        Packet_Payload_First +
-          Natural (Header.Len) - 1;
+      First_Data : constant Natural :=
+        Incoming.Income_Buffer'First +
+          Packet_Payload_First;
+      Len        : Natural;
    begin
-      Last := Buffer'First + Natural (Header.Len - 1);
+      Len  := Natural'Min (Natural (Header.Len), Buffer'Length);
+      Last := Buffer'First + Len - 1;
+
       Buffer (Buffer'First .. Last) := Incoming.Income_Buffer
-        (Incoming.Income_Buffer'First + Packet_Payload_First ..
-           Last_Data);
+        (First_Data .. First_Data + Len - 1);
    end Get_Message_Data;
 
    ----------------------
@@ -684,6 +686,36 @@ package body MAVLink.V2 is
    begin
       Get_Message_Data (Self.Incoming, Buffer, Last);
    end Get_Message_Data;
+
+   --------------------
+   -- Get_Msg_Length --
+   --------------------
+
+   function Get_Msg_Length (Incoming : Incoming_Data) return Interfaces.Unsigned_8
+   is
+      Header : constant V2_Header with Import,
+        Address => Incoming.Income_Buffer'Address;
+   begin
+      return Header.Len;
+   end Get_Msg_Length;
+
+   --------------------
+   -- Get_Msg_Length --
+   --------------------
+
+   function Get_Msg_Length (Self : Connection) return Interfaces.Unsigned_8 is
+   begin
+      return Get_Msg_Length (Self.Incoming);
+   end Get_Msg_Length;
+
+   --------------------
+   -- Get_Msg_Length --
+   --------------------
+
+   function Get_Msg_Length (Self : In_Connection) return Interfaces.Unsigned_8 is
+   begin
+      return Get_Msg_Length (Self.Incoming);
+   end Get_Msg_Length;
 
    ------------
    -- Encode --

--- a/generator/Ada/v2/mavlink-v2.ads
+++ b/generator/Ada/v2/mavlink-v2.ads
@@ -94,6 +94,8 @@ package MAVLink.V2 is
       return Boolean with Inline;
    --  Add the Value to the buffer and return True if a message has been read
    --  (collected all message data)
+   --  All methods that work with incoming data (like Get_*, Check_*) should be
+   --  called only when this method returned True.
 
    --  Get the message's information that is in the connection's buffer --
    procedure Get_Message_Information
@@ -121,6 +123,10 @@ package MAVLink.V2 is
       Comp_Id : out Component_Id_Type;
       Id      : out Msg_Id) with Inline;
    --  Same as above but do not check V2 signature
+
+   function Get_Msg_Length
+     (Self : Connection) return Interfaces.Unsigned_8 with Inline;
+   --  Returns length field from the packet header from the incoming buffer
 
    function Get_Message_Id (Self : Connection) return Msg_Id with Inline;
    --  Returns message's ID
@@ -188,6 +194,10 @@ package MAVLink.V2 is
       Sys_Id  : out System_Id_Type;
       Comp_Id : out Component_Id_Type;
       Id      : out Msg_Id) with Inline;
+
+   function Get_Msg_Length
+     (Self : In_Connection) return Interfaces.Unsigned_8 with Inline;
+   --  Returns length field from the packet header from the incoming buffer
 
    function Get_Message_Id (Self : In_Connection) return Msg_Id with Inline;
 
@@ -323,6 +333,9 @@ private
      (Self   : Connection;
       Buffer : out Data_Buffer;
       Last   : out Natural);
+   --  Copy data from the internal incoming buffer to Buffer,
+   --  and set Last to the index of the last copied byte.
+   --  Truncate the data if Buffer is too small to hold it all.
 
    -- In_Connection --
 
@@ -339,6 +352,9 @@ private
      (Self   : In_Connection;
       Buffer : out Data_Buffer;
       Last   : out Natural);
+   --  Copy data from the internal incoming buffer to Buffer,
+   --  and set Last to the index of the last copied byte.
+   --  Truncate the data if Buffer is too small to hold it all.
 
    -- Out_Connection --
 
@@ -387,6 +403,8 @@ private
       Link_Id   : out Link_Id_Type;
       Timestamp : out Timestamp_Type;
       Signature : out Three_Boolean);
+
+   function Get_Msg_Length (Incoming : Incoming_Data) return Interfaces.Unsigned_8;
 
    function Get_Message_Id (Incoming : Incoming_Data) return Msg_Id;
 

--- a/generator/mavgen_ada.py
+++ b/generator/mavgen_ada.py
@@ -572,27 +572,37 @@ def generate_message_methods(name, rev, spec, is_v1):
      (Message   : out {0};
       Connect   : {2}{1}.Connection;
       CRC_Valid : out Boolean);
-   --  Get the message from the Connect and delete it
-   --  from the Connect's buffer. CRC_Valid is set to
-   --  True if x25crc is valid for the message.
+   --  Get the message from the Connect if x25crc is valid and
+   --  set CRC_Valid to True.
+   --  Won't read data from the Connect if x25crc is False.
+   --  For v1: Won't read data from the Connect if message length mismatch
+   --    and set CRC_Valid to False in this case.
+   --  For v2: Truncate the extension fields.
 
    procedure Decode
      (Message : out {0};
       Connect : {1}.Connection);
-   --  Same as Above but does not check CRC
+   --  Get the message from the Connect.
+   --  For v1: May raise exception when message length mismatch
+   --  For v2: Truncate the extension fields.
 
    procedure Decode
      (Message   : out {0};
       Connect   : {2}{1}.In_Connection;
       CRC_Valid : out Boolean);
-   --  Get the message from the Connect and delete it
-   --  from the Connect's buffer. CRC_Valid is set to
-   --  True if x25crc is valid for the message.
+   --  Get the message from the Connect if x25crc is valid and
+   --  set CRC_Valid to True.
+   --  Won't read data from the Connect if x25crc is False.
+   --  For v1: Won't read data from the Connect if message length mismatch
+   --    and set CRC_Valid to False in this case.
+   --  For v2: Truncate the extension fields.
 
    procedure Decode
      (Message : out {0};
       Connect : {1}.In_Connection);
-   --  Same as Above but does not check CRC
+   --  Get the message from the Connect.
+   --  For v1: May raise an exception when message length mismatch
+   --  For v2: Truncate the extension fields.
 
    function Check_CRC
      (Connect : {2}{1}.Connection)
@@ -698,16 +708,21 @@ def generate_message_body_decode(name, rev, extra, body, is_v1, connection):
 """ % (name, mode, rev, connection))
 
     if is_v1:
-        body.write("""      Buf : Data_Buffer
-        (1 .. %s'Size / 8) := [others => 0]
-        with Address => Message'Address,
-        Convention   => Ada;
+        body.write("""      Buf : Data_Buffer (1 .. %s'Size / 8)
+        with Import,
+        Address    => Message'Address,
+        Convention => Ada;
    begin
-      pragma Assert
-        (Get_Msg_Len (Connect) =
-             Unsigned_8 (Integer (%s'Value_Size) / 8));
-      Get_Message_Data (Connect, Buf);
-      CRC_Valid := Check_CRC (Connect);
+      if Get_Msg_Len (Connect) =
+        Unsigned_8 (Integer (%s'Value_Size) / 8)
+      then
+         CRC_Valid := Check_CRC (Connect);
+         if CRC_Valid then
+            Get_Message_Data (Connect, Buf);
+         end if;
+      else
+         CRC_Valid := False;
+      end if;
 """ % (name, name))
     else:
         body.write("""      Data : Data_Buffer (1 .. %s'Value_Size / 8);
@@ -717,9 +732,11 @@ def generate_message_body_decode(name, rev, extra, body, is_v1, connection):
         with Address => Message'Address,
         Convention   => Ada;
    begin
-      Get_Message_Data (Connect, Data, Last);
-      Buf (1 .. Last) := Data (1 .. Last);
       CRC_Valid := Check_CRC (Connect);
+      if CRC_Valid then
+         Get_Message_Data (Connect, Data, Last);
+         Buf (1 .. Last) := Data (1 .. Last);
+      end if;
 """ % (name, name))
     body.write("""   end Decode;
 
@@ -1146,6 +1163,7 @@ pragma Warnings (Off); --  prevent "not used"
 with MAVLink.Raw_Floats;      use MAVLink.Raw_Floats;
 with MAVLink.Raw_Long_Floats; use MAVLink.Raw_Long_Floats;
 with MAVLink.SHA_256;
+with Interfaces;
 pragma Warnings (On);
 
 use MAVLink.V2;
@@ -1230,6 +1248,8 @@ is""");
    Buffer      : Data_Buffer (1 .. MAVLink.V2.Maximum_Buffer_Len);
    Last        : Positive;
 
+   use type Interfaces.Unsigned_8;
+
 begin
    Initialize (Sig,  1, Pass_Data, 200);
    Set_System_Id (In_Connect, 1);
@@ -1251,6 +1271,8 @@ begin
       Res := Parse_Byte (In_Connect, Hygrometer_Sensors_Data (Index));
    end loop;
    pragma Assert (Res);
+
+   pragma Assert (Get_Msg_Length (In_Connect) = 5);
 
    Get_Message_Information
      (In_Connect, Sig, Seq, Sys_Id, Comp_Id, Id, Link_Id, Timestamp, Signature);


### PR DESCRIPTION
Prevent exceptions when data is broken by checking the CRC before conversion.