### PR TITLE
mavftp: return from process_ftp_reply on read completion

### DIFF
--- a/mavftp.py
+++ b/mavftp.py
@@ -15,6 +15,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import os
+import tempfile
 import random
 import struct
 import sys
@@ -377,7 +378,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.list_temp_result: List[DirectoryEntry] = []
         self.requested_size: int = 0
         self.requested_offset: int = 0
-        self.temp_filename = "/tmp/temp_mavftp_file"
+        # set per-download by __handle_open_ro_reply: a securely
+        # created unique staging file, so concurrent MAVFTP clients on
+        # one host (e.g. parallel simulator test runners) cannot share
+        # a staging file and its name is not predictable
+        self.temp_filename = None
+        # only close file handles this instance opened itself; cmd_put
+        # stores a caller-owned handle in self.fh
+        self.fh_owned = False
 
         self.master = master
         self.target_system = target_system
@@ -441,12 +449,29 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.last_op_time = time.time()
         self.last_send_time = now
 
+    def __release_staging(self) -> None:
+        """Close and remove this instance's own staging resources.
+        Caller-owned handles (cmd_put's fh argument) are left alone."""
+        if self.fh is not None and self.fh_owned:
+            try:
+                self.fh.close()
+            except OSError:
+                pass
+        self.fh_owned = False
+        if self.temp_filename is not None:
+            try:
+                os.unlink(self.temp_filename)
+            except OSError:
+                pass
+            self.temp_filename = None
+
     def __terminate_session(self) -> None:
         """Terminate current session."""
         self.pending_terminate_seq = self.seq
         self.__send(
             FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None)
         )
+        self.__release_staging()
         self.fh = None
         self.filename = None
         self.write_list = None
@@ -670,7 +695,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 if self.callback is not None or self.filename == "-":
                     self.fh = SIO()
                 else:
-                    self.fh = open(self.temp_filename, "wb+")  # noqa: SIM115 pylint: disable=consider-using-with
+                    self.__release_staging()
+                    (temp_fd, self.temp_filename) = tempfile.mkstemp(prefix="mavftp_")
+                    try:
+                        self.fh = os.fdopen(temp_fd, "wb+")
+                    except OSError:
+                        os.close(temp_fd)
+                        raise
+                    self.fh_owned = True
                     self.fh.truncate(0)
                     self.fh.seek(self.requested_offset)
                     read = FTP_OP(
@@ -762,14 +794,17 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 )
             logging.info("read %u bytes", len(self.get_result))
             self.fh.flush()
-            self.fh.close()
-            if self.filename:
-                # Move the result to the final location
-                logging.info("Moving %s to %s", self.temp_filename, self.filename)
-                with open(self.filename, "wb") as final_file:
-                    final_file.write(self.get_result)
-            self.__terminate_session()
-            self.read_complete = True
+            try:
+                if self.filename and self.filename != "-":
+                    # Move the result to the final location
+                    logging.info("Moving %s to %s", self.temp_filename, self.filename)
+                    with open(self.filename, "wb") as final_file:
+                        final_file.write(self.get_result)
+            finally:
+                # terminate the remote session and release the staging
+                # file even when the destination cannot be written
+                self.__terminate_session()
+                self.read_complete = True
             return True
         return False
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -354,6 +354,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.last_send_time = time.time()
         self.rtt = 0.5
         self.reached_eof = False
+        self.read_complete = False
+        # sequence numbers of in-flight terminate/reset requests, None
+        # when nothing is outstanding: replies are correlated by
+        # sequence so a stale or duplicated reply from an earlier
+        # request cannot mark the current one complete
+        self.pending_terminate_seq = None
+        self.pending_reset_seq = None
         self.backlog = 0
         self.burst_size: int = int(self.ftp_settings.burst_read_size)
         self.write_list: Union[None, Set[int]] = None
@@ -379,6 +386,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.done = False
 
         # Reset the flight controller FTP state-machine
+        self.pending_reset_seq = self.seq
         self.__send(FTP_OP(self.seq, self.session, OP_ResetSessions, 0, 0, 0, 0, None))
         self.process_ftp_reply("ResetSessions")
 
@@ -435,6 +443,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def __terminate_session(self) -> None:
         """Terminate current session."""
+        self.pending_terminate_seq = self.seq
         self.__send(
             FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None)
         )
@@ -760,6 +769,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 with open(self.filename, "wb") as final_file:
                     final_file.write(self.get_result)
             self.__terminate_session()
+            self.read_complete = True
             return True
         return False
 
