### PR TITLE
DFReader.py: correct struct decode error in fast indexer on short item

### DIFF
--- a/DFReader.py
+++ b/DFReader.py
@@ -1332,6 +1332,8 @@ class DFReader_binary(DFReader):
         for ofs in offsets[fmt_type]:
             # Parse the FMT message
             body = data[ofs+3:ofs+fmt_fmt.len]
+            if len(body)+3 < fmt_fmt.len:
+                break
             elements = list(struct.unpack(fmt_fmt.msg_struct, body))
             ftype = elements[0]
             mfmt = DFFormat(


### PR DESCRIPTION
Fixes:

```
  Traceback (most recent call last):
    File "/tmp/trunc_raw.py", line 4, in <module>
      DFReader.DFReader_binary("/tmp/trunc.BIN", zero_time_base=True)
    File ".../pymavlink/DFReader.py", line 1136, in __init__
      self.init_arrays_fast(progress_callback=progress_callback)
    File ".../pymavlink/DFReader.py", line 1335, in init_arrays_fast
      elements = list(struct.unpack(fmt_fmt.msg_struct, body))
  struct.error: unpack requires a buffer of 86 bytes

  Compare against the one the sweep produced at p24, from GyroFFTAverage:

    File ".../arducopter.py", line 10040, in GyroFFTAverage
      psd = self.mavfft_fttd(1, 0, tstart * 1.0e6, tend * 1.0e6)
    File ".../vehicle_test_suite.py", line 18969, in mavfft_fttd
      mlog = self.dfreader_for_current_onboard_log()
    File ".../vehicle_test_suite.py", line 14425, in dfreader_for_path
      ret = DFReader.DFReader_binary(path, zero_time_base=True)
    File ".../pymavlink/DFReader.py", line 1136, in __init__
      self.init_arrays_fast(progress_callback=progress_callback)
    File ".../pymavlink/DFReader.py", line 1335, in init_arrays_fast
      elements = list(struct.unpack(fmt_fmt.msg_struct, body))
  struct.error: unpack requires a buffer of 86 bytes
```
