### PR TITLE
Make GoogleTest version compatible with C++11 / resolve errors running C++11 test on Ubuntu 24.04

### DIFF
--- a/generator/CPP11/test/posix/.gitignore
+++ b/generator/CPP11/test/posix/.gitignore
@@ -2,3 +2,4 @@
 /mavtest_ardupilotmega
 /mavtest_common
 /mavtest_uAvionix
+/.deps

--- a/generator/CPP11/test/posix/Makefile
+++ b/generator/CPP11/test/posix/Makefile
@@ -2,7 +2,11 @@
 CXX ?= g++
 CXXFLAGS ?= -std=c++11 -g -O0 -Wall -pthread
 GENDIR ?= ../../include_v2.0
-GTESTSRC ?= /usr/src/gtest/src/gtest-all.cc
+GTESTTAR := .deps/gtest-1.12.1.tar.gz
+GTESTURL := https://github.com/google/googletest/archive/refs/tags/release-1.12.1.tar.gz
+GTESTROOT ?= $(CURDIR)/.deps/googletest-release-1.12.1
+GTESTINC ?= -I$(GTESTROOT)/googletest/include -I$(GTESTROOT)/googletest
+GTESTSRC ?= $(GTESTROOT)/googletest/src/gtest-all.cc
 MSGDEFDIR ?= ../../../../../message_definitions/v1.0
 
 DIALECTS := $(notdir $(shell find $(GENDIR) -mindepth 1 -maxdepth 1 -type d))
@@ -10,13 +14,20 @@ TARGETS := $(foreach d,$(DIALECTS),mavtest_$(d))
 
 all: run_tests
 
+$(GTESTTAR):
+	mkdir -p $(dir $@)
+	curl -L -C - -o $@ $(GTESTURL)
+
+deps: $(GTESTTAR)
+	tar -xf $(GTESTTAR) -C .deps
+
 gtest-all.o: $(GTESTSRC)
-	$(CXX) $(CXXFLAGS) -I"$(dir $(GTESTSRC))../" -c -o $@ $<
+	$(CXX) $(CXXFLAGS) $(GTESTINC) -I"$(dir $(GTESTSRC))../" -c -o $@ $<
 
 mavtest_%: mtest.cpp gtest-all.o $(foreach d,$(DIALECTS),$(GENDIR)/$(d)/$(d).hpp)
-	$(CXX) $(CXXFLAGS) -I $(GENDIR)/$* -o $@ $< gtest-all.o
+	$(CXX) $(CXXFLAGS) $(GTESTINC) -I $(GENDIR)/$* -o $@ $< gtest-all.o
 
-run_tests: $(TARGETS)
+run_tests: deps $(TARGETS)
 	for f in $(TARGETS); do \
 		./$$f; \
 	done


### PR DESCRIPTION

## Problem Statement

While running test suites of generated C++11 code on recent OS versions of Ubuntu 24 or MacOS they fail with error like "googletest library requires at least C++14 standard".

I could not find any relevant issue so decided to go staright with the PR to fix that.

## Root Cause

It does not fail in CI because Ubuntu 22.04 runners are used:
[`.github/workflows/test.yml` line 12](https://github.com/ArduPilot/pymavlink/blob/master/.github/workflows/test.yml#L12)
```
runs-on: ubuntu-22.04
```

GoogleTest library is installed as libgtest-dev APT package:
[`.github/workflows/test.yml` line 31](https://github.com/ArduPilot/pymavlink/blob/master/.github/workflows/test.yml#L31)
```bash
sudo apt install -y libgtest-dev g++ tshark
```

Its Ubuntu 22.04 version is [1.11.0](https://launchpad.net/ubuntu/jammy/+package/libgtest-dev) and it supports C++11 standard.

Latest GoogleTest version to support C++11 is [1.12.1](https://github.com/google/googletest/releases#release-release-1.12.1).
```
This will be the last release to support C++11. Future releases will require at least C++14.
```

However running the same on Ubuntu 24.04 installs GoogleTest version 1.14.0 which explicitly requires C++14.
Same is happening on MacOS, brew googletest version is 1.18.0.

## Solution Design

C++ standard change seems too radical to me so I would suggest to decouple GoogleTest version from environment and download its sources (v1.12.1) during test suites runs.
This solution also works for MacOS (causing other issues with ARM compability but that's another topic).

The change also opens path to update CI runners to Ubuntu 24.04 (or even 26.04) as eventually 22.04 will reach EOL.

## Testing

Tested on clean Ubuntu 24.04 VM without libgtest-dev installed:

```bash
sudo apt install --yes build-essential
git clone https://github.com/ArduPilot/mavlink.git
ln -sf ./mavlink/message_definitions message_definitions
git clone https://github.com/garcia556/pymavlink.git
cd pymavlink
git switch make-gtest-portable-to-support-cpp11
git pull
./test_generator.sh
```