@@ -1301,6 +1311,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.req_opcode == OP_ResetSessions:
             return self.__handle_reset_sessions_reply(op, m)
         if op.req_opcode in {OP_None, OP_TerminateSession}:
+            if (
+                op.req_opcode == OP_TerminateSession
+                and self.pending_terminate_seq is not None
+                and op.seq == (self.pending_terminate_seq + 1) % 256
+            ):
+                # Ack or Nack (InvalidSession means it was already
+                # closed): the handshake has been answered
+                self.pending_terminate_seq = None
             return MAVFTPReturn(operation_name, FtpError.Success)  # ignore reply
         if op.req_opcode == OP_CreateFile:
             return self.__handle_create_file_reply(op, m)
@@ -1454,6 +1472,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def __handle_reset_sessions_reply(self, op: FTP_OP, _m) -> MAVFTPReturn:
         """Handle reset sessions reply."""
+        if (
+            self.pending_reset_seq is not None
+            and op.seq == (self.pending_reset_seq + 1) % 256
+        ):
+            # Ack or Nack, the handshake has been answered; the decoded
+            # result below still reports a Nack to the caller
+            self.pending_reset_seq = None
         return self.__decode_ftp_ack_and_nack(op)
 
     def process_ftp_reply(
@@ -1470,16 +1495,47 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             "recv_timeout must be < settings.retry_time"
         )  # noqa: S101
 
+        # A read operation reports its completion positively: EOF seen
+        # with no gaps outstanding (__check_read_finished).  Return as
+        # soon as the transfer and its session-terminate handshake are
+        # both done instead of waiting out idle_detection_time of link
+        # silence - on a fast or simulated link the quiet-period tail
+        # dwarfs the transfer itself.  The flag is only ever set while a
+        # reply-processing loop runs (this one, or read()'s own driver
+        # loop, which does not use this method), so clearing it here
+        # cannot lose a completion; idle detection remains the fallback for a lost
+        # terminate reply and for operations with no positive
+        # completion signal.
+        self.read_complete = False
         while True:  # an FTP operation can have multiple responses
             m = self.master.recv_match(
                 type=["FILE_TRANSFER_PROTOCOL"], timeout=recv_timeout
             )
             if m is not None:
                 if operation_name == "TerminateSession":
-                    # self.silently_discard_terminate_session_reply()
-                    ret = MAVFTPReturn(operation_name, FtpError.Success)
+                    # consume only the terminate reply itself: stale
+                    # replies from the aborted transfer must not reach
+                    # their handlers, which can re-enter
+                    # __terminate_session from this very wait
+                    op = self.__op_parse(m)
+                    if (
+                        op.req_opcode == OP_TerminateSession
+                        and self.pending_terminate_seq is not None
+                        and op.seq == (self.pending_terminate_seq + 1) % 256
+                    ):
+                        self.pending_terminate_seq = None
+                        ret = MAVFTPReturn(operation_name, FtpError.Success)
                 else:
                     ret = self.__mavlink_packet(m)
+            if self.pending_terminate_seq is None and (
+                self.read_complete
+                or operation_name == "TerminateSession"
+                or (
+                    operation_name == "ResetSessions"
+                    and self.pending_reset_seq is None
+                )
+            ):
+                break
             if self.__idle_task():
                 break
             if timeout > 0 and time.time() - start_time > timeout:  # pylint: disable=chained-comparison


### PR DESCRIPTION
A read reports its completion positively - EOF seen with no gaps outstanding (__check_read_finished) - but the synchronous process_ftp_reply wrapper never consulted that: its only exit was idle detection, waiting out idle_detection_time (3.7s) of link silence after the transfer.  On a fast or simulated link the quiet-period tail dwarfs the transfer: fetching @PARAM/param.pck from SITL takes 3.72s of which the transfer itself is 27ms.

The nested process_ftp_reply("TerminateSession") inside __terminate_session was the actual site of the wait, and its special-case discarded replies unparsed, so the terminate ack could never be recognised.  Route those replies through the normal packet handler, track the in-flight terminate with a pending_terminate flag, and return as soon as the read has completed and its session-terminate handshake has been acknowledged.  Idle detection remains the fallback for a lost terminate reply on a lossy link, and the exit for operations with no positive completion signal.

The completion signal has existed since the module was derived from MAVProxy's event-driven mavproxy_ftp (which completes immediately on it, and has no idle detection at all); the synchronous wrapper introduced in 50a291ad0 left it unwired, and 47824938b later raised the idle time from 1.2s to 3.7s.

Measured against ArduPilot SITL, three consecutive gets of @PARAM/param.pck (15580 bytes, 1408 parameters, all decoded correctly): 3.72s each before, 0.027s each after.