### PR TITLE
mavparse: fix include filenames corrupted by chunked CDATA

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -331,6 +331,8 @@ class MAVXML(object):
             elif in_element == "mavlink.enums.enum.entry.deprecated":
                 check_attrs(attrs, ['since', 'replaced_by'], 'deprecated')
                 self.enum[-1].entry[-1].deprecated = MAVDeprecated(attrs['since'], attrs['replaced_by'])
+            elif in_element == "mavlink.include":
+                self.include.append('')
 
         def is_target_system_field(m, f):
             if f.name == 'target_system':
@@ -364,7 +366,7 @@ class MAVXML(object):
             elif in_element == "mavlink.version":
                 self.version = int(data)
             elif in_element == "mavlink.include":
-                self.include.append(data)
+                self.include[-1] += data
 
         f = open(filename, mode='rb')
         p = xml.parsers.expat.ParserCreate()


### PR DESCRIPTION
CI on mavlink/mavlink (and any branch built on top of it) currently fails for Python 3.x and Node jobs with:

```
FileNotFoundError: ... message_definitions/v1.0/marsh.xm
```

`mavgen` is trying to open `marsh.xm` (missing the trailing `l`) instead of `marsh.xml`.

For example: https://github.com/mavlink/mavlink/pull/2566

## Root cause

Parsing `message_definitions/v1.0/all.xml` with pymavlink's expat-based parser yields a corrupted include list:

```
x.include == [..., 'csAirLink.xml', 'marsh.xm', 'l', 'stemstudios.xml']
```

The text `marsh.xml` inside `<include>marsh.xml</include>` is being delivered to expat's `CharacterDataHandler` in two chunks — `"marsh.xm"` and `"l"` — because that text node happens to straddle expat's internal parser buffer boundary (default 2048 bytes). In `all.xml` the text node starts at byte offset 2040, so the split lands exactly at byte 2048.

`char_data()` in `generator/mavparse.py` has a bug for this case:

```python
elif in_element == "mavlink.include":
    self.include.append(data)   # should accumulate, not append a new entry
```

Every other text accumulator in that function correctly merges chunks with `+=` (e.g. `self.message[-1].description += data`), but the include-file case blindly appends each chunk as a separate list entry. When a filename happens to be split across two `CharacterDataHandler` calls, it silently corrupts into two bogus include entries instead of one filename.

This was a latent bug — it only started tripping on `all.xml` because a recent edit to the include list shrank the file by just enough bytes to push the `marsh.xml` include text onto the 2048-byte boundary for the first time.

## Fix

Mirror the pattern used by every other accumulator in `char_data()`: seed a fresh `''` entry in `self.include` on `mavlink.include` element start, then accumulate into `self.include[-1]` instead of appending each chunk as a new entry.

```diff
+            elif in_element == "mavlink.include":
+                self.include.append('')
...
             elif in_element == "mavlink.include":
-                self.include.append(data)
+                self.include[-1] += data
```

## Testing

Reproduced the corruption directly with `MAVXML('message_definitions/v1.0/all.xml')` before the fix (`marsh.xml` split into `marsh.xm` + `l`), confirmed it's fixed after, and ran `mavgen` end-to-end against `all.xml`, which now correctly parses all 18 included XML files (including `marsh.xml` and `loweheiser.xml`) and generates 390 message types with no errors.