### PR TITLE
Backport mavftp fixes from AMC: harden MAVFTP transfers, validation, and cleanup

### DIFF
--- a/mavftp.py
+++ b/mavftp.py
@@ -336,6 +336,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.fh: Union[None, SIO, BufferedReader, BufferedWriter, BufferedRandom] = None
         self.filename: Union[None, str] = None
         self.callback = None
+        self.callback_failure: Optional[MAVFTPReturn] = None
         self.callback_progress = None
         self.put_callback = None
         self.put_callback_progress = None
@@ -356,6 +357,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.rtt = 0.5
         self.reached_eof = False
         self.read_complete = False
+        # Set by operations with an explicit successful terminal reply.
+        # Unlike read_complete, these operations do not need a session-close
+        # handshake to prove their result to process_ftp_reply().
+        self.operation_complete = False
         # sequence numbers of in-flight terminate/reset requests, None
         # when nothing is outstanding: replies are correlated by
         # sequence so a stale or duplicated reply from an earlier
@@ -504,6 +509,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def cmd_list(self, args: List[str]) -> MAVFTPReturn:
         """List files."""
+        self.operation_complete = False
         self.list_result = []
         self.list_temp_result = []
         if len(args) == 0:
@@ -570,6 +576,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             and op.payload[0] == FtpError.EndOfFile
         ):
             self.list_result = self.list_temp_result
+            self.operation_complete = True
             return MAVFTPReturn(
                 "ListDirectory", FtpError.Success, directory_listing=self.list_result
             )
@@ -661,6 +668,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if len(args) == 0 or len(args) > 2:
             logging.error("Usage: get [FILENAME <LOCALNAME>]")
             return MAVFTPReturn("OpenFileRO", FtpError.InvalidArguments)
+        self.operation_complete = False
         fname = args[0]
         if len(args) > 1:
             self.filename = args[1]
@@ -670,6 +678,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info("Getting %s to %s", fname, self.filename)
         self.op_start = time.time()
         self.callback = callback
+        self.callback_failure = None
         self.callback_progress = progress_callback
         self.read_retries = 0
         self.duplicates = 0
@@ -758,9 +767,16 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             ofs = self.fh.tell()
             dt = time.time() - self.op_start
             rate = (ofs / dt) / 1024.0
+            publish_result = True
             if self.callback is not None:
                 self.fh.seek(0)
-                self.callback(self.fh)
+                callback_result = self.callback(self.fh)
+                if (
+                    isinstance(callback_result, MAVFTPReturn)
+                    and callback_result.error_code != FtpError.Success
+                ):
+                    self.callback_failure = callback_result
+                    publish_result = False
                 self.callback = None
             elif self.filename == "-":
                 self.fh.seek(0)
@@ -795,7 +811,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info("read %u bytes", len(self.get_result))
             self.fh.flush()
             try:
-                if self.filename and self.filename != "-":
+                if publish_result and self.filename and self.filename != "-":
                     # Move the result to the final location
                     logging.info("Moving %s to %s", self.temp_filename, self.filename)
                     with open(self.filename, "wb") as final_file:
@@ -1001,6 +1017,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.write_list is not None:
             logging.error("FTP: put already in progress")
             return MAVFTPReturn("CreateFile", FtpError.PutAlreadyInProgress)
+        self.operation_complete = False
         fname = args[0]
         self.fh = fh
         if self.fh is None:
@@ -1086,6 +1103,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             # all done
             self.__put_finished(self.write_file_size)
             self.__terminate_session()
+            self.operation_complete = True
             return
 
         now = time.time()
@@ -1562,8 +1580,16 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         ret = MAVFTPReturn(operation_name, FtpError.Success)
                 else:
                     ret = self.__mavlink_packet(m)
+                if (
+                    self.callback_failure is not None
+                    and operation_name != "TerminateSession"
+                ):
+                    callback_failure = self.callback_failure
+                    self.callback_failure = None
+                    return callback_failure
             if self.pending_terminate_seq is None and (
                 self.read_complete
+                or self.operation_complete
                 or operation_name == "TerminateSession"
                 or (
                     operation_name == "ResetSessions"
@@ -1812,10 +1838,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 data = fh.read()
             except OSError as exp:
                 logging.error("FTP: Failed to read file param.pck: %s", exp)
-                sys.exit(1)
+                return MAVFTPReturn("GetParams", FtpError.Fail)
             pdata = MAVFTP.ftp_param_decode(data)
             if pdata is None:
-                sys.exit(1)
+                logging.error("FTP: Failed to decode parameter file param.pck")
+                return MAVFTPReturn("GetParams", FtpError.Fail)
 
             param_values = MAVFTP.extract_params(pdata.params, sort_type)
             param_defaults = MAVFTP.extract_params(pdata.defaults, sort_type)
@@ -2244,6 +2271,7 @@ def main() -> None:
     if args.command in {"get", "put", "getparams"}:
         ret = mav_ftp.process_ftp_reply(args.command, timeout=500)
 
+    exit_code = 1
     if isinstance(ret, str):
         logging.error(
             "Command returned: %s, but it should return a MAVFTPReturn instead", ret
@@ -2251,6 +2279,7 @@ def main() -> None:
     elif isinstance(ret, MAVFTPReturn):
         if ret.error_code or args.command in {"list"}:
             ret.display_message()
+        exit_code = 0 if ret.error_code == FtpError.Success else 1
     elif ret is None:
         logging.error(
             "Command returned: None, but it should return a MAVFTPReturn instead"
@@ -2261,6 +2290,7 @@ def main() -> None:
         )
 
     master.close()
+    sys.exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/mavftp.py
+++ b/mavftp.py
@@ -791,6 +791,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info("Getting %s to %s", fname, self.filename)
         self.op_start = time.time()
         self.read_to_memory = False
+        self.requested_offset = 0
+        self.requested_size = 0
         self.callback = callback
         self.callback_failure = None
         self.callback_progress = progress_callback

--- a/mavftp.py
+++ b/mavftp.py
@@ -397,6 +397,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.list_temp_result: List[DirectoryEntry] = []
         self.requested_size: int = 0
         self.requested_offset: int = 0
+        # The synchronous read/read_sector API returns data to its caller and
+        # must never publish a file named after the remote path.
+        self.read_to_memory = False
         # set per-download by __handle_open_ro_reply: a securely
         # created unique staging file, so concurrent MAVFTP clients on
         # one host (e.g. parallel simulator test runners) cannot share
@@ -505,6 +508,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.__release_staging()
         self.fh = None
         self.filename = None
+        self.read_to_memory = False
         self.write_list = None
         if self.callback is not None:
             # tell caller that the transfer failed
@@ -642,6 +646,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.requested_offset = offset
         self.requested_size = size
         self.filename = path
+        self.read_to_memory = True
+        self.callback = None
+        self.callback_failure = None
+        self.callback_progress = None
         self.done = False
 
         logging.info(
@@ -726,6 +734,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if callback is None or self.ftp_settings.debug > 1:
             logging.info("Getting %s to %s", fname, self.filename)
         self.op_start = time.time()
+        self.read_to_memory = False
         self.callback = callback
         self.callback_failure = None
         self.callback_progress = progress_callback
@@ -751,8 +760,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 return MAVFTPReturn("OpenFileRO", FtpError.FileNotFound)
             self.session = op.session
             try:
-                if self.callback is not None or self.filename == "-":
+                if self.callback is not None or self.filename == "-" or self.read_to_memory:
                     self.fh = SIO()
+                    if self.read_to_memory:
+                        self.fh.seek(self.requested_offset)
                 else:
                     self.__release_staging()
                     (temp_fd, self.temp_filename) = tempfile.mkstemp(prefix="mavftp_")
@@ -764,16 +775,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     self.fh_owned = True
                     self.fh.truncate(0)
                     self.fh.seek(self.requested_offset)
-                    read = FTP_OP(
-                        self.seq,
-                        self.session,
-                        OP_BurstReadFile,
-                        self.burst_size,
-                        0,
-                        0,
-                        self.requested_offset,
-                        None,
-                    )
             except Exception as ex:  # pylint: disable=broad-except
                 logging.error(
                     "FTP: Failed to open local file %s: %s", self.filename, ex
@@ -789,11 +790,19 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 )
                 if self.ftp_settings.debug > 0:
                     logging.info("Remote file size: %u", self.remote_file_size)
-                self.requested_size = self.remote_file_size
+                if not self.read_to_memory:
+                    self.requested_size = self.remote_file_size
             else:
                 self.remote_file_size = 0
             read = FTP_OP(
-                self.seq, self.session, OP_BurstReadFile, self.burst_size, 0, 0, 0, None
+                self.seq,
+                self.session,
+                OP_BurstReadFile,
+                self.burst_size,
+                0,
+                0,
+                self.requested_offset if self.read_to_memory else 0,
+                None,
             )
             self.last_burst_read = time.time()
             self.__send(read)
@@ -831,6 +840,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 ):
                     self.callback_failure = callback_result
                 self.callback = None
+            elif self.read_to_memory:
+                publish_result = False
+                self.done = True
             elif self.filename == "-":
                 self.fh.seek(0)
             else:

--- a/mavftp.py
+++ b/mavftp.py
@@ -14,6 +14,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 # FLAKE_CLEAN
 
 import logging
+import math
 import os
 import tempfile
 import random
@@ -715,6 +716,55 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.error("Invalid parameter value: %s", args[1])
             return MAVFTPReturn("Set", FtpError.InvalidArguments)
 
+        setting = self.ftp_settings._vars[setting_name]  # pylint: disable=protected-access
+        if not math.isfinite(setting_value):
+            logging.error("Invalid parameter value: %s", args[1])
+            return MAVFTPReturn("Set", FtpError.InvalidArguments)
+        if setting.type is int:
+            if not setting_value.is_integer():
+                logging.error("Invalid integer parameter value: %s", args[1])
+                return MAVFTPReturn("Set", FtpError.InvalidArguments)
+            setting_value = int(setting_value)
+
+        bounded_settings = {
+            "debug": (0, 2),
+            "pkt_loss_tx": (0, 100),
+            "pkt_loss_rx": (0, 100),
+            "max_backlog": (1, None),
+            "burst_read_size": (1, MAX_Payload),
+            "write_size": (1, MAX_Payload),
+            "write_qsize": (1, None),
+            "read_retry_time": (0, None),
+            "retry_time": (0.1, None),
+        }
+        minimum, maximum = bounded_settings.get(setting_name, (None, None))
+        if (
+            (minimum is not None and setting_value <= minimum and setting_name == "retry_time")
+            or (minimum is not None and setting_value < minimum)
+            or (maximum is not None and setting_value > maximum)
+        ):
+            logging.error("Invalid value for %s: %s", setting_name, setting_value)
+            return MAVFTPReturn("Set", FtpError.InvalidArguments)
+
+        idle_detection_time = (
+            setting_value
+            if setting_name == "idle_detection_time"
+            else self.ftp_settings.idle_detection_time
+        )
+        read_retry_time = (
+            setting_value
+            if setting_name == "read_retry_time"
+            else self.ftp_settings.read_retry_time
+        )
+        if setting_name == "idle_detection_time" and setting_value <= 0:
+            logging.error("Invalid value for %s: %s", setting_name, setting_value)
+            return MAVFTPReturn("Set", FtpError.InvalidArguments)
+        if idle_detection_time <= read_retry_time:
+            logging.error(
+                "idle_detection_time must be greater than read_retry_time"
+            )
+            return MAVFTPReturn("Set", FtpError.InvalidArguments)
+
         setattr(self.ftp_settings, setting_name, setting_value)
         logging.info("Set %s = %s", setting_name, setting_value)
         return MAVFTPReturn("Set", FtpError.Success)
@@ -1105,6 +1155,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.write_list is not None:
             logging.error("FTP: put already in progress")
             return MAVFTPReturn("CreateFile", FtpError.PutAlreadyInProgress)
+        self.write_block_size = int(self.ftp_settings.write_size)
+        if not 1 <= self.write_block_size <= MAX_Payload:
+            logging.error("FTP: write_size must be between 1 and %u", MAX_Payload)
+            return MAVFTPReturn("CreateFile", FtpError.InvalidArguments)
+        if self.ftp_settings.write_qsize < 1:
+            logging.error("FTP: write_qsize must be at least 1")
+            return MAVFTPReturn("CreateFile", FtpError.InvalidArguments)
         fname = args[0]
         self.fh = fh
         self.fh_owned = False
@@ -1128,7 +1185,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.fh.seek(0)
 
         # setup write list
-        self.write_block_size = int(self.ftp_settings.write_size)
         self.write_file_size = file_size
 
         write_blockcount = file_size // self.write_block_size

--- a/mavftp.py
+++ b/mavftp.py
@@ -1985,7 +1985,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     @staticmethod
     def missionplanner_sort(item: str) -> Tuple[str, ...]:
         """Sorts a parameter name according to the rules defined in the Mission Planner software."""
-        return Tuple(item.split("_"))
+        return tuple(item.split("_"))
 
     @staticmethod
     def extract_params(
@@ -1998,13 +1998,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 pdict[name.decode("utf-8")] = (value, ptype)
 
             if sort_type == "missionplanner":
-                pdict = Dict(
+                pdict = dict(
                     sorted(
                         pdict.items(), key=lambda x: MAVFTP.missionplanner_sort(x[0])
                     )
                 )  # sort alphabetically
             elif sort_type == "mavproxy":
-                pdict = Dict(sorted(pdict.items()))  # sort in ASCIIbetical order
+                pdict = dict(sorted(pdict.items()))  # sort in ASCIIbetical order
             elif sort_type == "none":
                 pass
         return pdict

--- a/mavftp.py
+++ b/mavftp.py
@@ -343,6 +343,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.total_size = 0
         self.read_gaps: List[Tuple[int, int]] = []
         self.read_gap_times: Dict[Tuple[int, int], float] = {}
+        # FTP permits several ReadFile requests in flight. Track their
+        # expected response sequences so delayed replies from a prior request
+        # cannot be dispatched as a current gap repair.
+        self.pending_read_replies: Dict[int, Tuple[int, int]] = {}
         self.last_gap_send = 0.0
         self.read_retries = 0
         self.read_total = 0
@@ -350,6 +354,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.duplicates = 0
         self.last_read = None
         self.last_burst_read: Union[None, float] = None
+        # The start offset of the active burst. Burst packets are streamed
+        # with advancing sequence numbers, so their offsets identify whether
+        # they belong to the current burst after a new burst is requested.
+        self.pending_burst_offset: Optional[int] = None
         self.op_start: Union[None, float] = None
         self.dir_offset = 0
         self.last_op_time = time.time()
@@ -357,10 +365,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.rtt = 0.5
         self.reached_eof = False
         self.read_complete = False
-        # Set by operations with an explicit successful terminal reply.
-        # Unlike read_complete, these operations do not need a session-close
-        # handshake to prove their result to process_ftp_reply().
-        self.operation_complete = False
+        # Explicit terminal reply, identified by (request opcode, reply
+        # sequence). A boolean here lets a delayed reply from an earlier
+        # operation complete whichever command is currently waiting.
+        self.completed_reply: Optional[Tuple[int, int]] = None
         # sequence numbers of in-flight terminate/reset requests, None
         # when nothing is outstanding: replies are correlated by
         # sequence so a stale or duplicated reply from an earlier
@@ -377,6 +385,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.write_idx = 0
         self.write_recv_idx = -1
         self.write_pending = 0
+        # Uploads have several WriteFile requests in flight. Map each
+        # response sequence to its requested offset.
+        self.pending_write_replies: Dict[int, int] = {}
         self.write_last_send: Union[None, float] = None
         self.open_retries = 0
         self.list_result: List[DirectoryEntry] = []
@@ -446,7 +457,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.master.mav.file_transfer_protocol_send(
             self.network, self.target_system, self.target_component, payload
         )
-        self.seq = (self.seq + 1) % 256
+        expected_reply_seq = (op.seq + 1) % 65536
+        if op.opcode == OP_BurstReadFile:
+            self.pending_burst_offset = op.offset
+        elif op.opcode == OP_ReadFile:
+            self.pending_read_replies[expected_reply_seq] = (op.offset, op.size)
+        elif op.opcode == OP_WriteFile:
+            self.pending_write_replies[expected_reply_seq] = op.offset
+        self.seq = (self.seq + 1) % 65536
         self.last_op = op
         now = time.time()
         if self.ftp_settings.debug > 1:
@@ -497,11 +515,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.read_gaps = []
         self.read_total = 0
         self.read_gap_times = {}
+        self.pending_read_replies = {}
         self.last_read = None
         self.last_burst_read = None
+        self.pending_burst_offset = None
         self.reached_eof = False
         self.backlog = 0
         self.duplicates = 0
+        self.pending_write_replies = {}
         if self.ftp_settings.debug > 0:
             logging.info("FTP: Terminated session")
         self.process_ftp_reply("TerminateSession")
@@ -509,7 +530,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def cmd_list(self, args: List[str]) -> MAVFTPReturn:
         """List files."""
-        self.operation_complete = False
         self.list_result = []
         self.list_temp_result = []
         if len(args) == 0:
@@ -576,7 +596,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             and op.payload[0] == FtpError.EndOfFile
         ):
             self.list_result = self.list_temp_result
-            self.operation_complete = True
+            self.completed_reply = (op.req_opcode, op.seq)
             return MAVFTPReturn(
                 "ListDirectory", FtpError.Success, directory_listing=self.list_result
             )
@@ -668,7 +688,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if len(args) == 0 or len(args) > 2:
             logging.error("Usage: get [FILENAME <LOCALNAME>]")
             return MAVFTPReturn("OpenFileRO", FtpError.InvalidArguments)
-        self.operation_complete = False
         fname = args[0]
         if len(args) > 1:
             self.filename = args[1]
@@ -916,6 +935,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                             time.time() - self.op_start,
                         )
                     self.reached_eof = True
+                    self.pending_burst_offset = None
                     if self.__check_read_finished():
                         return MAVFTPReturn("BurstReadFile", FtpError.Success)
                     self.__check_read_send()
@@ -952,6 +972,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         time.time() - self.op_start,
                     )
                 self.reached_eof = True
+                self.pending_burst_offset = None
                 if self.__check_read_finished():
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
                 self.__check_read_send()
@@ -960,12 +981,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 logging.error("FTP: burst nack: %s", op)
             self.__terminate_session()
             return nack_result
-        else:
-            logging.warning("FTP: burst error: %s", op)
+        logging.warning("FTP: burst error: %s", op)
         return MAVFTPReturn("BurstReadFile", FtpError.Fail)
 
     def __handle_reply_read(self, op: FTP_OP, _m) -> MAVFTPReturn:
         """Handle OP_ReadFile reply."""
+        self.pending_read_replies.pop(op.seq, None)
         if self.fh is None or self.filename is None:
             if self.ftp_settings.debug > 0:
                 logging.warning("FTP: Unexpected read reply")
@@ -978,6 +999,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if gap in self.read_gaps:
                 self.read_gaps.remove(gap)
                 self.read_gap_times.pop(gap)
+                self.pending_read_replies = {
+                    seq: pending_gap
+                    for seq, pending_gap in self.pending_read_replies.items()
+                    if pending_gap != gap
+                }
                 ofs = self.fh.tell()
                 self.__write_payload(op)
                 self.fh.seek(ofs)
@@ -1015,7 +1041,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.write_list is not None:
             logging.error("FTP: put already in progress")
             return MAVFTPReturn("CreateFile", FtpError.PutAlreadyInProgress)
-        self.operation_complete = False
         fname = args[0]
         self.fh = fh
         self.fh_owned = False
@@ -1090,20 +1115,24 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             self.__terminate_session()
             return MAVFTPReturn("CreateFile", FtpError.FileNotFound)
         if op.opcode == OP_Ack:
-            self.__send_more_writes()
+            self.__send_more_writes(op)
         else:
             ret = self.__decode_ftp_ack_and_nack(op)
             self.__terminate_session()
             return ret
         return MAVFTPReturn("CreateFile", FtpError.Success)
 
-    def __send_more_writes(self) -> None:
+    def __send_more_writes(self, completed_reply: Optional[FTP_OP] = None) -> None:
         """Send some more writes."""
         if self.write_list is None or len(self.write_list) == 0:
             # all done
             self.__put_finished(self.write_file_size)
             self.__terminate_session()
-            self.operation_complete = True
+            if completed_reply is not None:
+                self.completed_reply = (
+                    completed_reply.req_opcode,
+                    completed_reply.seq,
+                )
             return
 
         now = time.time()
@@ -1141,6 +1170,13 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def __handle_write_reply(self, op: FTP_OP, _m) -> MAVFTPReturn:
         """Handle OP_WriteFile reply."""
+        expected_offset = self.pending_write_replies.pop(op.seq, None)
+        if expected_offset is not None:
+            self.pending_write_replies = {
+                seq: offset
+                for seq, offset in self.pending_write_replies.items()
+                if offset != expected_offset
+            }
         if self.fh is None:
             self.__terminate_session()
             return MAVFTPReturn("WriteFile", FtpError.FileNotFound)
@@ -1161,7 +1197,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.write_acks += 1
         if self.put_callback_progress:
             self.put_callback_progress(self.write_acks / float(self.write_total))
-        self.__send_more_writes()
+        self.__send_more_writes(op)
         return MAVFTPReturn("WriteFile", FtpError.Success)
 
     def cmd_rm(self, args: List[str]) -> MAVFTPReturn:
@@ -1308,6 +1344,27 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             seq, session, opcode, size, req_opcode, burst_complete, offset, payload
         )
 
+    def __reply_matches_active_request(self, op: FTP_OP) -> bool:
+        """Return whether a reply can safely be dispatched to the active operation."""
+        if op.req_opcode == OP_BurstReadFile:
+            return (
+                self.pending_burst_offset is not None
+                and op.offset >= self.pending_burst_offset
+            )
+        if op.req_opcode == OP_ReadFile:
+            return op.seq in self.pending_read_replies
+        if op.req_opcode == OP_WriteFile:
+            return op.seq in self.pending_write_replies
+
+        if (
+            self.last_op is not None
+            and op.req_opcode == self.last_op.opcode
+            and op.seq == (self.last_op.seq + 1) % 65536
+        ):
+            return True
+
+        return False
+
     def __mavlink_packet(self, m) -> MAVFTPReturn:  # noqa: PLR0911, PGH004, pylint: disable=too-many-branches, too-many-return-statements
         """Handle a mavlink packet."""
         operation_name = "mavlink_packet"
@@ -1349,9 +1406,15 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 logging.warning("FTP: dropping packet RX")
             return MAVFTPReturn(operation_name, FtpError.Fail)
 
+        if not self.__reply_matches_active_request(op):
+            if self.ftp_settings.debug > 0:
+                logging.warning("FTP: stale reply. Will discard message: %s", op)
+            return MAVFTPReturn(operation_name, FtpError.Fail)
+
         if (
-            op.req_opcode == self.last_op.opcode
-            and op.seq == (self.last_op.seq + 1) % 256
+            self.last_op is not None
+            and op.req_opcode == self.last_op.opcode
+            and op.seq == (self.last_op.seq + 1) % 65536
         ):
             self.rtt = max(min(self.rtt, dt), 0.01)
 
@@ -1367,7 +1430,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if (
                 op.req_opcode == OP_TerminateSession
                 and self.pending_terminate_seq is not None
-                and op.seq == (self.pending_terminate_seq + 1) % 256
+                and op.seq == (self.pending_terminate_seq + 1) % 65536
             ):
                 # Ack or Nack (InvalidSession means it was already
                 # closed): the handshake has been answered
@@ -1527,14 +1590,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         """Handle reset sessions reply."""
         if (
             self.pending_reset_seq is not None
-            and op.seq == (self.pending_reset_seq + 1) % 256
+            and op.seq == (self.pending_reset_seq + 1) % 65536
         ):
             # Ack or Nack, the handshake has been answered; the decoded
             # result below still reports a Nack to the caller
             self.pending_reset_seq = None
         return self.__decode_ftp_ack_and_nack(op)
 
-    def process_ftp_reply(
+    def process_ftp_reply(  # pylint: disable=too-many-branches, too-many-locals
         self, operation_name: str, timeout: float = 5
     ) -> MAVFTPReturn:
         """Execute an FTP operation that requires processing a MAVLink response."""
@@ -1560,7 +1623,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # terminate reply and for operations with no positive
         # completion signal.
         self.read_complete = False
-        self.operation_complete = False
+        self.completed_reply = None
         while True:  # an FTP operation can have multiple responses
             m = self.master.recv_match(
                 type=["FILE_TRANSFER_PROTOCOL"], timeout=recv_timeout
@@ -1573,14 +1636,52 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     # __terminate_session from this very wait
                     op = self.__op_parse(m)
                     if (
-                        op.req_opcode == OP_TerminateSession
+                        m.target_system == self.master.source_system  # pylint: disable=too-many-boolean-expressions
+                        and m.target_component == self.master.source_component
+                        and op.session == self.session
+                        and op.req_opcode == OP_TerminateSession
                         and self.pending_terminate_seq is not None
-                        and op.seq == (self.pending_terminate_seq + 1) % 256
+                        and op.seq == (self.pending_terminate_seq + 1) % 65536
                     ):
                         self.pending_terminate_seq = None
                         ret = MAVFTPReturn(operation_name, FtpError.Success)
                 else:
-                    ret = self.__mavlink_packet(m)
+                    # Keep a result only from the request that was current
+                    # when this reply arrived.  Packet handlers must still
+                    # see stale replies so they can maintain their own
+                    # state, but retaining their result would make idle
+                    # fallback return a previous operation's outcome.
+                    op = self.__op_parse(m)
+                    reply_matches_last_op = (
+                        self.last_op is not None
+                        and op.req_opcode == self.last_op.opcode
+                        and op.seq == (self.last_op.seq + 1) % 65536
+                        and op.session == self.session
+                    )
+                    reply_matches_active_request = (
+                        op.session == self.session
+                        and self.__reply_matches_active_request(op)
+                    )
+                    packet_ret = self.__mavlink_packet(m)
+                    # An upload's final CreateFile/WriteFile reply starts a
+                    # TerminateSession request before returning here.  Its
+                    # result is therefore valid even though last_op is now
+                    # the terminate request.
+                    completed_upload = (
+                        operation_name.lower() == "put"
+                        and self.completed_reply is not None
+                        and self.completed_reply[0]
+                        in {OP_CreateFile, OP_WriteFile}
+                    )
+                    if (
+                        reply_matches_last_op
+                        or completed_upload
+                        or (
+                            reply_matches_active_request
+                            and packet_ret.error_code != FtpError.Success
+                        )
+                    ):
+                        ret = packet_ret
                 if (
                     self.callback_failure is not None
                     and operation_name != "TerminateSession"
@@ -1588,7 +1689,26 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     callback_failure = self.callback_failure
                     self.callback_failure = None
                     return callback_failure
-            reply_complete = self.operation_complete
+            # Completion is scoped to the terminal reply that produced it.
+            # This prevents a delayed ListDirectory EOF from completing a
+            # following RemoveFile or a subsequent list operation.
+            reply_complete = False
+            if self.completed_reply is not None and self.last_op is not None:
+                completed_opcode, completed_seq = self.completed_reply
+                reply_complete = (
+                    completed_opcode == self.last_op.opcode
+                    and completed_seq == (self.last_op.seq + 1) % 65536
+                )
+                # A completed upload sends TerminateSession immediately after
+                # its final CreateFile/WriteFile reply. It is explicitly
+                # scoped to the upload reply type, rather than being a global
+                # latch that any packet handler can set.
+                if (
+                    not reply_complete
+                    and completed_opcode in {OP_CreateFile, OP_WriteFile}
+                    and operation_name.lower() == "put"
+                ):
+                    reply_complete = True
             if not reply_complete and self.pending_terminate_seq is None:
                 reply_complete = self.read_complete
                 if not reply_complete:
@@ -1853,7 +1973,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 f.write("\n")
         logging.info("Outputted %u parameters to %s", len(pdict), filename)
 
-    def cmd_getparams(  # pylint: disable=too-many-arguments
+    def cmd_getparams(
         self,
         args: List[str],
         progress_callback=None,

--- a/mavftp.py
+++ b/mavftp.py
@@ -2023,7 +2023,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def save_params(
-        pdict: Dict[str, Tuple[float, str]],
+        pdict: Dict[str, Tuple[float, int]],
         filename: str,
         sort_type: str,
         add_datatype_comments: bool,
@@ -2034,10 +2034,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             return
         with open(filename, "w", encoding="utf-8") as f:
             parameter_data_types = {
-                "1": "8-bit",
-                "2": "16-bit",
-                "3": "32-bit integer",
-                "4": "32-bit float",
+                1: "8-bit",
+                2: "16-bit",
+                3: "32-bit integer",
+                4: "32-bit float",
             }
             if add_timestamp_comment:
                 f.write(

--- a/mavftp.py
+++ b/mavftp.py
@@ -833,13 +833,18 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 # which must never be treated as local filenames.
                 publish_result = False
                 self.fh.seek(0)
-                callback_result = self.callback(self.fh)
-                if (
-                    isinstance(callback_result, MAVFTPReturn)
-                    and callback_result.error_code != FtpError.Success
-                ):
-                    self.callback_failure = callback_result
-                self.callback = None
+                try:
+                    callback_result = self.callback(self.fh)
+                    if (
+                        isinstance(callback_result, MAVFTPReturn)
+                        and callback_result.error_code != FtpError.Success
+                    ):
+                        self.callback_failure = callback_result
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logging.error("FTP: download callback failed: %s", exc)
+                    self.callback_failure = MAVFTPReturn("Get", FtpError.Fail)
+                finally:
+                    self.callback = None
             elif self.read_to_memory:
                 publish_result = False
                 self.done = True

--- a/mavftp.py
+++ b/mavftp.py
@@ -347,6 +347,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # expected response sequences so delayed replies from a prior request
         # cannot be dispatched as a current gap repair.
         self.pending_read_replies: Dict[int, Tuple[int, int]] = {}
+        self.pending_read_requests: Dict[int, FTP_OP] = {}
         self.last_gap_send = 0.0
         self.read_retries = 0
         self.read_total = 0
@@ -358,6 +359,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # with advancing sequence numbers, so their offsets identify whether
         # they belong to the current burst after a new burst is requested.
         self.pending_burst_offset: Optional[int] = None
+        self.pending_burst_request: Optional[FTP_OP] = None
         self.op_start: Union[None, float] = None
         self.dir_offset = 0
         self.last_op_time = time.time()
@@ -388,6 +390,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # Uploads have several WriteFile requests in flight. Map each
         # response sequence to its requested offset.
         self.pending_write_replies: Dict[int, int] = {}
+        self.pending_write_requests: Dict[int, FTP_OP] = {}
         self.write_last_send: Union[None, float] = None
         self.open_retries = 0
         self.list_result: List[DirectoryEntry] = []
@@ -447,9 +450,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         logging.error(usage)
         return MAVFTPReturn("FTP command", FtpError.InvalidArguments)
 
-    def __send(self, op: FTP_OP) -> None:
-        """Send a request."""
-        op.seq = self.seq
+    def __send(self, op: FTP_OP, retry: bool = False) -> None:
+        """Send a request, preserving its sequence number on retransmission."""
+        if not retry:
+            op.seq = self.seq
         payload = op.pack()
         plen = len(payload)
         if plen < MAX_Payload + HDR_Len:
@@ -460,11 +464,15 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         expected_reply_seq = (op.seq + 1) % 65536
         if op.opcode == OP_BurstReadFile:
             self.pending_burst_offset = op.offset
+            self.pending_burst_request = op
         elif op.opcode == OP_ReadFile:
             self.pending_read_replies[expected_reply_seq] = (op.offset, op.size)
+            self.pending_read_requests[expected_reply_seq] = op
         elif op.opcode == OP_WriteFile:
             self.pending_write_replies[expected_reply_seq] = op.offset
-        self.seq = (self.seq + 1) % 65536
+            self.pending_write_requests[expected_reply_seq] = op
+        if not retry:
+            self.seq = (self.seq + 1) % 65536
         self.last_op = op
         now = time.time()
         if self.ftp_settings.debug > 1:
@@ -516,17 +524,37 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.read_total = 0
         self.read_gap_times = {}
         self.pending_read_replies = {}
+        self.pending_read_requests = {}
         self.last_read = None
         self.last_burst_read = None
         self.pending_burst_offset = None
+        self.pending_burst_request = None
         self.reached_eof = False
         self.backlog = 0
         self.duplicates = 0
         self.pending_write_replies = {}
+        self.pending_write_requests = {}
         if self.ftp_settings.debug > 0:
             logging.info("FTP: Terminated session")
         self.process_ftp_reply("TerminateSession")
         self.session = (self.session + 1) % 256
+
+    def __has_active_session(self) -> bool:
+        """Return whether a file operation may have opened a remote session."""
+        if self.fh is not None or self.write_list is not None:
+            return True
+        return (
+            self.filename is not None
+            and self.last_op is not None
+            and self.last_op.opcode
+            in {
+                OP_OpenFileRO,
+                OP_BurstReadFile,
+                OP_ReadFile,
+                OP_CreateFile,
+                OP_WriteFile,
+            }
+        )
 
     def cmd_list(self, args: List[str]) -> MAVFTPReturn:
         """List files."""
@@ -653,6 +681,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             self.__idle_task()
             time.sleep(0.0001)
         logging.info("loop closed, gaps:%u, done: %u", self.read_gaps, self.done)
+        if not self.done and self.__has_active_session():
+            self.__terminate_session()
         if len(self.read_gaps) == 0:
             return self.get_result
         logging.error("closed read with %u gaps", self.read_gaps)
@@ -719,6 +749,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.opcode == OP_Ack:
             if self.filename is None:
                 return MAVFTPReturn("OpenFileRO", FtpError.FileNotFound)
+            self.session = op.session
             try:
                 if self.callback is not None or self.filename == "-":
                     self.fh = SIO()
@@ -936,11 +967,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         )
                     self.reached_eof = True
                     self.pending_burst_offset = None
+                    self.pending_burst_request = None
                     if self.__check_read_finished():
                         return MAVFTPReturn("BurstReadFile", FtpError.Success)
                     self.__check_read_send()
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
-                more = self.last_op
+                more = self.pending_burst_request
+                if more is None:
+                    return MAVFTPReturn("BurstReadFile", FtpError.Fail)
                 more.offset = op.offset + op.size
                 if self.ftp_settings.debug > 0:
                     logging.info(
@@ -973,6 +1007,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     )
                 self.reached_eof = True
                 self.pending_burst_offset = None
+                self.pending_burst_request = None
                 if self.__check_read_finished():
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
                 self.__check_read_send()
@@ -987,6 +1022,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     def __handle_reply_read(self, op: FTP_OP, _m) -> MAVFTPReturn:
         """Handle OP_ReadFile reply."""
         self.pending_read_replies.pop(op.seq, None)
+        self.pending_read_requests.pop(op.seq, None)
         if self.fh is None or self.filename is None:
             if self.ftp_settings.debug > 0:
                 logging.warning("FTP: Unexpected read reply")
@@ -1003,6 +1039,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     seq: pending_gap
                     for seq, pending_gap in self.pending_read_replies.items()
                     if pending_gap != gap
+                }
+                self.pending_read_requests = {
+                    seq: pending_read
+                    for seq, pending_read in self.pending_read_requests.items()
+                    if (pending_read.offset, pending_read.size) != gap
                 }
                 ofs = self.fh.tell()
                 self.__write_payload(op)
@@ -1027,7 +1068,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.info(
                 "FTP: Read failed with %u gaps %s", len(self.read_gaps), str(op)
             )
+            ret = self.__decode_ftp_ack_and_nack(op)
             self.__terminate_session()
+            return ret
         self.__check_read_send()
         return MAVFTPReturn("ReadFile", FtpError.Success)
 
@@ -1115,6 +1158,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             self.__terminate_session()
             return MAVFTPReturn("CreateFile", FtpError.FileNotFound)
         if op.opcode == OP_Ack:
+            self.session = op.session
             self.__send_more_writes(op)
         else:
             ret = self.__decode_ftp_ack_and_nack(op)
@@ -1151,19 +1195,30 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             while idx not in self.write_list:
                 idx = (idx + 1) % self.write_total
             ofs = idx * self.write_block_size
-            self.fh.seek(ofs)
-            data = self.fh.read(self.write_block_size)
-            write = FTP_OP(
-                self.seq,
-                self.session,
-                OP_WriteFile,
-                len(data),
-                0,
-                0,
-                ofs,
-                bytearray(data),
+            write = next(
+                (
+                    pending_write
+                    for pending_write in self.pending_write_requests.values()
+                    if pending_write.offset == ofs
+                ),
+                None,
             )
-            self.__send(write)
+            if write is None:
+                self.fh.seek(ofs)
+                data = self.fh.read(self.write_block_size)
+                write = FTP_OP(
+                    self.seq,
+                    self.session,
+                    OP_WriteFile,
+                    len(data),
+                    0,
+                    0,
+                    ofs,
+                    bytearray(data),
+                )
+                self.__send(write)
+            else:
+                self.__send(write, retry=True)
             self.write_idx = (idx + 1) % self.write_total
             self.write_pending += 1
             self.write_last_send = now
@@ -1171,19 +1226,26 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
     def __handle_write_reply(self, op: FTP_OP, _m) -> MAVFTPReturn:
         """Handle OP_WriteFile reply."""
         expected_offset = self.pending_write_replies.pop(op.seq, None)
+        self.pending_write_requests.pop(op.seq, None)
         if expected_offset is not None:
             self.pending_write_replies = {
                 seq: offset
                 for seq, offset in self.pending_write_replies.items()
                 if offset != expected_offset
             }
+            self.pending_write_requests = {
+                seq: pending_write
+                for seq, pending_write in self.pending_write_requests.items()
+                if pending_write.offset != expected_offset
+            }
         if self.fh is None:
             self.__terminate_session()
             return MAVFTPReturn("WriteFile", FtpError.FileNotFound)
         if op.opcode != OP_Ack:
             logging.error("FTP: Write failed")
+            ret = self.__decode_ftp_ack_and_nack(op)
             self.__terminate_session()
-            return MAVFTPReturn("WriteFile", FtpError.FileProtected)
+            return ret
 
         # assume the FTP server processes the blocks sequentially. This means
         # when we receive an ack that any blocks between the last ack and this
@@ -1389,7 +1451,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         dt = now - self.last_op_time
         if self.ftp_settings.debug > 1:
             logging.info("FTP: < %s dt=%.2f", op, dt)
-        if op.session != self.session:
+        allocated_session_reply = (
+            op.opcode == OP_Ack
+            and op.req_opcode in {OP_OpenFileRO, OP_CreateFile}
+        )
+        if op.session != self.session and not allocated_session_reply:
             if self.ftp_settings.debug > 0:
                 logging.warning(
                     "FTP: wrong session replied %u expected %u. Will discard message",
@@ -1465,8 +1531,21 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 len(self.read_gaps),
                 self.backlog,
             )
-        read = FTP_OP(self.seq, self.session, OP_ReadFile, length, 0, 0, offset, None)
-        self.__send(read)
+        read = next(
+            (
+                pending_read
+                for pending_read in self.pending_read_requests.values()
+                if (pending_read.offset, pending_read.size) == g
+            ),
+            None,
+        )
+        if read is None:
+            read = FTP_OP(
+                self.seq, self.session, OP_ReadFile, length, 0, 0, offset, None
+            )
+            self.__send(read)
+        else:
+            self.__send(read, retry=True)
         self.read_gaps.remove(g)
         self.read_gaps.append(g)
         self.last_gap_send = time.time()
@@ -1524,13 +1603,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 return False  # Not idle yet
             if self.ftp_settings.debug > 0:
                 logging.info("FTP: retry open")
-            send_op = self.last_op
-            self.__send(
-                FTP_OP(self.seq, self.session, OP_TerminateSession, 0, 0, 0, 0, None)
-            )
-            self.session = (self.session + 1) % 256
-            send_op.session = self.session
-            self.__send(send_op)
+            self.__send(self.last_op, retry=True)
 
         if (
             len(self.read_gaps) == 0
@@ -1557,18 +1630,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     self.rtt,
                     dt,
                 )
-            self.__send(
-                FTP_OP(
-                    self.seq,
-                    self.session,
-                    OP_BurstReadFile,
-                    self.burst_size,
-                    0,
-                    0,
-                    self.fh.tell(),
-                    None,
-                )
-            )
+            if self.pending_burst_request is not None:
+                self.__send(self.pending_burst_request, retry=True)
             self.read_retries += 1
 
         # see if we can fill gaps
@@ -1727,6 +1790,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 )
                 ret = MAVFTPReturn(operation_name, FtpError.RemoteReplyTimeout)
                 break
+        if (
+            ret.error_code == FtpError.RemoteReplyTimeout
+            and operation_name != "TerminateSession"
+            and self.__has_active_session()
+        ):
+            self.__terminate_session()
         return ret
 
     def __decode_ftp_ack_and_nack(

--- a/mavftp.py
+++ b/mavftp.py
@@ -927,13 +927,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         "FTP: burst continue at %u %u", more.offset, self.fh.tell()
                     )
                 self.__send(more)
-        elif op.opcode == OP_Nack:
-            ecode = (
-                FtpError(op.payload[0])
-                if op.payload is not None
-                else FtpError.NoErrorCodeInNack
-            )
-            if ecode in (FtpError.EndOfFile, 0):
+            # A valid burst reply may be only one part of the transfer.
+            # It is successful even when it does not complete the read.
+            return MAVFTPReturn("BurstReadFile", FtpError.Success)
+        if op.opcode == OP_Nack:
+            nack_result = self.__decode_ftp_ack_and_nack(op)
+            if nack_result.error_code == FtpError.EndOfFile:
                 if not self.reached_eof and op.offset > self.fh.tell():
                     # we lost the last part of the burst
                     if self.ftp_settings.debug > 0:
@@ -956,12 +955,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 if self.__check_read_finished():
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
                 self.__check_read_send()
-            elif self.ftp_settings.debug > 0:
-                logging.info("FTP: burst Nack (ecode:%u): %s", ecode, op)
                 return MAVFTPReturn("BurstReadFile", FtpError.Fail)
             if self.ftp_settings.debug > 0:
                 logging.error("FTP: burst nack: %s", op)
-                return MAVFTPReturn("BurstReadFile", FtpError.Fail)
+            self.__terminate_session()
+            return nack_result
         else:
             logging.warning("FTP: burst error: %s", op)
         return MAVFTPReturn("BurstReadFile", FtpError.Fail)
@@ -1598,6 +1596,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             ):
                 break
             if self.__idle_task():
+                if self.last_burst_read is not None and not self.read_complete:
+                    ret = MAVFTPReturn(operation_name, FtpError.RemoteReplyTimeout)
                 break
             if timeout > 0 and time.time() - start_time > timeout:  # pylint: disable=chained-comparison
                 logging.error(

--- a/mavftp.py
+++ b/mavftp.py
@@ -1075,6 +1075,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             elif op.size < self.burst_size:
                 logging.info("FTP: file size changed to %u", op.offset + op.size)
                 self.__terminate_session()
+                return MAVFTPReturn("ReadFile", FtpError.Fail)
             else:
                 self.duplicates += 1
                 if self.ftp_settings.debug > 0:

--- a/mavftp.py
+++ b/mavftp.py
@@ -701,7 +701,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         logging.error("closed read with %u gaps", len(self.read_gaps))
         return None
 
-    def cmd_set(self, args: List[str]) -> MAVFTPReturn:
+    def cmd_set(  # pylint: disable=too-many-return-statements,too-many-boolean-expressions
+        self, args: List[str]
+    ) -> MAVFTPReturn:
         """Set a MAVFTP configuration parameter."""
         if len(args) != 2:
             logging.error("Usage: set PARAMETERNAME PARAMETERVALUE")
@@ -866,7 +868,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.__terminate_session()
         return ret
 
-    def __check_read_finished(self) -> bool:
+    def __check_read_finished(self) -> bool:  # pylint: disable=too-many-branches
         """Check if download has completed."""
         if self.fh is None:
             return True

--- a/mavftp.py
+++ b/mavftp.py
@@ -830,7 +830,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     and callback_result.error_code != FtpError.Success
                 ):
                     self.callback_failure = callback_result
-                    publish_result = False
                 self.callback = None
             elif self.filename == "-":
                 self.fh.seek(0)

--- a/mavftp.py
+++ b/mavftp.py
@@ -680,12 +680,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 logging.error(e)
             self.__idle_task()
             time.sleep(0.0001)
-        logging.info("loop closed, gaps:%u, done: %u", self.read_gaps, self.done)
+        logging.info("loop closed, gaps:%u, done: %u", len(self.read_gaps), self.done)
         if not self.done and self.__has_active_session():
             self.__terminate_session()
         if len(self.read_gaps) == 0:
             return self.get_result
-        logging.error("closed read with %u gaps", self.read_gaps)
+        logging.error("closed read with %u gaps", len(self.read_gaps))
         return None
 
     def cmd_set(self, args: List[str]) -> MAVFTPReturn:
@@ -1713,11 +1713,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         self.pending_terminate_seq = None
                         ret = MAVFTPReturn(operation_name, FtpError.Success)
                 else:
-                    # Keep a result only from the request that was current
-                    # when this reply arrived.  Packet handlers must still
-                    # see stale replies so they can maintain their own
-                    # state, but retaining their result would make idle
-                    # fallback return a previous operation's outcome.
+                    # Keep a result from the latest request or an active
+                    # in-flight request. Packet handlers must still see
+                    # stale replies so they can maintain their own state,
+                    # but retaining a stale result would make idle fallback
+                    # return a previous operation's outcome.
                     op = self.__op_parse(m)
                     reply_matches_last_op = (
                         self.last_op is not None
@@ -1743,10 +1743,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     if (
                         reply_matches_last_op
                         or completed_upload
-                        or (
-                            reply_matches_active_request
-                            and packet_ret.error_code != FtpError.Success
-                        )
+                        or reply_matches_active_request
                     ):
                         ret = packet_ret
                 if (

--- a/mavftp.py
+++ b/mavftp.py
@@ -2440,7 +2440,7 @@ def wait_heartbeat(m) -> None:
     logging.info("Waiting for flight controller heartbeat")
     m.wait_heartbeat(timeout=5)
     logging.info(
-        "Heartbeat from system %u, component %u", m.target_system, m.target_system
+        "Heartbeat from system %u, component %u", m.target_system, m.target_component
     )
 
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -6,7 +6,7 @@ MAVLink File Transfer Protocol support - https://mavlink.io/en/services/ftp.html
 
 Original from MAVProxy/MAVProxy/modules/mavproxy_ftp.py.
 
-SPDX-FileCopyrightText: 2011-2024 Andrew Tridgell, 2024-2025 Amilcar Lucas
+SPDX-FileCopyrightText: 2011-2024 Andrew Tridgell, 2024-2026 Amilcar Lucas
 
 SPDX-License-Identifier: GPL-3.0-or-later
 """
@@ -607,7 +607,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         DirectoryEntry(name=dir_entry[1:], is_dir=True, size_b=0)
                     )
                 elif dir_entry[0] == "F":
-                    (name, size_str) = dir_entry[1:].split("\t")
+                    try:
+                        (name, size_str) = dir_entry[1:].rsplit("\t", 1)
+                    except ValueError:
+                        logging.error("Invalid file entry: %s", dir_entry)
+                        return MAVFTPReturn("ListDirectory", FtpError.InvalidDataSize)
                     try:
                         size = int(size_str)
                     except (ValueError, TypeError, OverflowError):

--- a/mavftp.py
+++ b/mavftp.py
@@ -819,6 +819,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             rate = (ofs / dt) / 1024.0
             publish_result = True
             if self.callback is not None:
+                # The callback owns the downloaded data.  This is also used
+                # for virtual MAVFTP paths such as param.pck?withdefaults=1,
+                # which must never be treated as local filenames.
+                publish_result = False
                 self.fh.seek(0)
                 callback_result = self.callback(self.fh)
                 if (
@@ -2042,7 +2046,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 f.write("\n")
         logging.info("Outputted %u parameters to %s", len(pdict), filename)
 
-    def cmd_getparams(
+    def cmd_getparams(  # pylint: disable=too-many-arguments
         self,
         args: List[str],
         progress_callback=None,

--- a/mavftp.py
+++ b/mavftp.py
@@ -723,7 +723,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
         try:
             setting_value = float(args[1])
-        except (ValueError, TypeError):
+        except (ValueError, TypeError, OverflowError):
             logging.error("Invalid parameter value: %s", args[1])
             return MAVFTPReturn("Set", FtpError.InvalidArguments)
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -1694,9 +1694,16 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 "paramftp: Not enough data do decode, only %u bytes", len(data)
             )
             return None
-        magic2, _num_params, total_params = struct.unpack("<HHH", data[0:6])
+        magic2, num_params, total_params = struct.unpack("<HHH", data[0:6])
         if magic2 not in {magic, magic_defaults}:
             logging.error("paramftp: bad magic 0x%x expected 0x%x", magic2, magic)
+            return None
+        if num_params > total_params:
+            logging.error(
+                "paramftp: parameter count %u exceeds total count %u",
+                num_params,
+                total_params,
+            )
             return None
         with_defaults = magic2 == magic_defaults
         data = data[6:]
@@ -1778,8 +1785,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 pdata.add_param(name, v, ptype)
             count += 1
 
-        if count != total_params:
-            logging.error("paramftp: bad count %u should be %u", count, total_params)
+        if count != num_params:
+            logging.error("paramftp: bad count %u should be %u", count, num_params)
             return None
 
         return pdata

--- a/mavftp.py
+++ b/mavftp.py
@@ -1683,7 +1683,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         )
 
     @staticmethod
-    def ftp_param_decode(data: bytes) -> Union[None, ParamData]:  # pylint: disable=too-many-locals
+    def ftp_param_decode(data: bytes) -> Union[None, ParamData]:  # pylint: disable=too-many-locals,too-many-statements,too-many-branches,too-many-return-statements
         """Decode parameter data, returning ParamData."""
         pdata = ParamData()
 
@@ -1718,6 +1718,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
             if len(data) == 0:
                 break
+            if len(data) < 2:
+                logging.error("paramftp: truncated parameter header")
+                return None
 
             ptype, plen = struct.unpack("<BB", data[0:2])
             flags = (ptype >> 4) & 0x0F
@@ -1733,10 +1736,31 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
             name_len = ((plen >> 4) & 0x0F) + 1
             common_len = plen & 0x0F
+            value_len = type_len + default_len
+            record_len = 2 + name_len + value_len
+            if len(data) < record_len:
+                logging.error("paramftp: truncated parameter record")
+                return None
+            if common_len > len(last_name):
+                logging.error(
+                    "paramftp: invalid shared parameter name prefix length %u",
+                    common_len,
+                )
+                return None
             name = last_name[0:common_len] + data[2 : 2 + name_len]
-            vdata = data[2 + name_len : 2 + name_len + type_len + default_len]
+            if len(name) > 16:
+                logging.error(
+                    "paramftp: parameter name is too long (%u bytes)", len(name)
+                )
+                return None
+            try:
+                name.decode("utf-8")
+            except UnicodeDecodeError:
+                logging.error("paramftp: parameter name is not valid UTF-8")
+                return None
+            vdata = data[2 + name_len : record_len]
             last_name = name
-            data = data[2 + name_len + type_len + default_len :]
+            data = data[record_len:]
             if with_defaults:
                 if has_default:
                     (

--- a/mavftp.py
+++ b/mavftp.py
@@ -1018,9 +1018,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.operation_complete = False
         fname = args[0]
         self.fh = fh
+        self.fh_owned = False
         if self.fh is None:
             try:
                 self.fh = open(fname, "rb")  # noqa: SIM115 pylint: disable=consider-using-with
+                self.fh_owned = True
             except Exception as ex:  # pylint: disable=broad-exception-caught
                 logging.error("FTP: Failed to open %s: %s", fname, ex)
                 return MAVFTPReturn("CreateFile", FtpError.FailToOpenLocalFile)
@@ -1558,6 +1560,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # terminate reply and for operations with no positive
         # completion signal.
         self.read_complete = False
+        self.operation_complete = False
         while True:  # an FTP operation can have multiple responses
             m = self.master.recv_match(
                 type=["FILE_TRANSFER_PROTOCOL"], timeout=recv_timeout
@@ -1585,15 +1588,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     callback_failure = self.callback_failure
                     self.callback_failure = None
                     return callback_failure
-            if self.pending_terminate_seq is None and (
-                self.read_complete
-                or self.operation_complete
-                or operation_name == "TerminateSession"
-                or (
-                    operation_name == "ResetSessions"
-                    and self.pending_reset_seq is None
-                )
-            ):
+            reply_complete = self.operation_complete
+            if not reply_complete and self.pending_terminate_seq is None:
+                reply_complete = self.read_complete
+                if not reply_complete:
+                    reply_complete = operation_name == "TerminateSession"
+                if not reply_complete and operation_name == "ResetSessions":
+                    reply_complete = self.pending_reset_seq is None
+            if reply_complete:
                 break
             if self.__idle_task():
                 if self.last_burst_read is not None and not self.read_complete:

--- a/mavftp.py
+++ b/mavftp.py
@@ -102,6 +102,7 @@ class FtpError(IntEnum):
 
 HDR_Len = 12
 MAX_Payload = 239
+BURST_REPLY_SEQUENCE_WINDOW = 4096
 # pylint: enable=invalid-name
 
 
@@ -1004,6 +1005,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.info("FTP: Setting burst size to %u", self.burst_size)
         if op.opcode == OP_Ack and self.fh is not None:
+            if self.pending_burst_seq is not None:
+                sequence_distance = (op.seq - self.pending_burst_seq) & 0xFFFF
+                if sequence_distance > BURST_REPLY_SEQUENCE_WINDOW:
+                    self.pending_burst_seq = (
+                        op.seq - BURST_REPLY_SEQUENCE_WINDOW
+                    ) & 0xFFFF
             ofs = self.__read_position()
             if op.offset < ofs:
                 # writing an earlier portion, possibly remove a gap

--- a/mavftp.py
+++ b/mavftp.py
@@ -2445,9 +2445,9 @@ def create_argument_parser() -> ArgumentParser:
         help="Current path of the file/directory.",
     )
     parser_rename.add_argument(
-        "new_remote_path",
+        "arg2",
         type=str,
-        metavar="arg2",
+        metavar="new_remote_path",
         help="New path for the file/directory.",
     )
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -70,6 +70,8 @@ from pymavlink.mavftp_op import (
     OP_WriteFile,
 )
 
+ParameterDataType = Union[str, int]
+
 
 # pylint: disable=invalid-name
 class FtpError(IntEnum):
@@ -2110,7 +2112,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     @staticmethod
     def save_params(
-        pdict: Dict[str, Tuple[float, int]],
+        pdict: Dict[str, Tuple[float, ParameterDataType]],
         filename: str,
         sort_type: str,
         add_datatype_comments: bool,
@@ -2137,7 +2139,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     f.write(f"{name:<16} {value:<8.6f}")
 
                 if add_datatype_comments:
-                    f.write(f"  # {parameter_data_types[datatype]}")
+                    datatype_id = int(datatype)
+                    f.write(f"  # {parameter_data_types[datatype_id]}")
                 f.write("\n")
         logging.info("Outputted %u parameters to %s", len(pdict), filename)
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -1769,6 +1769,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     dt,
                 )
             if self.pending_burst_request is not None:
+                # Resume at the first byte not yet written.  Reusing the
+                # request sequence keeps this a retransmission for servers
+                # that require it, while the new offset avoids re-streaming
+                # an entire stalled burst.
+                self.pending_burst_request.offset = self.__read_position()
                 self.__send(self.pending_burst_request, retry=True)
             self.read_retries += 1
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -1386,7 +1386,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.write_list.discard(idx)
         self.write_acks += 1
         if self.put_callback_progress:
-            self.put_callback_progress(self.write_acks / float(self.write_total))
+            progress = (
+                self.write_acks / float(self.write_total) if self.write_total else 1.0
+            )
+            self.put_callback_progress(progress)
         self.__send_more_writes(op)
         return MAVFTPReturn("WriteFile", FtpError.Success)
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -2476,6 +2476,7 @@ def auto_detect_serial() -> List[mavutil.SerialPort]:
         "*Ardu*",
         "*PX4*",
         "*Hex_*",
+        "*ProfiCNC*",
         "*Holybro_*",
         "*mRo*",
         "*FMU*",
@@ -2483,6 +2484,7 @@ def auto_detect_serial() -> List[mavutil.SerialPort]:
         "*Serial*",
         "*CubePilot*",
         "*Qiotek*",
+        "*Matek*",
     ]
     serial_list: List[mavutil.SerialPort] = mavutil.auto_detect_serial(
         preferred_list=preferred_ports

--- a/mavftp.py
+++ b/mavftp.py
@@ -103,6 +103,7 @@ class FtpError(IntEnum):
 HDR_Len = 12
 MAX_Payload = 239
 BURST_REPLY_SEQUENCE_WINDOW = 4096
+MAX_READ_GAPS = 4096
 # pylint: enable=invalid-name
 
 
@@ -1060,6 +1061,14 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 # we have a gap
                 gap = (ofs, op.offset - ofs)
                 max_read = self.burst_size
+                gap_count = (gap[1] + max_read - 1) // max_read
+                total_gap_count = len(self.read_gaps) + gap_count
+                if total_gap_count > MAX_READ_GAPS:
+                    logging.error(
+                        "FTP: burst reply creates too many gaps (%u)", total_gap_count
+                    )
+                    self.__terminate_session()
+                    return MAVFTPReturn("BurstReadFile", FtpError.InvalidDataSize)
                 while True:
                     if gap[1] <= max_read:
                         self.read_gaps.append(gap)

--- a/mavftp.py
+++ b/mavftp.py
@@ -364,6 +364,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         # identify whether a reply belongs to the current burst.
         self.pending_burst_offset: Optional[int] = None
         self.pending_burst_seq: Optional[int] = None
+        self.pending_burst_retry = False
         self.pending_burst_request: Optional[FTP_OP] = None
         self.op_start: Union[None, float] = None
         self.dir_offset = 0
@@ -473,6 +474,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.opcode == OP_BurstReadFile:
             self.pending_burst_offset = op.offset
             self.pending_burst_seq = expected_reply_seq
+            self.pending_burst_retry = retry
             self.pending_burst_request = op
         elif op.opcode == OP_ReadFile:
             self.pending_read_replies[expected_reply_seq] = (op.offset, op.size)
@@ -1005,12 +1007,27 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.info("FTP: Setting burst size to %u", self.burst_size)
         if op.opcode == OP_Ack and self.fh is not None:
-            if self.pending_burst_seq is not None:
+            # A retried request must see its first expected reply before a
+            # delayed packet can affect its sequence floor.  Other packets
+            # still reach the writer: their offsets can preserve useful data
+            # and create gaps for normal repair.
+            expected_retry_reply = (
+                self.pending_burst_seq is not None
+                and op.seq == self.pending_burst_seq
+            )
+            if not self.pending_burst_retry or expected_retry_reply:
+                self.pending_burst_retry = False
+            if (
+                self.pending_burst_seq is not None
+                and self.pending_burst_offset is not None
+            ):
                 sequence_distance = (op.seq - self.pending_burst_seq) & 0xFFFF
-                if sequence_distance > BURST_REPLY_SEQUENCE_WINDOW:
-                    self.pending_burst_seq = (
-                        op.seq - BURST_REPLY_SEQUENCE_WINDOW
-                    ) & 0xFFFF
+                offset_distance = op.offset - self.pending_burst_offset
+                # A stream cannot advance its sequence more times than bytes
+                # since its requested offset.  Do not let a delayed reply
+                # with an implausibly distant sequence ratchet the floor.
+                if BURST_REPLY_SEQUENCE_WINDOW < sequence_distance <= offset_distance:
+                    self.pending_burst_seq = (self.pending_burst_seq + 1) & 0xFFFF
             ofs = self.__read_position()
             if op.offset < ofs:
                 # writing an earlier portion, possibly remove a gap
@@ -1766,10 +1783,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     dt,
                 )
             if self.pending_burst_request is not None:
-                # Resume at the first byte not yet written.  Reusing the
-                # request sequence keeps this a retransmission for servers
-                # that require it, while the new offset avoids re-streaming
-                # an entire stalled burst.
+                # Resume at the current high-water mark while preserving the
+                # client's reply gate and re-arming the server's burst offset.
                 self.pending_burst_request.offset = self.__read_position()
                 self.__send(self.pending_burst_request, retry=True)
             self.read_retries += 1

--- a/mavftp.py
+++ b/mavftp.py
@@ -1386,10 +1386,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.write_list.discard(idx)
         self.write_acks += 1
         if self.put_callback_progress:
-            progress = (
-                self.write_acks / float(self.write_total) if self.write_total else 1.0
-            )
-            self.put_callback_progress(progress)
+            self.put_callback_progress(self.write_acks / float(self.write_total))
         self.__send_more_writes(op)
         return MAVFTPReturn("WriteFile", FtpError.Success)
 

--- a/mavftp.py
+++ b/mavftp.py
@@ -875,7 +875,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.op_start is None:
             return True
         if len(self.read_gaps) == 0 and (
-            self.reached_eof or self.read_total >= self.requested_size
+            self.reached_eof or (self.read_to_memory and self.read_total >= self.requested_size)
         ):
             ofs = self.fh.tell()
             dt = time.time() - self.op_start
@@ -1024,6 +1024,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 self.__write_payload(op)
             else:
                 self.__write_payload(op)
+            if self.__check_read_finished():
+                return MAVFTPReturn("BurstReadFile", FtpError.Success)
             if op.burst_complete:
                 if op.size > 0 and op.size < self.burst_size:
                     # a burst complete with non-zero size and less than burst packet size

--- a/mavftp.py
+++ b/mavftp.py
@@ -1222,7 +1222,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.__check_read_send()
         return MAVFTPReturn("ReadFile", FtpError.Success)
 
-    def cmd_put(
+    def cmd_put(  # pylint: disable=too-many-return-statements,too-many-statements
         self, args: List[str], fh=None, callback=None, progress_callback=None
     ) -> MAVFTPReturn:
         """Put file."""
@@ -1240,6 +1240,17 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             logging.error("FTP: write_qsize must be at least 1")
             return MAVFTPReturn("CreateFile", FtpError.InvalidArguments)
         fname = args[0]
+        if len(args) > 1:
+            filename = args[1]
+        else:
+            filename = os.path.basename(fname)
+        if filename.endswith("/"):
+            filename += os.path.basename(fname)
+        try:
+            enc_fname = bytearray(filename, "ascii")
+        except UnicodeEncodeError:
+            logging.error("Invalid remote file name: %s", filename)
+            return MAVFTPReturn("CreateFile", FtpError.InvalidArguments)
         self.fh = fh
         self.fh_owned = False
         if self.fh is None:
@@ -1249,12 +1260,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             except Exception as ex:  # pylint: disable=broad-exception-caught
                 logging.error("FTP: Failed to open %s: %s", fname, ex)
                 return MAVFTPReturn("CreateFile", FtpError.FailToOpenLocalFile)
-        if len(args) > 1:
-            self.filename = args[1]
-        else:
-            self.filename = os.path.basename(fname)
-        if self.filename.endswith("/"):
-            self.filename += os.path.basename(fname)
+        self.filename = filename
         if callback is None:
             logging.info("Putting %s to %s", fname, self.filename)
         self.fh.seek(0, 2)
@@ -1280,7 +1286,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.put_callback_progress = progress_callback
         self.read_retries = 0
         self.op_start = time.time()
-        enc_fname = bytearray(self.filename, "ascii")
         op = FTP_OP(
             self.seq, self.session, OP_CreateFile, len(enc_fname), 0, 0, 0, enc_fname
         )

--- a/mavftp.py
+++ b/mavftp.py
@@ -816,8 +816,6 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             try:
                 if self.callback is not None or self.filename == "-" or self.read_to_memory:
                     self.fh = SIO()
-                    if self.read_to_memory:
-                        self.fh.seek(self.requested_offset)
                 else:
                     self.__release_staging()
                     (temp_fd, self.temp_filename) = tempfile.mkstemp(prefix="mavftp_")
@@ -877,7 +875,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if len(self.read_gaps) == 0 and (
             self.reached_eof or (self.read_to_memory and self.read_total >= self.requested_size)
         ):
-            ofs = self.fh.tell()
+            ofs = self.__read_position()
             dt = time.time() - self.op_start
             rate = (ofs / dt) / 1024.0
             publish_result = True
@@ -960,6 +958,19 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if self.callback_progress is not None and self.remote_file_size:
             self.callback_progress(self.read_total / self.remote_file_size)
 
+    def __read_position(self) -> int:
+        """Return the current remote offset represented by the read buffer."""
+        position = self.fh.tell()
+        if self.read_to_memory:
+            position += self.requested_offset
+        return position
+
+    def __seek_read_position(self, offset: int) -> None:
+        """Seek the read buffer to a remote offset."""
+        if self.read_to_memory:
+            offset -= self.requested_offset
+        self.fh.seek(offset)
+
     def __handle_burst_read(self, op: FTP_OP, _m) -> MAVFTPReturn:  # noqa: PLR0911, PLR0915 pylint: disable=too-many-statements,too-many-branches,too-many-return-statements
         """Handle OP_BurstReadFile reply."""
         if (
@@ -984,7 +995,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.info("FTP: Setting burst size to %u", self.burst_size)
         if op.opcode == OP_Ack and self.fh is not None:
-            ofs = self.fh.tell()
+            ofs = self.__read_position()
             if op.offset < ofs:
                 # writing an earlier portion, possibly remove a gap
                 gap = (op.offset, len(op.payload))
@@ -1004,12 +1015,12 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                             "FTP: dup read reply at %u of len %u ofs=%u",
                             op.offset,
                             op.size,
-                            self.fh.tell(),
+                            self.__read_position(),
                         )
                     self.duplicates += 1
                     return MAVFTPReturn("BurstReadFile", FtpError.Fail)
                 self.__write_payload(op)
-                self.fh.seek(ofs)
+                self.__seek_read_position(ofs)
                 if self.__check_read_finished():
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
             elif op.offset > ofs:
@@ -1041,7 +1052,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     ):
                         logging.info(
                             "FTP: EOF at %u with %u gaps t=%.2f",
-                            self.fh.tell(),
+                            self.__read_position(),
                             len(self.read_gaps),
                             time.time() - self.op_start,
                         )
@@ -1058,7 +1069,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 more.offset = op.offset + op.size
                 if self.ftp_settings.debug > 0:
                     logging.info(
-                        "FTP: burst continue at %u %u", more.offset, self.fh.tell()
+                        "FTP: burst continue at %u %u", more.offset, self.__read_position()
                     )
                 self.__send(more)
             # A valid burst reply may be only one part of the transfer.
@@ -1067,11 +1078,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.opcode == OP_Nack:
             nack_result = self.__decode_ftp_ack_and_nack(op)
             if nack_result.error_code == FtpError.EndOfFile:
-                if not self.reached_eof and op.offset > self.fh.tell():
+                if not self.reached_eof and op.offset > self.__read_position():
                     # we lost the last part of the burst
                     if self.ftp_settings.debug > 0:
                         logging.error(
-                            "FTP: burst lost EOF %u %u", self.fh.tell(), op.offset
+                            "FTP: burst lost EOF %u %u", self.__read_position(), op.offset
                         )
                     return MAVFTPReturn("BurstReadFile", FtpError.Fail)
                 if (
@@ -1081,7 +1092,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 ):
                     logging.info(
                         "FTP: EOF at %u with %u gaps t=%.2f",
-                        self.fh.tell(),
+                        self.__read_position(),
                         len(self.read_gaps),
                         time.time() - self.op_start,
                     )
@@ -1125,9 +1136,9 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     for seq, pending_read in self.pending_read_requests.items()
                     if (pending_read.offset, pending_read.size) != gap
                 }
-                ofs = self.fh.tell()
+                ofs = self.__read_position()
                 self.__write_payload(op)
-                self.fh.seek(ofs)
+                self.__seek_read_position(ofs)
                 if self.ftp_settings.debug > 0:
                     logging.info(
                         "FTP: removed gap %u, %u, %u",
@@ -1713,7 +1724,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             if self.ftp_settings.debug > 0:
                 logging.info(
                     "FTP: Retry read at %u rtt=%.2f dt=%.2f",
-                    self.fh.tell(),
+                    self.__read_position(),
                     self.rtt,
                     dt,
                 )

--- a/mavftp.py
+++ b/mavftp.py
@@ -924,9 +924,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             assert self.fh is not None  # noqa: S101
             self.fh.seek(0)
             result = self.fh.read()
-            self.get_result = result[
-                self.requested_offset : self.requested_offset + self.requested_size
-            ]
+            if self.read_to_memory:
+                self.get_result = result[: self.requested_size]
+            else:
+                self.get_result = result
             assert self.get_result is not None  # noqa: S101
             if len(self.get_result) < self.requested_size:
                 logging.warning(
@@ -950,7 +951,10 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
 
     def __write_payload(self, op: FTP_OP) -> None:
         """Write payload from a read op."""
-        self.fh.seek(op.offset)
+        write_offset = op.offset
+        if self.read_to_memory:
+            write_offset -= self.requested_offset
+        self.fh.seek(write_offset)
         self.fh.write(op.payload)
         self.read_total += len(op.payload)
         if self.callback_progress is not None and self.remote_file_size:

--- a/mavftp.py
+++ b/mavftp.py
@@ -358,10 +358,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.duplicates = 0
         self.last_read = None
         self.last_burst_read: Union[None, float] = None
-        # The start offset of the active burst. Burst packets are streamed
-        # with advancing sequence numbers, so their offsets identify whether
-        # they belong to the current burst after a new burst is requested.
+        # The start offset and first expected reply sequence of the active burst.
+        # Burst packets are streamed with advancing sequence numbers, so both
+        # identify whether a reply belongs to the current burst.
         self.pending_burst_offset: Optional[int] = None
+        self.pending_burst_seq: Optional[int] = None
         self.pending_burst_request: Optional[FTP_OP] = None
         self.op_start: Union[None, float] = None
         self.dir_offset = 0
@@ -470,6 +471,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         expected_reply_seq = (op.seq + 1) % 65536
         if op.opcode == OP_BurstReadFile:
             self.pending_burst_offset = op.offset
+            self.pending_burst_seq = expected_reply_seq
             self.pending_burst_request = op
         elif op.opcode == OP_ReadFile:
             self.pending_read_replies[expected_reply_seq] = (op.offset, op.size)
@@ -535,6 +537,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         self.last_read = None
         self.last_burst_read = None
         self.pending_burst_offset = None
+        self.pending_burst_seq = None
         self.pending_burst_request = None
         self.reached_eof = False
         self.backlog = 0
@@ -1045,6 +1048,18 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                 self.__write_payload(op)
             else:
                 self.__write_payload(op)
+            # Burst replies have their own advancing sequence stream.  Keep
+            # future requests beyond every accepted reply so a new download
+            # cannot reuse a stale reply sequence when a server reuses a
+            # session identifier.
+            if (
+                self.pending_burst_seq is not None
+                and self.pending_burst_offset is not None
+                and ((op.seq - self.pending_burst_seq) & 0xFFFF)
+                <= (op.offset - self.pending_burst_offset)
+                and self.__seq_is_at_or_after(op.seq, self.seq)
+            ):
+                self.seq = (op.seq + 1) & 0xFFFF
             if self.__check_read_finished():
                 return MAVFTPReturn("BurstReadFile", FtpError.Success)
             if op.burst_complete:
@@ -1064,6 +1079,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                         )
                     self.reached_eof = True
                     self.pending_burst_offset = None
+                    self.pending_burst_seq = None
                     self.pending_burst_request = None
                     if self.__check_read_finished():
                         return MAVFTPReturn("BurstReadFile", FtpError.Success)
@@ -1104,6 +1120,7 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
                     )
                 self.reached_eof = True
                 self.pending_burst_offset = None
+                self.pending_burst_seq = None
                 self.pending_burst_request = None
                 if self.__check_read_finished():
                     return MAVFTPReturn("BurstReadFile", FtpError.Success)
@@ -1515,6 +1532,8 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
         if op.req_opcode == OP_BurstReadFile:
             return (
                 self.pending_burst_offset is not None
+                and self.pending_burst_seq is not None
+                and self.__seq_is_at_or_after(op.seq, self.pending_burst_seq)
                 and op.offset >= self.pending_burst_offset
             )
         if op.req_opcode == OP_ReadFile:
@@ -1530,6 +1549,11 @@ class MAVFTP:  # pylint: disable=too-many-instance-attributes
             return True
 
         return False
+
+    @staticmethod
+    def __seq_is_at_or_after(seq: int, expected: int) -> bool:
+        """Return whether a uint16 sequence is equal to or newer than expected."""
+        return ((seq - expected) & 0xFFFF) < 0x8000
 
     def __mavlink_packet(self, m) -> MAVFTPReturn:  # noqa: PLR0911, PGH004, pylint: disable=too-many-branches, too-many-return-statements
         """Handle a mavlink packet."""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 # Filter pytest to only running files with the following pattern
 [pytest]
+testpaths = tests
 python_files = test_*.py

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -713,6 +713,22 @@ class TestMAVFTPParamDecode(unittest.TestCase):
             self.assertIsNone(MAVFTP.ftp_param_decode(header + first + second))
         self.assertIn("parameter name is too long", logs.output[0])
 
+    def test_save_params_writes_integer_datatype_comments(self):
+        """Decoded integer type IDs produce the documented datatype comment."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            output = f"{tempdir}/params.txt"
+
+            MAVFTP.save_params(
+                {"TEST_PARAM": (1.0, 4)},
+                output,
+                "missionplanner",
+                add_datatype_comments=True,
+                add_timestamp_comment=False,
+            )
+
+            with open(output, encoding="utf-8") as param_file:
+                self.assertEqual(param_file.read(), "TEST_PARAM,1  # 32-bit float\n")
+
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):
     """Test MAVFTP payload decoding"""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -641,6 +641,28 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             self.assertEqual(result.error_code, FtpError.Fail)
             self.assertFalse(os.path.exists(destination))
 
+    def test_callback_exception_terminates_download(self):
+        """Callback exceptions are reported as FTP failures after session cleanup."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO(b"data")
+        ftp.filename = "-"
+        ftp.op_start = 1
+        ftp.requested_size = 4
+        ftp.read_total = 4
+        ftp.reached_eof = True
+        terminated = []
+        setattr(ftp, "_MAVFTP__terminate_session", lambda: terminated.append(True))
+
+        def failing_callback(_fh):
+            raise RuntimeError("decode failed")
+
+        ftp.callback = failing_callback
+
+        self.assertTrue(ftp._MAVFTP__check_read_finished())
+        self.assertEqual(terminated, [True])
+        self.assertIsNotNone(ftp.callback_failure)
+        self.assertEqual(ftp.callback_failure.error_code, FtpError.Fail)
+
     def test_callback_success_does_not_publish_download(self):
         """Regression: callbacks consume all four advertised bytes without publishing."""
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -79,13 +79,15 @@ class FakeMaster:  # pylint: disable=too-few-public-methods
         return None
 
 
-def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0):
+def ftp_reply(  # pylint: disable=too-many-arguments
+    seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0, session=0
+):
     """Create a parsed FTP response represented as a minimal MAVLink message."""
     data = bytearray(payload) if payload is not None else bytearray()
     return FakeFTPMessage(
         FTP_OP(
             seq=seq,
-            session=0,
+            session=session,
             opcode=opcode,
             size=len(data),
             req_opcode=req_opcode,
@@ -109,6 +111,26 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
         ftp.ftp_settings.read_retry_time = 0.01
         ftp.ftp_settings.retry_time = 0.2
         return ftp, master
+
+    def test_terminate_ignores_reply_for_wrong_target_or_session(self):
+        """TerminateSession accepts replies only from its target and session."""
+        for target_system, session in ((99, 0), (1, 1)):
+            with self.subTest(target_system=target_system, session=session):
+                ftp, master = self.make_ftp([])
+                ftp.pending_terminate_seq = ftp.seq
+                reply = ftp_reply(
+                    ftp.seq + 1,
+                    OP_Ack,
+                    OP_TerminateSession,
+                    session=session,
+                )
+                reply.target_system = target_system
+                master.replies.append(reply)
+
+                result = ftp.process_ftp_reply("TerminateSession")
+
+                self.assertEqual(result.error_code, FtpError.Fail)
+                self.assertEqual(ftp.pending_terminate_seq, ftp.seq)
 
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
@@ -160,19 +182,6 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
         self.assertEqual(master.replies, [])
         self.assertEqual(len(master.mav.sent), 3)
 
-    def test_follow_up_command_waits_after_completed_list(self):
-        ftp, master = self.make_ftp(
-            [ftp_reply(2, OP_Nack, OP_ListDirectory, payload=[FtpError.EndOfFile])]
-        )
-        self.assertEqual(ftp.cmd_list([]).error_code, FtpError.Success)
-
-        master.empty_polls = 1
-        master.replies.append(ftp_reply(3, OP_Ack, OP_RemoveFile))
-        result = ftp.cmd_rm(["remote"])
-
-        self.assertEqual(result.error_code, FtpError.Success)
-        self.assertEqual(master.replies, [])
-
     def test_out_of_order_burst_reply_is_dispatched(self):
         ftp, _master = self.make_ftp(
             [
@@ -184,17 +193,16 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
                     payload=b"x" * 80,
                     burst_complete=1,
                 ),
-                # This is the remaining part of the first burst. The next
-                # burst request has already been sent, so its sequence is
-                # older than last_op but still belongs to this download.
+                # The next burst starts at offset 80. This delayed duplicate
+                # from the completed burst must not reach its handler.
                 ftp_reply(
                     3,
                     OP_Ack,
                     OP_BurstReadFile,
-                    payload=b"y",
-                    offset=80,
+                    payload=b"x" * 80,
                     burst_complete=1,
                 ),
+                ftp_reply(4, OP_Ack, OP_BurstReadFile, payload=b"y", offset=80, burst_complete=1),
                 ftp_reply(5, OP_Ack, OP_TerminateSession),
             ]
         )
@@ -206,6 +214,90 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
         result = ftp.process_ftp_reply("get", timeout=1)
 
         self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(ftp.duplicates, 0)
+
+    def test_out_of_order_gap_reply_is_dispatched(self):
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_gaps = [(0, 2), (2, 2)]
+        ftp.read_gap_times = {(0, 2): 0, (2, 2): 0}
+
+        ftp._MAVFTP__send_gap_read((0, 2))  # pylint: disable=protected-access
+        ftp._MAVFTP__send_gap_read((2, 2))  # pylint: disable=protected-access
+
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(3, OP_Ack, OP_ReadFile, payload=b"cd", offset=2)
+        )
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(ftp.read_gaps, [(0, 2)])
+        self.assertEqual(ftp.fh.getvalue(), b"\x00\x00cd")
+
+        stale_result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(99, OP_Ack, OP_ReadFile, payload=b"zz", offset=0)
+        )
+
+        self.assertEqual(stale_result.error_code, FtpError.Fail)
+        self.assertEqual(ftp.read_gaps, [(0, 2)])
+        self.assertEqual(ftp.fh.getvalue(), b"\x00\x00cd")
+
+    def test_stale_write_reply_is_discarded(self):
+        ftp, master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_CreateFile),
+                ftp_reply(99, OP_Ack, OP_WriteFile, offset=0),
+            ]
+        )
+
+        ftp.cmd_put(["local", "remote"], fh=BytesIO(b"x"))
+        ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            master.replies.pop(0)
+        )
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            master.replies.pop(0)
+        )
+
+        self.assertEqual(result.error_code, FtpError.Fail)
+        self.assertIsNotNone(ftp.write_list)
+        self.assertEqual(ftp.write_acks, 0)
+
+    def test_noncurrent_write_nack_fails_upload(self):
+        ftp, _master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_CreateFile),
+                ftp_reply(
+                    3,
+                    OP_Nack,
+                    OP_WriteFile,
+                    payload=[FtpError.FileProtected],
+                    offset=0,
+                ),
+                ftp_reply(5, OP_Ack, OP_TerminateSession),
+            ]
+        )
+
+        ftp.cmd_put(["local", "remote"], fh=BytesIO(b"x" * 160))
+        result = ftp.process_ftp_reply("put", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.FileProtected)
+
+    def test_remove_accepts_16_bit_sequence_wrap(self):
+        ftp, master = self.make_ftp([])
+        ftp.seq = 255
+        master.replies.append(ftp_reply(256, OP_Ack, OP_RemoveFile))
+
+        result = ftp.cmd_rm(["remote"])
+
+        self.assertEqual(result.error_code, FtpError.Success)
+
+    def test_wrong_session_reply_is_not_retained(self):
+        ftp, master = self.make_ftp([])
+        master.replies.append(ftp_reply(2, OP_Ack, OP_RemoveFile, session=1))
+
+        result = ftp.cmd_rm(["remote"])
+
+        self.assertEqual(result.error_code, FtpError.Fail)
 
     def test_completed_put_skips_late_reply_after_termination_timeout(self):
         ftp, master = self.make_ftp(

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -155,6 +155,25 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.session, 42)
         self.assertEqual(master.mav.sent[-1][-1][2], 42)
 
+    def test_cmd_get_clears_range_read_state(self):
+        """A normal download must not inherit a prior range-read offset."""
+        ftp, master = self.make_ftp([])
+        ftp.requested_offset = 123
+        ftp.requested_size = 2
+
+        try:
+            ftp.cmd_get(["remote", "download"])
+            ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[4, 0, 0, 0], session=7)
+            )
+
+            self.assertEqual(ftp.requested_offset, 0)
+            self.assertEqual(ftp.requested_size, 4)
+            self.assertEqual(ftp.fh.tell(), 0)
+            self.assertEqual(struct.unpack_from("<I", master.mav.sent[-1][-1], 8)[0], 0)
+        finally:
+            ftp._MAVFTP__release_staging()  # pylint: disable=protected-access
+
     def test_create_file_ack_uses_allocated_session(self):
         """A non-echoing CreateFile server session is used for WriteFile."""
         ftp, master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -196,6 +196,28 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(result.error_code, FtpError.FileNotFound)
         self.assertEqual(terminated, [True])
 
+    def test_unexpected_short_gap_ack_reports_failure(self):
+        """A short reply for an unknown gap must not report a completed read."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        ftp.read_gaps = [(4, 2)]
+        ftp.read_gap_times = {(4, 2): 1}
+        terminated = []
+        setattr(
+            ftp,
+            "_MAVFTP__terminate_session",
+            lambda: terminated.append(True),
+        )
+
+        result = ftp._MAVFTP__handle_reply_read(
+            FTP_OP(1, 0, OP_Ack, 1, OP_ReadFile, 0, 0, bytearray(b"x")),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.Fail)
+        self.assertEqual(terminated, [True])
+
     def test_write_nack_preserves_server_error(self):
         """WriteFile NACKs retain their precise protocol error code."""
         ftp, _master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -8,17 +8,270 @@ SPDX-FileCopyrightText: 2024 Amilcar Lucas
 SPDX-License-Identifier: GPL-3.0-or-later
 '''
 
-import unittest
-#from unittest.mock import patch
-from io import StringIO
 import logging
+import os
+import struct
+import tempfile
+import unittest
+from io import BytesIO, StringIO
+
+#from unittest.mock import patch
 from pymavlink import mavutil
-from pymavlink.mavftp import FTP_OP, MAVFTP, MAVFTPReturn
-from pymavlink.mavftp import FtpError
-from pymavlink.mavftp import OP_ListDirectory
-from pymavlink.mavftp import OP_ReadFile
-from pymavlink.mavftp import OP_Ack
-from pymavlink.mavftp import OP_Nack
+from pymavlink.mavftp import (
+    FTP_OP,
+    MAVFTP,
+    FtpError,
+    MAVFTPReturn,
+    OP_Ack,
+    OP_BurstReadFile,
+    OP_CreateFile,
+    OP_ListDirectory,
+    OP_Nack,
+    OP_OpenFileRO,
+    OP_ReadFile,
+    OP_ResetSessions,
+    OP_TerminateSession,
+    OP_WriteFile,
+)
+
+
+class FakeFTPMessage:
+    """Minimal FILE_TRANSFER_PROTOCOL message for reply-loop tests."""
+
+    def __init__(self, op):
+        self.payload = op.pack()
+        self.target_system = 1
+        self.target_component = 1
+
+    @staticmethod
+    def get_type():
+        return "FILE_TRANSFER_PROTOCOL"
+
+
+class FakeMAV:
+    """Record FTP sends without requiring a MAVLink transport."""
+
+    def __init__(self):
+        self.sent = []
+
+    def file_transfer_protocol_send(self, *args):
+        self.sent.append(args)
+
+
+class FakeMaster:
+    """Serve a predetermined sequence of FTP replies."""
+
+    source_system = 1
+    source_component = 1
+
+    def __init__(self, replies):
+        self.mav = FakeMAV()
+        self.replies = replies
+
+    def recv_match(self, **_kwargs):
+        if self.replies:
+            return self.replies.pop(0)
+        return None
+
+
+def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0):
+    """Create a parsed FTP response represented as a minimal MAVLink message."""
+    data = bytearray(payload) if payload is not None else bytearray()
+    return FakeFTPMessage(
+        FTP_OP(
+            seq=seq,
+            session=0,
+            opcode=opcode,
+            size=len(data),
+            req_opcode=req_opcode,
+            burst_complete=burst_complete,
+            offset=offset,
+            payload=data,
+        )
+    )
+
+
+class TestMAVFTPReplyCompletion(unittest.TestCase):
+    """Regression tests for command completion and idle fallback."""
+
+    @staticmethod
+    def make_ftp(replies):
+        master = FakeMaster(
+            [ftp_reply(1, OP_Ack, OP_ResetSessions)] + replies
+        )
+        ftp = MAVFTP(master, target_system=1, target_component=1)
+        ftp.ftp_settings.idle_detection_time = 0.02
+        ftp.ftp_settings.read_retry_time = 0.01
+        ftp.ftp_settings.retry_time = 0.2
+        return ftp, master
+
+    def test_put_returns_after_completion_before_late_write_reply(self):
+        ftp, master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_CreateFile),
+                ftp_reply(3, OP_Ack, OP_WriteFile, offset=0),
+                ftp_reply(5, OP_Ack, OP_TerminateSession),
+                ftp_reply(3, OP_Ack, OP_WriteFile, offset=0),
+            ]
+        )
+
+        ftp.cmd_put(["local", "remote"], fh=BytesIO(b"x"))
+        result = ftp.process_ftp_reply("put", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(len(master.replies), 1)
+
+    def test_list_returns_after_eof_before_late_error(self):
+        ftp, master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Nack, OP_ListDirectory, payload=[FtpError.EndOfFile]),
+                ftp_reply(3, OP_Nack, OP_ListDirectory, payload=[FtpError.Fail]),
+            ]
+        )
+
+        result = ftp.cmd_list([])
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(len(master.replies), 1)
+
+    def test_stale_list_ack_does_not_resend_remove(self):
+        ftp, master = self.make_ftp(
+            [ftp_reply(2, OP_Nack, OP_ListDirectory, payload=[FtpError.EndOfFile])]
+        )
+        self.assertEqual(ftp.cmd_list([]).error_code, FtpError.Success)
+
+        # A delayed list ACK arrives while waiting for RemoveFile. It must not
+        # be dispatched to __handle_list_reply(), which would resend last_op
+        # (the RemoveFile request) with a new sequence number.
+        master.replies.extend(
+            [
+                ftp_reply(2, OP_Ack, OP_ListDirectory),
+                ftp_reply(3, OP_Ack, OP_RemoveFile),
+            ]
+        )
+        result = ftp.cmd_rm(["remote"])
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(master.replies, [])
+        self.assertEqual(len(master.mav.sent), 3)
+
+    def test_out_of_order_burst_reply_is_dispatched(self):
+        ftp, _master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[81, 0, 0, 0]),
+                ftp_reply(
+                    3,
+                    OP_Ack,
+                    OP_BurstReadFile,
+                    payload=b"x" * 80,
+                    burst_complete=1,
+                ),
+                # This is the remaining part of the first burst. The next
+                # burst request has already been sent, so its sequence is
+                # older than last_op but still belongs to this download.
+                ftp_reply(3, OP_Ack, OP_BurstReadFile, payload=b"y", offset=80, burst_complete=1),
+                ftp_reply(5, OP_Ack, OP_TerminateSession),
+            ]
+        )
+
+        ftp.cmd_get(
+            ["remote", "-"],
+            callback=lambda _fh: MAVFTPReturn("Get", FtpError.Success),
+        )
+        result = ftp.process_ftp_reply("get", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.Success)
+
+    def test_completed_put_skips_late_reply_after_termination_timeout(self):
+        ftp, master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_WriteFile),
+                ftp_reply(3, OP_Ack, OP_WriteFile),
+            ]
+        )
+        ftp.pending_terminate_seq = 7
+
+        def complete_operation(_message):
+            ftp.completed_reply = (OP_WriteFile, 6)
+            return MAVFTPReturn("WriteFile", FtpError.Success)
+
+        setattr(ftp, "_MAVFTP__mavlink_packet", complete_operation)
+        result = ftp.process_ftp_reply("put", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(len(master.replies), 1)
+
+    def test_incomplete_burst_read_reports_timeout_on_idle(self):
+        ftp, _master = self.make_ftp(
+            [
+                ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[160, 0, 0, 0]),
+                ftp_reply(3, OP_Ack, OP_BurstReadFile, payload=b"x" * 80),
+            ]
+        )
+
+        ftp.cmd_get(
+            ["remote"],
+            callback=lambda _fh: MAVFTPReturn("Get", FtpError.Success),
+        )
+        result = ftp.process_ftp_reply("get", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.RemoteReplyTimeout)
+        self.assertIsNone(ftp.get_result)
+
+    def test_callback_failure_does_not_publish_download(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            destination = f"{tempdir}/param.pck"
+            ftp, _master = self.make_ftp(
+                [
+                    ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[3, 0, 0, 0]),
+                    ftp_reply(
+                        3,
+                        OP_Ack,
+                        OP_BurstReadFile,
+                        payload=b"bad",
+                        burst_complete=1,
+                    ),
+                    ftp_reply(4, OP_Ack, OP_TerminateSession),
+                ]
+            )
+
+            ftp.cmd_get(
+                ["@PARAM/param.pck", destination],
+                callback=lambda _fh: MAVFTPReturn("GetParams", FtpError.Fail),
+            )
+            result = ftp.process_ftp_reply("getparams", timeout=1)
+
+            self.assertEqual(result.error_code, FtpError.Fail)
+            self.assertFalse(os.path.exists(destination))
+
+
+class TestMAVFTPParamDecode(unittest.TestCase):
+    """Validate packed parameter name constraints."""
+
+    @staticmethod
+    def packed_param(name):
+        # A float parameter with one name component and no defaults.
+        header = struct.pack("<HHH", 0x671B, 1, 1)
+        record = (
+            struct.pack("<BB", 4, (len(name) - 1) << 4)
+            + name
+            + struct.pack("<f", 1.0)
+        )
+        return header + record
+
+    def test_rejects_non_utf8_name(self):
+        with self.assertLogs(level="ERROR") as logs:
+            self.assertIsNone(MAVFTP.ftp_param_decode(self.packed_param(b"bad\xff")))
+        self.assertIn("parameter name is not valid UTF-8", logs.output[0])
+
+    def test_rejects_name_longer_than_16_bytes(self):
+        header = struct.pack("<HHH", 0x671B, 2, 2)
+        first = struct.pack("<BB", 4, 15 << 4) + b"A" * 16 + struct.pack("<f", 1.0)
+        # Reuse 15 bytes of the previous name and append two bytes.
+        second = struct.pack("<BB", 4, (1 << 4) | 15) + b"BC" + struct.pack("<f", 1.0)
+        with self.assertLogs(level="ERROR") as logs:
+            self.assertIsNone(MAVFTP.ftp_param_decode(header + first + second))
+        self.assertIn("parameter name is too long", logs.output[0])
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):
     """Test MAVFTP payload decoding"""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -244,6 +244,26 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(result.error_code, FtpError.Fail)
         self.assertEqual(terminated, [True])
 
+    def test_malformed_directory_entry_reports_invalid_data(self):
+        """A malformed file listing entry must not crash reply processing."""
+        ftp, _master = self.make_ftp([])
+
+        result = ftp._MAVFTP__handle_list_reply(
+            FTP_OP(
+                1,
+                0,
+                OP_Ack,
+                len(b"Fmissing-size"),
+                OP_ListDirectory,
+                0,
+                0,
+                bytearray(b"Fmissing-size"),
+            ),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.InvalidDataSize)
+
     def test_write_nack_preserves_server_error(self):
         """WriteFile NACKs retain their precise protocol error code."""
         ftp, _master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -29,6 +29,7 @@ from pymavlink.mavftp import (
     OP_Nack,
     OP_OpenFileRO,
     OP_ReadFile,
+    OP_RemoveFile,
     OP_ResetSessions,
     OP_TerminateSession,
     OP_WriteFile,
@@ -67,14 +68,18 @@ class FakeMaster:  # pylint: disable=too-few-public-methods
     def __init__(self, replies):
         self.mav = FakeMAV()
         self.replies = replies
+        self.empty_polls = 0
 
     def recv_match(self, **_kwargs):
+        if self.empty_polls:
+            self.empty_polls -= 1
+            return None
         if self.replies:
             return self.replies.pop(0)
         return None
 
 
-def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0):
+def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0):
     """Create a parsed FTP response represented as a minimal MAVLink message."""
     data = bytearray(payload) if payload is not None else bytearray()
     return FakeFTPMessage(
@@ -84,7 +89,7 @@ def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0):
             opcode=opcode,
             size=len(data),
             req_opcode=req_opcode,
-            burst_complete=0,
+            burst_complete=burst_complete,
             offset=offset,
             payload=data,
         )
@@ -154,6 +159,19 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
         self.assertEqual(result.error_code, FtpError.Success)
         self.assertEqual(master.replies, [])
         self.assertEqual(len(master.mav.sent), 3)
+
+    def test_follow_up_command_waits_after_completed_list(self):
+        ftp, master = self.make_ftp(
+            [ftp_reply(2, OP_Nack, OP_ListDirectory, payload=[FtpError.EndOfFile])]
+        )
+        self.assertEqual(ftp.cmd_list([]).error_code, FtpError.Success)
+
+        master.empty_polls = 1
+        master.replies.append(ftp_reply(3, OP_Ack, OP_RemoveFile))
+        result = ftp.cmd_rm(["remote"])
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(master.replies, [])
 
     def test_out_of_order_burst_reply_is_dispatched(self):
         ftp, _master = self.make_ftp(

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -293,6 +293,16 @@ class TestMAVFTPParamDecode(unittest.TestCase):
             self.assertIsNone(MAVFTP.ftp_param_decode(self.packed_param(b"bad\xff")))
         self.assertIn("parameter name is not valid UTF-8", logs.output[0])
 
+    def test_rejects_count_larger_than_total(self):
+        first = self.packed_param(b"PARAM_A")[6:]
+        second = self.packed_param(b"PARAM_B")[6:]
+        data = struct.pack("<HHH", 0x671B, 2, 1) + first + second
+
+        with self.assertLogs(level="ERROR") as logs:
+            self.assertIsNone(MAVFTP.ftp_param_decode(data))
+
+        self.assertIn("parameter count 2 exceeds total count 1", logs.output[0])
+
     def test_rejects_name_longer_than_16_bytes(self):
         header = struct.pack("<HHH", 0x671B, 2, 2)
         first = struct.pack("<BB", 4, 15 << 4) + b"A" * 16 + struct.pack("<f", 1.0)

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -15,7 +15,7 @@ import tempfile
 import unittest
 from io import BytesIO, StringIO
 
-#from unittest.mock import patch
+from unittest.mock import patch
 from pymavlink import mavutil
 from pymavlink.mavftp import (
     FTP_OP,
@@ -34,6 +34,8 @@ from pymavlink.mavftp import (
     OP_TerminateSession,
     OP_WriteFile,
 )
+
+# pylint: disable=protected-access
 
 
 class FakeFTPMessage:  # pylint: disable=too-few-public-methods
@@ -98,8 +100,8 @@ def ftp_reply(  # pylint: disable=too-many-arguments
     )
 
 
-class TestMAVFTPReplyCompletion(unittest.TestCase):
-    """Regression tests for command completion and idle fallback."""
+class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-public-methods
+    """Regression tests for FTP replies, retries, and session cleanup."""
 
     @staticmethod
     def make_ftp(replies):
@@ -132,12 +134,179 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
                 self.assertEqual(result.error_code, FtpError.Fail)
                 self.assertEqual(ftp.pending_terminate_seq, ftp.seq)
 
+    @staticmethod
+    def sent_request_sequences(master, opcode):
+        """Return FTP request sequence numbers sent for an opcode."""
+        return [
+            struct.unpack_from("<H", sent[-1])[0]
+            for sent in master.mav.sent
+            if sent[-1][3] == opcode
+        ]
+
+    def test_open_file_ack_uses_allocated_session(self):
+        """A non-echoing OpenFileRO server session is used for BurstReadFile."""
+        ftp, master = self.make_ftp([])
+        ftp.cmd_get(["remote", "-"])
+
+        ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[1, 0, 0, 0], session=42)
+        )
+
+        self.assertEqual(ftp.session, 42)
+        self.assertEqual(master.mav.sent[-1][-1][2], 42)
+
+    def test_create_file_ack_uses_allocated_session(self):
+        """A non-echoing CreateFile server session is used for WriteFile."""
+        ftp, master = self.make_ftp([])
+        ftp.cmd_put(["local", "remote"], fh=BytesIO(b"x"))
+
+        ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_CreateFile, session=37)
+        )
+
+        self.assertEqual(ftp.session, 37)
+        self.assertEqual(master.mav.sent[-1][-1][2], 37)
+
+    def test_gap_read_nack_preserves_server_error(self):
+        """A failed gap repair must not turn a ReadFile NACK into success."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        terminated = []
+        setattr(
+            ftp,
+            "_MAVFTP__terminate_session",
+            lambda: terminated.append(True),
+        )
+
+        result = ftp._MAVFTP__handle_reply_read(
+            FTP_OP(
+                1,
+                0,
+                OP_Nack,
+                1,
+                OP_ReadFile,
+                0,
+                0,
+                bytearray([FtpError.FileNotFound]),
+            ),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.FileNotFound)
+        self.assertEqual(terminated, [True])
+
+    def test_write_nack_preserves_server_error(self):
+        """WriteFile NACKs retain their precise protocol error code."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        terminated = []
+        setattr(
+            ftp,
+            "_MAVFTP__terminate_session",
+            lambda: terminated.append(True),
+        )
+
+        result = ftp._MAVFTP__handle_write_reply(  # pylint: disable=protected-access
+            FTP_OP(
+                1,
+                0,
+                OP_Nack,
+                2,
+                OP_WriteFile,
+                0,
+                0,
+                bytearray([FtpError.FailErrno, 13]),
+            ),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.FailErrno)
+        self.assertEqual(result.system_error, 13)
+        self.assertEqual(terminated, [True])
+
+    def test_gap_read_retry_reuses_request_sequence(self):
+        """Retransmitting a lost ReadFile reply keeps the original sequence."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        ftp.read_gaps = [(0, 2)]
+        ftp.read_gap_times = {(0, 2): 0}
+
+        ftp._MAVFTP__send_gap_read((0, 2))  # pylint: disable=protected-access
+        ftp._MAVFTP__send_gap_read((0, 2))  # pylint: disable=protected-access
+
+        self.assertEqual(self.sent_request_sequences(master, OP_ReadFile), [1, 1])
+
+    def test_open_retry_reuses_request_sequence(self):
+        """Retransmitting an unanswered OpenFileRO preserves its sequence."""
+        ftp, master = self.make_ftp([])
+        ftp.cmd_get(["remote", "-"])
+        ftp.op_start = 0
+
+        with patch("pymavlink.mavftp.time.time", return_value=1):
+            ftp._MAVFTP__idle_task()  # pylint: disable=protected-access
+
+        self.assertEqual(self.sent_request_sequences(master, OP_OpenFileRO), [1, 1])
+
+    def test_write_retry_reuses_request_sequence(self):
+        """Retransmitting a lost WriteFile reply keeps the original sequence."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO(b"x")
+        ftp.filename = "remote"
+        ftp.write_list = {0}
+        ftp.write_block_size = 1
+        ftp.write_total = 1
+
+        ftp._MAVFTP__send_more_writes()  # pylint: disable=protected-access
+        ftp.write_last_send = 0
+        ftp._MAVFTP__send_more_writes()  # pylint: disable=protected-access
+
+        self.assertEqual(self.sent_request_sequences(master, OP_WriteFile), [1, 1])
+
+    def test_process_timeout_terminates_active_session(self):
+        """A reply-loop timeout closes an opened remote file session."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        terminated = []
+        setattr(
+            ftp,
+            "_MAVFTP__terminate_session",
+            lambda: terminated.append(True),
+        )
+        setattr(
+            ftp,
+            "_MAVFTP__idle_task",
+            lambda: False,
+        )
+
+        result = ftp.process_ftp_reply("get", timeout=0.03)
+
+        self.assertEqual(result.error_code, FtpError.RemoteReplyTimeout)
+        self.assertEqual(terminated, [True])
+
+    def test_read_timeout_terminates_active_session(self):
+        """The synchronous read API also closes its session on timeout."""
+        ftp, _master = self.make_ftp([])
+        terminated = []
+        setattr(
+            ftp,
+            "_MAVFTP__terminate_session",
+            lambda: terminated.append(True),
+        )
+
+        with patch("pymavlink.mavftp.time.time", side_effect=[0, 0, 0, 0, 6]):
+            self.assertIsNone(ftp.read("remote", 1))
+
+        self.assertEqual(terminated, [True])
+
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
             [
                 ftp_reply(2, OP_Ack, OP_CreateFile),
                 ftp_reply(3, OP_Ack, OP_WriteFile, offset=0),
-                ftp_reply(5, OP_Ack, OP_TerminateSession),
+                ftp_reply(4, OP_Ack, OP_TerminateSession),
                 ftp_reply(3, OP_Ack, OP_WriteFile, offset=0),
             ]
         )

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -167,6 +167,32 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.session, 37)
         self.assertEqual(master.mav.sent[-1][-1][2], 37)
 
+    def test_cmd_set_rejects_unsafe_transfer_settings(self):
+        """Transfer settings must remain valid for the FTP state machine."""
+        ftp, _master = self.make_ftp([])
+
+        for setting, value in (
+            ("write_size", "0"),
+            ("write_size", "240"),
+            ("write_qsize", "0"),
+            ("max_backlog", "0"),
+            ("retry_time", "0.1"),
+            ("idle_detection_time", "0.01"),
+            ("read_retry_time", "3.7"),
+        ):
+            with self.subTest(setting=setting, value=value):
+                result = ftp.cmd_set([setting, value])
+                self.assertEqual(result.error_code, FtpError.InvalidArguments)
+
+    def test_put_rejects_invalid_write_size(self):
+        """An API-set invalid write size must not reach division or packet packing."""
+        ftp, _master = self.make_ftp([])
+        ftp.ftp_settings.write_size = 0
+
+        result = ftp.cmd_put(["local", "remote"], fh=BytesIO(b"x"))
+
+        self.assertEqual(result.error_code, FtpError.InvalidArguments)
+
     def test_gap_read_nack_preserves_server_error(self):
         """A failed gap repair must not turn a ReadFile NACK into success."""
         ftp, _master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -296,7 +296,13 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             lambda: terminated.append(True),
         )
 
-        with patch("pymavlink.mavftp.time.time", side_effect=[0, 0, 0, 0, 6]):
+        clock_calls = [0]
+
+        def fake_time():
+            clock_calls[0] += 1
+            return 0 if clock_calls[0] <= 20 else 6
+
+        with patch("pymavlink.mavftp.time.time", side_effect=fake_time):
             self.assertIsNone(ftp.read("remote", 1))
 
         self.assertEqual(terminated, [True])
@@ -410,6 +416,49 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(stale_result.error_code, FtpError.Fail)
         self.assertEqual(ftp.read_gaps, [(0, 2)])
         self.assertEqual(ftp.fh.getvalue(), b"\x00\x00cd")
+
+    def test_out_of_order_final_gap_reply_reports_success(self):
+        """A successful final gap repair completes a read when it is not last_op."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.op_start = 1
+        ftp.requested_size = 240
+        ftp.burst_size = 239
+        ftp.reached_eof = True
+        ftp.read_gaps = [(0, 120), (120, 120)]
+        ftp.read_gap_times = {(0, 120): 0, (120, 120): 0}
+
+        ftp._MAVFTP__send_gap_read((0, 120))
+        ftp._MAVFTP__send_gap_read((120, 120))
+        # A burst request was sent after the gap requests, so neither gap
+        # reply matches last_op even though both remain active requests.
+        ftp._MAVFTP__send(
+            FTP_OP(
+                ftp.seq,
+                ftp.session,
+                OP_BurstReadFile,
+                239,
+                0,
+                0,
+                240,
+                None,
+            )
+        )
+        master.replies.extend(
+            [
+                ftp_reply(3, OP_Ack, OP_ReadFile, payload=b"b" * 120, offset=120),
+                ftp_reply(2, OP_Ack, OP_ReadFile, payload=b"a" * 120, offset=0),
+                ftp_reply(5, OP_Ack, OP_TerminateSession),
+            ]
+        )
+
+        result = ftp.process_ftp_reply("get", timeout=1)
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertTrue(ftp.read_complete)
+        self.assertEqual(ftp.read_gaps, [])
+        self.assertEqual(ftp.get_result, b"a" * 120 + b"b" * 120)
 
     def test_stale_write_reply_is_discarded(self):
         ftp, master = self.make_ftp(

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -530,6 +530,38 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             self.assertEqual(result.error_code, FtpError.Fail)
             self.assertFalse(os.path.exists(destination))
 
+    def test_callback_success_does_not_publish_download(self):
+        with tempfile.TemporaryDirectory() as tempdir:
+            destination = f"{tempdir}/param.pck"
+            callback_data = []
+            ftp, _master = self.make_ftp(
+                [
+                    ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[3, 0, 0, 0]),
+                    ftp_reply(
+                        3,
+                        OP_Ack,
+                        OP_BurstReadFile,
+                        payload=b"data",
+                        burst_complete=1,
+                    ),
+                    ftp_reply(4, OP_Ack, OP_TerminateSession),
+                ]
+            )
+
+            def callback(fh):
+                callback_data.append(fh.read())
+                return MAVFTPReturn("GetParams", FtpError.Success)
+
+            ftp.cmd_get(
+                ["@PARAM/param.pck?withdefaults=1", destination],
+                callback=callback,
+            )
+            result = ftp.process_ftp_reply("getparams", timeout=1)
+
+            self.assertEqual(result.error_code, FtpError.Success)
+            self.assertEqual(callback_data, [b"data"])
+            self.assertFalse(os.path.exists(destination))
+
     def test_malformed_burst_nacks_are_decoded(self):
         for payload, expected_error in (
             (b"", FtpError.NoErrorCodeInPayload),

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -35,7 +35,7 @@ from pymavlink.mavftp import (
 )
 
 
-class FakeFTPMessage:
+class FakeFTPMessage:  # pylint: disable=too-few-public-methods
     """Minimal FILE_TRANSFER_PROTOCOL message for reply-loop tests."""
 
     def __init__(self, op):
@@ -48,7 +48,7 @@ class FakeFTPMessage:
         return "FILE_TRANSFER_PROTOCOL"
 
 
-class FakeMAV:
+class FakeMAV:  # pylint: disable=too-few-public-methods
     """Record FTP sends without requiring a MAVLink transport."""
 
     def __init__(self):
@@ -58,7 +58,7 @@ class FakeMAV:
         self.sent.append(args)
 
 
-class FakeMaster:
+class FakeMaster:  # pylint: disable=too-few-public-methods
     """Serve a predetermined sequence of FTP replies."""
 
     source_system = 1
@@ -74,7 +74,7 @@ class FakeMaster:
         return None
 
 
-def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0):
+def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0):
     """Create a parsed FTP response represented as a minimal MAVLink message."""
     data = bytearray(payload) if payload is not None else bytearray()
     return FakeFTPMessage(
@@ -84,7 +84,7 @@ def ftp_reply(seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0)
             opcode=opcode,
             size=len(data),
             req_opcode=req_opcode,
-            burst_complete=burst_complete,
+            burst_complete=0,
             offset=offset,
             payload=data,
         )
@@ -169,7 +169,14 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
                 # This is the remaining part of the first burst. The next
                 # burst request has already been sent, so its sequence is
                 # older than last_op but still belongs to this download.
-                ftp_reply(3, OP_Ack, OP_BurstReadFile, payload=b"y", offset=80, burst_complete=1),
+                ftp_reply(
+                    3,
+                    OP_Ack,
+                    OP_BurstReadFile,
+                    payload=b"y",
+                    offset=80,
+                    burst_complete=1,
+                ),
                 ftp_reply(5, OP_Ack, OP_TerminateSession),
             ]
         )
@@ -244,6 +251,28 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):
             self.assertEqual(result.error_code, FtpError.Fail)
             self.assertFalse(os.path.exists(destination))
 
+    def test_malformed_burst_nacks_are_decoded(self):
+        for payload, expected_error in (
+            (b"", FtpError.NoErrorCodeInPayload),
+            (b"\xff", FtpError.InvalidErrorCode),
+        ):
+            with self.subTest(payload=payload):
+                ftp, master = self.make_ftp(
+                    [
+                        ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[1, 0, 0, 0]),
+                        ftp_reply(3, OP_Nack, OP_BurstReadFile, payload=payload),
+                        ftp_reply(4, OP_Ack, OP_TerminateSession),
+                    ]
+                )
+                ftp.cmd_get(
+                    ["remote", "-"],
+                    callback=lambda _fh: MAVFTPReturn("Get", FtpError.Success),
+                )
+                result = ftp.process_ftp_reply("get", timeout=1)
+
+                self.assertEqual(result.error_code, expected_error)
+                self.assertEqual(master.replies, [])
+
 
 class TestMAVFTPParamDecode(unittest.TestCase):
     """Validate packed parameter name constraints."""
@@ -272,6 +301,7 @@ class TestMAVFTPParamDecode(unittest.TestCase):
         with self.assertLogs(level="ERROR") as logs:
             self.assertIsNone(MAVFTP.ftp_param_decode(header + first + second))
         self.assertIn("parameter name is too long", logs.output[0])
+
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):
     """Test MAVFTP payload decoding"""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -554,6 +554,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertIsNone(ftp.get_result)
 
     def test_callback_failure_does_not_publish_download(self):
+        """Regression: a failing callback must not publish its temporary download."""
         with tempfile.TemporaryDirectory() as tempdir:
             destination = f"{tempdir}/param.pck"
             ftp, _master = self.make_ftp(
@@ -580,12 +581,13 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             self.assertFalse(os.path.exists(destination))
 
     def test_callback_success_does_not_publish_download(self):
+        """Regression: callbacks consume all four advertised bytes without publishing."""
         with tempfile.TemporaryDirectory() as tempdir:
             destination = f"{tempdir}/param.pck"
             callback_data = []
             ftp, _master = self.make_ftp(
                 [
-                    ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[3, 0, 0, 0]),
+                    ftp_reply(2, OP_Ack, OP_OpenFileRO, payload=[4, 0, 0, 0]),
                     ftp_reply(
                         3,
                         OP_Ack,

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -307,6 +307,45 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(terminated, [True])
 
+    def test_read_sector_returns_only_requested_range_without_local_output(self):
+        """A sector read starts at its offset and must not publish the remote path."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            previous_cwd = os.getcwd()
+            os.chdir(tempdir)
+            try:
+                ftp, master = self.make_ftp(
+                    [
+                        ftp_reply(
+                            2,
+                            OP_Ack,
+                            OP_OpenFileRO,
+                            payload=[8, 0, 0, 0],
+                            session=7,
+                        ),
+                        ftp_reply(
+                            3,
+                            OP_Ack,
+                            OP_BurstReadFile,
+                            payload=b"defgh",
+                            offset=3,
+                            burst_complete=1,
+                            session=7,
+                        ),
+                        ftp_reply(4, OP_Ack, OP_TerminateSession, session=7),
+                    ]
+                )
+
+                self.assertEqual(ftp.read_sector("remote", 3, 2), b"de")
+                self.assertFalse(os.path.exists("remote"))
+                burst_request = next(
+                    sent[-1]
+                    for sent in master.mav.sent
+                    if sent[-1][3] == OP_BurstReadFile
+                )
+                self.assertEqual(struct.unpack_from("<I", burst_request, 8)[0], 3)
+            finally:
+                os.chdir(previous_cwd)
+
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -35,7 +35,7 @@ from pymavlink.mavftp import (
     OP_WriteFile,
 )
 
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-many-lines
 
 
 class FakeFTPMessage:  # pylint: disable=too-few-public-methods

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -270,6 +270,14 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
                 result = ftp.cmd_set([setting, value])
                 self.assertEqual(result.error_code, FtpError.InvalidArguments)
 
+    def test_cmd_set_rejects_an_integer_too_large_for_float(self):
+        """An overflow while normalising an API-provided integer is invalid input."""
+        ftp, _master = self.make_ftp([])
+
+        result = ftp.cmd_set(["debug", 10**1000])
+
+        self.assertEqual(result.error_code, FtpError.InvalidArguments)
+
     def test_put_rejects_invalid_write_size(self):
         """An API-set invalid write size must not reach division or packet packing."""
         ftp, _master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -793,22 +793,27 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.fh.getvalue(), b"")
 
     def test_burst_reply_before_pending_offset_is_discarded(self):
-        """A delayed reply for an earlier burst must not write into this one."""
+        """A delayed reply must not repair a gap before the active burst."""
         ftp, _master = self.make_ftp([])
-        ftp.fh = BytesIO()
+        ftp.fh = BytesIO(b"a" * 80 + b"\0" * 80 + b"b" * 80)
+        ftp.fh.seek(240)
         ftp.filename = "-"
         ftp.read_to_memory = True
-        ftp.requested_offset = 80
-        ftp.pending_burst_offset = 80
+        ftp.requested_size = 240
+        ftp.read_total = 160
+        ftp.read_gaps = [(80, 80)]
+        ftp.read_gap_times = {(80, 80): 0}
+        ftp.pending_burst_offset = 240
         ftp.pending_burst_seq = 2
-        ftp.pending_burst_request = FTP_OP(1, 0, OP_BurstReadFile, 40, 0, 0, 80, None)
+        ftp.pending_burst_request = FTP_OP(1, 0, OP_BurstReadFile, 80, 0, 0, 240, None)
 
         result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
-            ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"stale", offset=0)
+            ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"s" * 80, offset=80)
         )
 
         self.assertEqual(result.error_code, FtpError.Fail)
-        self.assertEqual(ftp.fh.getvalue(), b"")
+        self.assertEqual(ftp.fh.getvalue(), b"a" * 80 + b"\0" * 80 + b"b" * 80)
+        self.assertEqual(ftp.read_gaps, [(80, 80)])
 
     def test_burst_reply_requires_pending_offset(self):
         """Burst packets are ignored until a request establishes its offset."""
@@ -1128,6 +1133,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(first_result.error_code, FtpError.Success)
         self.assertEqual(second_result.error_code, FtpError.InvalidDataSize)
         self.assertEqual(len(ftp.read_gaps), MAX_READ_GAPS)
+
     def test_stalled_burst_retries_from_current_read_position(self):
         """A stalled burst retains its sequence but resumes at the next byte."""
         ftp, master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -414,6 +414,62 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             finally:
                 os.chdir(previous_cwd)
 
+    def test_read_sector_stops_after_requested_range_in_full_burst(self):
+        """A full burst must not continue after a small range is satisfied."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        ftp.read_to_memory = True
+        ftp.requested_offset = 0
+        ftp.requested_size = 2
+        ftp.op_start = 1
+        ftp.burst_size = 80
+        ftp.session = 7
+        ftp.pending_burst_request = FTP_OP(
+            seq=1,
+            session=7,
+            opcode=OP_BurstReadFile,
+            size=80,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+
+        result = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=2,
+                session=7,
+                opcode=OP_Ack,
+                size=80,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=1,
+                offset=0,
+                payload=bytearray(b"x" * 80),
+            ),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertTrue(ftp.done)
+        self.assertEqual(ftp.get_result, b"xx")
+        self.assertEqual(master.mav.sent[-1][-1][3], OP_TerminateSession)
+        self.assertNotIn(
+            OP_BurstReadFile, [sent[-1][3] for sent in master.mav.sent[1:]]
+        )
+
+    def test_full_download_waits_for_eof_when_size_is_underestimated(self):
+        """A full download must not finish at an estimated remote file size."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO(b"data")
+        ftp.filename = "-"
+        ftp.requested_size = 4
+        ftp.read_total = 4
+        ftp.op_start = 1
+        setattr(ftp, "_MAVFTP__terminate_session", lambda: None)
+
+        self.assertFalse(ftp._MAVFTP__check_read_finished())
+
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -1159,6 +1159,33 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.pending_burst_seq, 18)
         self.assertEqual(ftp.seq, next_request_sequence)
 
+    def test_stalled_range_burst_retry_uses_absolute_remote_offset(self):
+        """A range retry includes the requested remote offset in its resume point."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO(b"x" * 120)
+        ftp.fh.seek(80)
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_offset = 1000
+        ftp.last_burst_read = 10
+        ftp.pending_burst_seq = 501
+        ftp.pending_burst_request = FTP_OP(
+            seq=17,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=40,
+            req_opcode=0,
+            burst_complete=0,
+            offset=1000,
+            payload=None,
+        )
+
+        with patch("pymavlink.mavftp.time.time", return_value=11):
+            ftp._MAVFTP__idle_task()
+
+        request = master.mav.sent[-1][-1]
+        self.assertEqual(struct.unpack_from("<I", request, 8)[0], 1080)
+
     def test_out_of_order_gap_reply_is_dispatched(self):
         ftp, _master = self.make_ftp([])
         ftp.fh = BytesIO()

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -507,6 +507,60 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertTrue(ftp._MAVFTP__check_read_finished())
         self.assertEqual(ftp.get_result, b"x" * 200)
 
+    def test_read_sector_relative_buffer_preserves_remote_gap_offsets(self):
+        """Compact buffers still track absolute remote offsets for gaps."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        ftp.read_to_memory = True
+        ftp.requested_offset = 100
+        ftp.requested_size = 4
+        ftp.burst_size = 2
+        ftp.op_start = 1
+        ftp.session = 7
+        ftp.pending_burst_request = FTP_OP(
+            seq=1,
+            session=7,
+            opcode=OP_BurstReadFile,
+            size=2,
+            req_opcode=0,
+            burst_complete=0,
+            offset=100,
+            payload=None,
+        )
+
+        first = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=2,
+                session=7,
+                opcode=OP_Ack,
+                size=2,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=0,
+                offset=102,
+                payload=bytearray(b"cd"),
+            ),
+            None,
+        )
+        self.assertEqual(first.error_code, FtpError.Success)
+        self.assertEqual(ftp.read_gaps, [(100, 2)])
+
+        second = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=3,
+                session=7,
+                opcode=OP_Ack,
+                size=2,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=1,
+                offset=100,
+                payload=bytearray(b"ab"),
+            ),
+            None,
+        )
+        self.assertEqual(second.error_code, FtpError.Success)
+        self.assertEqual(ftp.get_result, b"abcd")
+
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -20,6 +20,7 @@ from pymavlink import mavutil
 from pymavlink.mavftp import (
     BURST_REPLY_SEQUENCE_WINDOW,
     FTP_OP,
+    MAX_READ_GAPS,
     MAVFTP,
     FtpError,
     MAVFTPReturn,
@@ -1028,6 +1029,71 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             FtpError.Success,
         )
 
+    def test_burst_reply_rejects_unbounded_gap_allocation(self):
+        """A far-ahead burst reply must not allocate unbounded read gaps."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.burst_size = 239
+        setattr(ftp, "_MAVFTP__terminate_session", lambda: None)
+        far_offset = (MAX_READ_GAPS + 1) * ftp.burst_size
+
+        result = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=1,
+                session=0,
+                opcode=OP_Ack,
+                size=1,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=0,
+                offset=far_offset,
+                payload=bytearray(b"x"),
+            ),
+            None,
+        )
+
+        self.assertEqual(result.error_code, FtpError.InvalidDataSize)
+        self.assertEqual(ftp.read_gaps, [])
+
+    def test_burst_reply_rejects_cumulative_gap_allocation(self):
+        """Successive far-ahead replies must respect the total gap bound."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.burst_size = 239
+        setattr(ftp, "_MAVFTP__terminate_session", lambda: None)
+        first_offset = MAX_READ_GAPS * ftp.burst_size
+
+        first_result = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=1,
+                session=0,
+                opcode=OP_Ack,
+                size=1,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=0,
+                offset=first_offset,
+                payload=bytearray(b"x"),
+            ),
+            None,
+        )
+        second_result = ftp._MAVFTP__handle_burst_read(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=2,
+                session=0,
+                opcode=OP_Ack,
+                size=1,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=0,
+                offset=first_offset + 1 + (MAX_READ_GAPS * ftp.burst_size),
+                payload=bytearray(b"x"),
+            ),
+            None,
+        )
+
+        self.assertEqual(first_result.error_code, FtpError.Success)
+        self.assertEqual(second_result.error_code, FtpError.InvalidDataSize)
+        self.assertEqual(len(ftp.read_gaps), MAX_READ_GAPS)
     def test_stalled_burst_retries_from_current_read_position(self):
         """A stalled burst retains its sequence but resumes at the next byte."""
         ftp, master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -18,6 +18,7 @@ from io import BytesIO, StringIO
 from unittest.mock import patch
 from pymavlink import mavutil
 from pymavlink.mavftp import (
+    BURST_REPLY_SEQUENCE_WINDOW,
     FTP_OP,
     MAVFTP,
     FtpError,
@@ -837,6 +838,46 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(ftp.read_gaps, [])
         self.assertEqual(ftp.get_result, b"a" * 80 + b"b" * 80 + b"c" * 80)
+
+    def test_long_burst_advances_its_trailing_sequence_floor(self):
+        """A burst longer than half the uint16 sequence space remains accepted."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 32770
+        ftp.burst_size = 1
+        ftp.op_start = 1
+        ftp._MAVFTP__send(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=ftp.seq,
+                session=0,
+                opcode=OP_BurstReadFile,
+                size=1,
+                req_opcode=0,
+                burst_complete=0,
+                offset=0,
+                payload=None,
+            )
+        )
+
+        for sequence in range(2, 32771):
+            result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(
+                    sequence,
+                    OP_Ack,
+                    OP_BurstReadFile,
+                    payload=b"x",
+                    offset=sequence - 2,
+                )
+            )
+            self.assertEqual(result.error_code, FtpError.Success)
+
+        self.assertEqual(ftp.fh.getvalue(), b"x" * 32769)
+        self.assertLessEqual(
+            (32770 - ftp.pending_burst_seq) & 0xFFFF,
+            BURST_REPLY_SEQUENCE_WINDOW,
+        )
 
     def test_retry_straggler_does_not_block_restarted_burst(self):
         """A high-sequence straggler cannot advance the restarted burst floor."""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -913,6 +913,37 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.read_gaps, [])
         self.assertEqual(ftp.get_result, b"a" * 40 + b"b" * 40)
 
+    def test_stalled_burst_retries_from_current_read_position(self):
+        """A stalled burst retains its sequence but resumes at the next byte."""
+        ftp, master = self.make_ftp([])
+        ftp.fh = BytesIO(b"x" * 120)
+        ftp.fh.seek(80)
+        ftp.filename = "-"
+        ftp.last_burst_read = 10
+        ftp.pending_burst_seq = 501
+        ftp.pending_burst_request = FTP_OP(
+            seq=17,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=40,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+        next_request_sequence = ftp.seq
+
+        with patch("pymavlink.mavftp.time.time", return_value=11):
+            ftp._MAVFTP__idle_task()
+
+        request = master.mav.sent[-1][-1]
+        self.assertEqual(request[3], OP_BurstReadFile)
+        self.assertEqual(struct.unpack_from("<H", request)[0], 17)
+        self.assertEqual(struct.unpack_from("<I", request, 8)[0], 80)
+        self.assertEqual(ftp.pending_burst_offset, 80)
+        self.assertEqual(ftp.pending_burst_seq, 18)
+        self.assertEqual(ftp.seq, next_request_sequence)
+
     def test_out_of_order_gap_reply_is_dispatched(self):
         ftp, _master = self.make_ftp([])
         ftp.fh = BytesIO()

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -1034,7 +1034,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(ftp.write_acks, 0)
 
     def test_empty_put_reports_complete_progress(self):
-        """An empty upload completes without a progress division by zero."""
+        """An empty upload completes from CreateFile without a WriteFile ACK."""
         ftp, master = self.make_ftp([])
         progress = []
 
@@ -1049,6 +1049,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(result.error_code, FtpError.Success)
         self.assertEqual(progress, [1.0])
+        self.assertEqual(ftp.write_total, 0)
         self.assertEqual(self.sent_request_sequences(master, OP_WriteFile), [])
 
     def test_noncurrent_write_nack_fails_upload(self):

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -879,8 +879,8 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             BURST_REPLY_SEQUENCE_WINDOW,
         )
 
-    def test_retry_straggler_does_not_block_restarted_burst(self):
-        """A high-sequence straggler cannot advance the restarted burst floor."""
+    def test_retry_straggler_is_repairable_until_expected_reply(self):
+        """A retry writes stragglers without letting them change its floor."""
         ftp, _master = self.make_ftp([])
         ftp.fh = BytesIO()
         ftp.filename = "-"
@@ -888,9 +888,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         ftp.requested_size = 80
         ftp.burst_size = 40
         ftp.op_start = 1
-        ftp.pending_burst_offset = 0
-        ftp.pending_burst_seq = 2
-        ftp.pending_burst_request = FTP_OP(
+        request = FTP_OP(
             seq=1,
             session=0,
             opcode=OP_BurstReadFile,
@@ -900,18 +898,135 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             offset=0,
             payload=None,
         )
+        ftp._MAVFTP__send(request)  # pylint: disable=protected-access
+        ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
 
         straggler = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
-            ftp_reply(42, OP_Ack, OP_BurstReadFile, payload=b"b" * 40, offset=40)
+            ftp_reply(5000, OP_Ack, OP_BurstReadFile, payload=b"b" * 40, offset=40)
         )
-        restarted = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+        self.assertEqual(straggler.error_code, FtpError.Success)
+        self.assertTrue(ftp.pending_burst_retry)
+        self.assertEqual(ftp.pending_burst_seq, 2)
+        self.assertEqual(ftp.seq, 2)
+        self.assertEqual(ftp.read_gaps, [(0, 40)])
+        first_restarted = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
             ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"a" * 40, offset=0)
         )
 
-        self.assertEqual(straggler.error_code, FtpError.Success)
-        self.assertEqual(restarted.error_code, FtpError.Success)
+        self.assertEqual(first_restarted.error_code, FtpError.Success)
+        self.assertFalse(ftp.pending_burst_retry)
         self.assertEqual(ftp.read_gaps, [])
         self.assertEqual(ftp.get_result, b"a" * 40 + b"b" * 40)
+
+    def test_retry_first_reply_loss_leaves_a_repairable_gap(self):
+        """Later restarted packets remain usable if the first reply is lost."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 120
+        ftp.burst_size = 40
+        ftp.op_start = 1
+        request = FTP_OP(
+            seq=1,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=40,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+        ftp._MAVFTP__send(request)  # pylint: disable=protected-access
+        ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
+
+        for seq, offset, payload in (
+            (3, 40, b"b" * 40),
+            (4, 80, b"c" * 40),
+        ):
+            result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(seq, OP_Ack, OP_BurstReadFile, payload=payload, offset=offset)
+            )
+            self.assertEqual(result.error_code, FtpError.Success)
+
+        self.assertTrue(ftp.pending_burst_retry)
+        self.assertEqual(ftp.pending_burst_seq, 2)
+        self.assertEqual(ftp.read_gaps, [(0, 40)])
+        self.assertEqual(ftp.fh.getvalue(), b"\0" * 40 + b"b" * 40 + b"c" * 40)
+
+    def test_retry_with_lost_first_reply_advances_long_stream_floor(self):
+        """A lost retry reply cannot make a stream fail after 32767 packets."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 32770
+        ftp.burst_size = 1
+        ftp.op_start = 1
+        request = FTP_OP(1, 0, OP_BurstReadFile, 1, 0, 0, 0, None)
+        ftp._MAVFTP__send(request)  # pylint: disable=protected-access
+        ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
+
+        for sequence in range(3, 32772):
+            result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(
+                    sequence,
+                    OP_Ack,
+                    OP_BurstReadFile,
+                    payload=b"x",
+                    offset=sequence - 2,
+                )
+            )
+            self.assertEqual(result.error_code, FtpError.Success)
+
+        self.assertLessEqual(
+            (32771 - ftp.pending_burst_seq) & 0xFFFF,
+            BURST_REPLY_SEQUENCE_WINDOW,
+        )
+
+    def test_retry_stragglers_do_not_poison_floor_after_first_reply(self):
+        """A restarted burst retains its next expected reply after stragglers."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 120
+        ftp.burst_size = 40
+        ftp.op_start = 1
+        request = FTP_OP(
+            seq=1,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=40,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+        ftp._MAVFTP__send(request)  # pylint: disable=protected-access
+        ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
+
+        self.assertEqual(
+            ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"a" * 40, offset=0)
+            ).error_code,
+            FtpError.Success,
+        )
+        for seq, offset in ((5000, 80), (5001, 120)):
+            self.assertEqual(
+                ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                    ftp_reply(seq, OP_Ack, OP_BurstReadFile, payload=b"x" * 40, offset=offset)
+                ).error_code,
+                FtpError.Success,
+            )
+
+        self.assertEqual(ftp.pending_burst_seq, 2)
+        self.assertEqual(
+            ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(3, OP_Ack, OP_BurstReadFile, payload=b"b" * 40, offset=40)
+            ).error_code,
+            FtpError.Success,
+        )
 
     def test_stalled_burst_retries_from_current_read_position(self):
         """A stalled burst retains its sequence but resumes at the next byte."""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -801,8 +801,10 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         ftp.read_to_memory = True
         ftp.requested_size = 240
         ftp.read_total = 160
+        ftp.op_start = 1
+        ftp.reached_eof = True
         ftp.read_gaps = [(80, 80)]
-        ftp.read_gap_times = {(80, 80): 0}
+        ftp.read_gap_times = {(80, 80): 123}
         ftp.pending_burst_offset = 240
         ftp.pending_burst_seq = 2
         ftp.pending_burst_request = FTP_OP(1, 0, OP_BurstReadFile, 80, 0, 0, 240, None)
@@ -813,7 +815,12 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(result.error_code, FtpError.Fail)
         self.assertEqual(ftp.fh.getvalue(), b"a" * 80 + b"\0" * 80 + b"b" * 80)
+        self.assertEqual(ftp.fh.tell(), 240)
         self.assertEqual(ftp.read_gaps, [(80, 80)])
+        self.assertEqual(ftp.read_gap_times, {(80, 80): 123})
+        self.assertEqual(ftp.read_total, 160)
+        self.assertEqual(ftp.duplicates, 0)
+        self.assertFalse(ftp.read_complete)
 
     def test_burst_reply_requires_pending_offset(self):
         """Burst packets are ignored until a request establishes its offset."""

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -81,6 +81,56 @@ class FakeMaster:  # pylint: disable=too-few-public-methods
         return None
 
 
+class AllocatingSessionReplayMaster(FakeMaster):  # pylint: disable=too-few-public-methods
+    """Server model that reuses session 0 and replays a prior burst packet."""
+
+    def __init__(self):
+        super().__init__([])
+        self.sent_index = 0
+        self.download_count = 0
+        self.stale_reply = None
+
+    def recv_match(self, **kwargs):
+        while self.sent_index < len(self.mav.sent):
+            payload = self.mav.sent[self.sent_index][-1]
+            self.sent_index += 1
+            (seq, session, opcode, size, _req_opcode, _burst_complete, _pad, offset) = (
+                struct.unpack("<HBBBBBBI", payload[:12])
+            )
+            request = FTP_OP(
+                seq, session, opcode, size, 0, 0, offset, bytearray(payload[12 : 12 + size])
+            )
+            reply_seq = (request.seq + 1) % 65536
+            if request.opcode == OP_ResetSessions:
+                self.replies.append(ftp_reply(reply_seq, OP_Ack, OP_ResetSessions))
+            elif request.opcode == OP_OpenFileRO:
+                self.download_count += 1
+                self.replies.append(
+                    ftp_reply(reply_seq, OP_Ack, OP_OpenFileRO, payload=[63, 1, 0, 0])
+                )
+            elif request.opcode == OP_BurstReadFile:
+                data = b"A" if self.download_count == 1 else b"B"
+                replies = [
+                    ftp_reply(reply_seq + index, OP_Ack, OP_BurstReadFile,
+                              payload=data * size, offset=index * size,
+                              burst_complete=index == 3)
+                    for index in range(3)
+                ]
+                replies.append(
+                    ftp_reply(reply_seq + 3, OP_Ack, OP_BurstReadFile,
+                              payload=data * (size - 1), offset=3 * size,
+                              burst_complete=1)
+                )
+                if self.download_count == 1:
+                    self.stale_reply = replies[-1]
+                else:
+                    self.replies.append(self.stale_reply)
+                self.replies.extend(replies)
+            elif request.opcode == OP_TerminateSession:
+                self.replies.append(ftp_reply(reply_seq, OP_Ack, OP_TerminateSession))
+        return super().recv_match(**kwargs)
+
+
 def ftp_reply(  # pylint: disable=too-many-arguments
     seq, opcode, req_opcode, payload=None, offset=0, burst_complete=0, session=0
 ):
@@ -154,6 +204,23 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(ftp.session, 42)
         self.assertEqual(master.mav.sent[-1][-1][2], 42)
+
+    def test_allocated_session_discards_replayed_prior_download_burst_reply(self):
+        """A reused allocated session cannot let old data into the next read."""
+        master = AllocatingSessionReplayMaster()
+        ftp = MAVFTP(master, target_system=1, target_component=1)
+        ftp.ftp_settings.idle_detection_time = 0.02
+        ftp.ftp_settings.read_retry_time = 0.01
+        ftp.ftp_settings.retry_time = 0.2
+
+        for expected in (b"A" * 319, b"B" * 319):
+            ftp.cmd_get(
+                ["remote", "-"],
+                callback=lambda _fh: MAVFTPReturn("Get", FtpError.Success),
+            )
+            result = ftp.process_ftp_reply("get", timeout=1)
+            self.assertEqual(result.error_code, FtpError.Success)
+            self.assertEqual(ftp.get_result, expected)
 
     def test_cmd_get_clears_range_read_state(self):
         """A normal download must not inherit a prior range-read offset."""
@@ -650,8 +717,8 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
                     payload=b"x" * 80,
                     burst_complete=1,
                 ),
-                ftp_reply(4, OP_Ack, OP_BurstReadFile, payload=b"y", offset=80, burst_complete=1),
-                ftp_reply(5, OP_Ack, OP_TerminateSession),
+                ftp_reply(5, OP_Ack, OP_BurstReadFile, payload=b"y", offset=80, burst_complete=1),
+                ftp_reply(6, OP_Ack, OP_TerminateSession),
             ]
         )
 
@@ -663,6 +730,139 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertEqual(result.error_code, FtpError.Success)
         self.assertEqual(ftp.duplicates, 0)
+
+    def test_stale_burst_reply_sequence_is_discarded_for_reused_session(self):
+        """A delayed burst packet must not match a new request in session 0."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.pending_burst_offset = 0
+        ftp.pending_burst_seq = 11
+        ftp.pending_burst_request = FTP_OP(
+            seq=10,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=80,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(
+                10,
+                OP_Ack,
+                OP_BurstReadFile,
+                payload=b"stale",
+                offset=0,
+                session=0,
+            )
+        )
+
+        self.assertEqual(result.error_code, FtpError.Fail)
+        self.assertEqual(ftp.fh.getvalue(), b"")
+
+    def test_burst_reply_before_pending_offset_is_discarded(self):
+        """A delayed reply for an earlier burst must not write into this one."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_offset = 80
+        ftp.pending_burst_offset = 80
+        ftp.pending_burst_seq = 2
+        ftp.pending_burst_request = FTP_OP(1, 0, OP_BurstReadFile, 40, 0, 0, 80, None)
+
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"stale", offset=0)
+        )
+
+        self.assertEqual(result.error_code, FtpError.Fail)
+        self.assertEqual(ftp.fh.getvalue(), b"")
+
+    def test_burst_reply_requires_pending_offset(self):
+        """Burst packets are ignored until a request establishes its offset."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.pending_burst_seq = 2
+
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"stale", offset=0)
+        )
+
+        self.assertEqual(result.error_code, FtpError.Fail)
+        self.assertEqual(ftp.fh.getvalue(), b"")
+
+    def test_out_of_order_replies_in_one_burst_fill_the_gap(self):
+        """Burst reply sequencing is a floor, not a per-reply ratchet."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 240
+        ftp.burst_size = 80
+        ftp.op_start = 1
+        ftp.pending_burst_offset = 0
+        ftp.pending_burst_seq = 2
+        ftp.pending_burst_request = FTP_OP(
+            seq=1,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=80,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+
+        for seq, offset, payload in (
+            (2, 0, b"a" * 80),
+            (4, 160, b"c" * 80),
+            (3, 80, b"b" * 80),
+        ):
+            result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(seq, OP_Ack, OP_BurstReadFile, payload=payload, offset=offset)
+            )
+            self.assertEqual(result.error_code, FtpError.Success)
+
+        self.assertEqual(ftp.read_gaps, [])
+        self.assertEqual(ftp.get_result, b"a" * 80 + b"b" * 80 + b"c" * 80)
+
+    def test_retry_straggler_does_not_block_restarted_burst(self):
+        """A high-sequence straggler cannot advance the restarted burst floor."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 80
+        ftp.burst_size = 40
+        ftp.op_start = 1
+        ftp.pending_burst_offset = 0
+        ftp.pending_burst_seq = 2
+        ftp.pending_burst_request = FTP_OP(
+            seq=1,
+            session=0,
+            opcode=OP_BurstReadFile,
+            size=40,
+            req_opcode=0,
+            burst_complete=0,
+            offset=0,
+            payload=None,
+        )
+
+        straggler = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(42, OP_Ack, OP_BurstReadFile, payload=b"b" * 40, offset=40)
+        )
+        restarted = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"a" * 40, offset=0)
+        )
+
+        self.assertEqual(straggler.error_code, FtpError.Success)
+        self.assertEqual(restarted.error_code, FtpError.Success)
+        self.assertEqual(ftp.read_gaps, [])
+        self.assertEqual(ftp.get_result, b"a" * 40 + b"b" * 40)
 
     def test_out_of_order_gap_reply_is_dispatched(self):
         ftp, _master = self.make_ftp([])

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -470,6 +470,43 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
 
         self.assertFalse(ftp._MAVFTP__check_read_finished())
 
+    def test_read_sector_memory_uses_range_relative_offset(self):
+        """A range read buffer must scale with the range, not remote offset."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "remote"
+        ftp.read_to_memory = True
+        ftp.requested_offset = 1024 * 1024
+
+        ftp._MAVFTP__write_payload(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=1,
+                session=0,
+                opcode=OP_Ack,
+                size=2,
+                req_opcode=OP_BurstReadFile,
+                burst_complete=0,
+                offset=ftp.requested_offset,
+                payload=bytearray(b"xy"),
+            )
+        )
+
+        self.assertEqual(ftp.fh.getvalue(), b"xy")
+
+    def test_full_download_result_ignores_estimated_remote_size(self):
+        """A full download publishes bytes received past the advertised size."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO(b"x" * 200)
+        ftp.filename = "-"
+        ftp.requested_size = 80
+        ftp.read_total = 200
+        ftp.reached_eof = True
+        ftp.op_start = 1
+        setattr(ftp, "_MAVFTP__terminate_session", lambda: None)
+
+        self.assertTrue(ftp._MAVFTP__check_read_finished())
+        self.assertEqual(ftp.get_result, b"x" * 200)
+
     def test_put_returns_after_completion_before_late_write_reply(self):
         ftp, master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -899,6 +899,43 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
             BURST_REPLY_SEQUENCE_WINDOW,
         )
 
+    def test_burst_accepts_replies_across_uint16_sequence_wrap(self):
+        """A burst remains accepted when reply sequence numbers wrap."""
+        ftp, _master = self.make_ftp([])
+        ftp.fh = BytesIO()
+        ftp.filename = "-"
+        ftp.read_to_memory = True
+        ftp.requested_size = 21
+        ftp.burst_size = 1
+        ftp.op_start = 1
+        ftp.seq = 65530
+        ftp._MAVFTP__send(  # pylint: disable=protected-access
+            FTP_OP(
+                seq=ftp.seq,
+                session=0,
+                opcode=OP_BurstReadFile,
+                size=1,
+                req_opcode=0,
+                burst_complete=0,
+                offset=0,
+                payload=None,
+            )
+        )
+
+        for offset in range(20):
+            result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+                ftp_reply(
+                    (65531 + offset) & 0xFFFF,
+                    OP_Ack,
+                    OP_BurstReadFile,
+                    payload=b"x",
+                    offset=offset,
+                )
+            )
+            self.assertEqual(result.error_code, FtpError.Success)
+
+        self.assertEqual(ftp.fh.getvalue(), b"x" * 20)
+
     def test_retry_straggler_is_repairable_until_expected_reply(self):
         """A retry writes stragglers without letting them change its floor."""
         ftp, _master = self.make_ftp([])
@@ -932,7 +969,6 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         first_restarted = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
             ftp_reply(2, OP_Ack, OP_BurstReadFile, payload=b"a" * 40, offset=0)
         )
-
         self.assertEqual(first_restarted.error_code, FtpError.Success)
         self.assertFalse(ftp.pending_burst_retry)
         self.assertEqual(ftp.read_gaps, [])
@@ -947,23 +983,11 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         ftp.requested_size = 120
         ftp.burst_size = 40
         ftp.op_start = 1
-        request = FTP_OP(
-            seq=1,
-            session=0,
-            opcode=OP_BurstReadFile,
-            size=40,
-            req_opcode=0,
-            burst_complete=0,
-            offset=0,
-            payload=None,
-        )
+        request = FTP_OP(1, 0, OP_BurstReadFile, 40, 0, 0, 0, None)
         ftp._MAVFTP__send(request)  # pylint: disable=protected-access
         ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
 
-        for seq, offset, payload in (
-            (3, 40, b"b" * 40),
-            (4, 80, b"c" * 40),
-        ):
+        for seq, offset, payload in ((3, 40, b"b" * 40), (4, 80, b"c" * 40)):
             result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
                 ftp_reply(seq, OP_Ack, OP_BurstReadFile, payload=payload, offset=offset)
             )
@@ -1013,16 +1037,7 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         ftp.requested_size = 120
         ftp.burst_size = 40
         ftp.op_start = 1
-        request = FTP_OP(
-            seq=1,
-            session=0,
-            opcode=OP_BurstReadFile,
-            size=40,
-            req_opcode=0,
-            burst_complete=0,
-            offset=0,
-            payload=None,
-        )
+        request = FTP_OP(1, 0, OP_BurstReadFile, 40, 0, 0, 0, None)
         ftp._MAVFTP__send(request)  # pylint: disable=protected-access
         ftp._MAVFTP__send(request, retry=True)  # pylint: disable=protected-access
 

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -673,6 +673,25 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertEqual(result.error_code, FtpError.Success)
         self.assertEqual(len(master.replies), 1)
 
+    def test_put_rejects_non_ascii_remote_name_before_claiming_file(self):
+        """A rejected remote name must not leave upload state in progress."""
+        ftp, master = self.make_ftp([])
+        master.mav.sent.clear()
+
+        with tempfile.NamedTemporaryFile() as local_file:
+            result = ftp.cmd_put(
+                [local_file.name, "r\N{LATIN SMALL LETTER E WITH ACUTE}mote"]
+            )
+
+        self.assertEqual(result.error_code, FtpError.InvalidArguments)
+        self.assertIsNone(ftp.write_list)
+        self.assertIsNone(ftp.fh)
+        self.assertEqual(master.mav.sent, [])
+
+        retry_result = ftp.cmd_put(["local", "remote"], fh=BytesIO(b"payload"))
+
+        self.assertEqual(retry_result.error_code, FtpError.Success)
+
     def test_list_returns_after_eof_before_late_error(self):
         ftp, master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -1002,6 +1002,24 @@ class TestMAVFTPReplyCompletion(unittest.TestCase):  # pylint: disable=too-many-
         self.assertIsNotNone(ftp.write_list)
         self.assertEqual(ftp.write_acks, 0)
 
+    def test_empty_put_reports_complete_progress(self):
+        """An empty upload completes without a progress division by zero."""
+        ftp, master = self.make_ftp([])
+        progress = []
+
+        ftp.cmd_put(
+            ["local", "remote"],
+            fh=BytesIO(),
+            progress_callback=progress.append,
+        )
+        result = ftp._MAVFTP__mavlink_packet(  # pylint: disable=protected-access
+            ftp_reply(2, OP_Ack, OP_CreateFile)
+        )
+
+        self.assertEqual(result.error_code, FtpError.Success)
+        self.assertEqual(progress, [1.0])
+        self.assertEqual(self.sent_request_sequences(master, OP_WriteFile), [])
+
     def test_noncurrent_write_nack_fails_upload(self):
         ftp, _master = self.make_ftp(
             [

--- a/tests/test_mavftp.py
+++ b/tests/test_mavftp.py
@@ -969,21 +969,24 @@ class TestMAVFTPParamDecode(unittest.TestCase):
             self.assertIsNone(MAVFTP.ftp_param_decode(header + first + second))
         self.assertIn("parameter name is too long", logs.output[0])
 
-    def test_save_params_writes_integer_datatype_comments(self):
-        """Decoded integer type IDs produce the documented datatype comment."""
+    def test_save_params_accepts_integer_and_string_datatype_ids(self):
+        """Both public save_params datatype representations produce valid comments."""
         with tempfile.TemporaryDirectory() as tempdir:
-            output = f"{tempdir}/params.txt"
+            for datatype in (4, "4"):
+                with self.subTest(datatype=datatype):
+                    output = f"{tempdir}/params-{datatype}.txt"
+                    MAVFTP.save_params(
+                        {"TEST_PARAM": (1.0, datatype)},
+                        output,
+                        "missionplanner",
+                        add_datatype_comments=True,
+                        add_timestamp_comment=False,
+                    )
 
-            MAVFTP.save_params(
-                {"TEST_PARAM": (1.0, 4)},
-                output,
-                "missionplanner",
-                add_datatype_comments=True,
-                add_timestamp_comment=False,
-            )
-
-            with open(output, encoding="utf-8") as param_file:
-                self.assertEqual(param_file.read(), "TEST_PARAM,1  # 32-bit float\n")
+                    with open(output, encoding="utf-8") as param_file:
+                        self.assertEqual(
+                            param_file.read(), "TEST_PARAM,1  # 32-bit float\n"
+                        )
 
 
 class TestMAVFTPPayloadDecoding(unittest.TestCase):

--- a/tools/test_mavftp_hardware.py
+++ b/tools/test_mavftp_hardware.py
@@ -10,6 +10,12 @@ best-effort failure cleanup). Run it only against hardware whose filesystem
 may be modified. The default Pixhawk USB port is ``/dev/ttyACM0``; pass a
 different device, baud rate, or component ID on the command line as needed.
 
+Known hardware limitation: some flight-controller firmware leaves the FTP
+session handshake incomplete after synchronous range reads. In that case the
+range checks pass, but the subsequent MAVFTP reinitialization can block before
+rename/delete; reboot the controller and remove the uniquely named test file
+if cleanup did not complete.
+
 SPDX-FileCopyrightText: 2026 Amilcar Lucas
 
 SPDX-License-Identifier: GPL-3.0-or-later
@@ -55,6 +61,15 @@ def run(device: str, baud: int, component: int) -> None:  # pylint: disable=too-
         print(f"list: {listing.error_code.name}", flush=True)
         if listing.error_code != FtpError.Success:
             raise RuntimeError(f"directory listing failed: {listing.error_code.name}")
+        directory = f"/APM/mavftp_hwtest_{int(time.time())}"
+        result = ftp.cmd_mkdir([directory])
+        print(f"mkdir: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"mkdir failed: {result.error_code.name}")
+        result = ftp.cmd_rmdir([directory])
+        print(f"rmdir: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"rmdir failed: {result.error_code.name}")
 
         # Remove leftovers from an interrupted prior run; FileNotFound is fine.
         for path in (remote, renamed):
@@ -90,6 +105,32 @@ def run(device: str, baud: int, component: int) -> None:  # pylint: disable=too-
         if data != payload:
             raise RuntimeError("downloaded data does not match uploaded data")
 
+        small_range = ftp.read_sector(remote, 0, 2)
+        print(f"small full-burst range: {len(small_range) if small_range is not None else 'none'} bytes", flush=True)
+        if small_range != payload[:2]:
+            raise RuntimeError("small full-burst range did not match uploaded data")
+        high_offset = len(payload) - 2
+        tail_range = ftp.read_sector(remote, high_offset, 2)
+        print(
+            f"high-offset range: {len(tail_range) if tail_range is not None else 'none'} "
+            f"bytes at {high_offset}",
+            flush=True,
+        )
+        if tail_range != payload[high_offset:]:
+            raise RuntimeError("high-offset range did not match uploaded data")
+
+        # Reopen after synchronous reads so late termination replies cannot
+        # interfere with the following rename and delete operations. Some FC
+        # firmware does not complete this handshake; see the module note.
+        master.close()
+        time.sleep(0.5)
+        master = mavutil.mavlink_connection(
+            device, baud=baud, source_system=250, autoreconnect=False
+        )
+        if master.wait_heartbeat(timeout=10) is None:
+            raise RuntimeError("no MAVLink heartbeat after range reads")
+        ftp = MAVFTP(master, target_system=master.target_system, target_component=component)
+
         result = ftp.cmd_rename([remote, renamed])
         print(f"rename: {result.error_code.name}", flush=True)
         if result.error_code != FtpError.Success:
@@ -99,16 +140,6 @@ def run(device: str, baud: int, component: int) -> None:  # pylint: disable=too-
         if result.error_code != FtpError.Success:
             raise RuntimeError(f"delete failed: {result.error_code.name}")
 
-        directory = f"/APM/mavftp_hwtest_{int(time.time())}"
-        result = ftp.cmd_mkdir([directory])
-        print(f"mkdir: {result.error_code.name}", flush=True)
-        if result.error_code != FtpError.Success:
-            raise RuntimeError(f"mkdir failed: {result.error_code.name}")
-        result = ftp.cmd_rmdir([directory])
-        print(f"rmdir: {result.error_code.name}", flush=True)
-        if result.error_code != FtpError.Success:
-            raise RuntimeError(f"rmdir failed: {result.error_code.name}")
-
         with tempfile.TemporaryDirectory(prefix="mavftp_params_") as temp_dir:
             values = f"{temp_dir}/values.txt"
             result = ftp.cmd_getparams([values])
@@ -116,6 +147,7 @@ def run(device: str, baud: int, component: int) -> None:  # pylint: disable=too-
             print(f"getparams: {result.error_code.name}", flush=True)
             if result.error_code != FtpError.Success:
                 raise RuntimeError(f"getparams failed: {result.error_code.name}")
+
         print("MAVFTP HARDWARE TEST PASSED", flush=True)
     finally:
         if ftp is not None:

--- a/tools/test_mavftp_hardware.py
+++ b/tools/test_mavftp_hardware.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+
+"""
+Exercise MAVFTP end-to-end against a connected flight controller.
+
+This destructive integration test uses a uniquely named temporary path on the
+vehicle. It covers the public MAVFTP commands, verifies an upload by download
+and CRC, and removes all temporary files and directories when complete (or on
+best-effort failure cleanup). Run it only against hardware whose filesystem
+may be modified. The default Pixhawk USB port is ``/dev/ttyACM0``; pass a
+different device, baud rate, or component ID on the command line as needed.
+
+SPDX-FileCopyrightText: 2026 Amilcar Lucas
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# FLAKE_CLEAN
+
+import argparse
+import hashlib
+import io
+import sys
+import tempfile
+import time
+import zlib
+
+from pymavlink import mavutil
+from pymavlink.mavftp import FtpError, MAVFTP
+
+
+def run(device: str, baud: int, component: int) -> None:  # pylint: disable=too-many-branches,too-many-locals,too-many-statements
+    payload = (b"pymavlink-mavftp-hardware-test\x00" * 8) + bytes(range(64))
+    remote = f"/APM/mavftp_hwtest_{int(time.time())}.bin"
+    renamed = remote + ".renamed"
+    master = mavutil.mavlink_connection(
+        device, baud=baud, source_system=250, autoreconnect=False
+    )
+    ftp = None
+    try:
+        if master.wait_heartbeat(timeout=10) is None:
+            raise RuntimeError("no MAVLink heartbeat received")
+        print(
+            f"heartbeat system={master.target_system} component={component}",
+            flush=True,
+        )
+        ftp = MAVFTP(master, target_system=master.target_system, target_component=component)
+        result = ftp.cmd_status()
+        print(f"status: {result.error_code.name}", flush=True)
+        result = ftp.cmd_set(["debug", "0"])
+        print(f"set debug: {result.error_code.name}", flush=True)
+        result = ftp.cmd_cancel()
+        print(f"cancel: {result.error_code.name}", flush=True)
+        listing = ftp.cmd_list(["/APM"])
+        print(f"list: {listing.error_code.name}", flush=True)
+        if listing.error_code != FtpError.Success:
+            raise RuntimeError(f"directory listing failed: {listing.error_code.name}")
+
+        # Remove leftovers from an interrupted prior run; FileNotFound is fine.
+        for path in (remote, renamed):
+            ftp.cmd_rm([path])
+
+        result = ftp.cmd_put(["-", remote], fh=io.BytesIO(payload))
+        result = ftp.process_ftp_reply("CreateFile", timeout=60)
+        print(f"upload: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"upload failed: {result.error_code.name}")
+
+        result = ftp.cmd_crc([remote])
+        expected_crc = zlib.crc32(payload) & 0xFFFFFFFF
+        print(f"crc: {result.error_code.name} (expected 0x{expected_crc:08x})", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"crc failed: {result.error_code.name}")
+
+        result = ftp.cmd_get([remote, "-"])
+        result = ftp.process_ftp_reply("Get", timeout=60)
+        print(f"get: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"get failed: {result.error_code.name}")
+
+        result = ftp.cmd_list(["/APM"])
+        names = {entry.name for entry in (result.directory_listing or [])}
+        print(f"list uploaded file: {result.error_code.name} ({remote.rsplit('/', 1)[-1] in names})", flush=True)
+        if result.error_code != FtpError.Success or remote.rsplit("/", 1)[-1] not in names:
+            raise RuntimeError("uploaded file was not listed")
+
+        data = ftp.read_sector(remote, 0, len(payload))
+        digest = hashlib.sha256(data).hexdigest() if data is not None else "n/a"
+        print(f"download: {len(data) if data is not None else 'none'} bytes sha256={digest}", flush=True)
+        if data != payload:
+            raise RuntimeError("downloaded data does not match uploaded data")
+
+        result = ftp.cmd_rename([remote, renamed])
+        print(f"rename: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"rename failed: {result.error_code.name}")
+        result = ftp.cmd_rm([renamed])
+        print(f"delete: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"delete failed: {result.error_code.name}")
+
+        directory = f"/APM/mavftp_hwtest_{int(time.time())}"
+        result = ftp.cmd_mkdir([directory])
+        print(f"mkdir: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"mkdir failed: {result.error_code.name}")
+        result = ftp.cmd_rmdir([directory])
+        print(f"rmdir: {result.error_code.name}", flush=True)
+        if result.error_code != FtpError.Success:
+            raise RuntimeError(f"rmdir failed: {result.error_code.name}")
+
+        with tempfile.TemporaryDirectory(prefix="mavftp_params_") as temp_dir:
+            values = f"{temp_dir}/values.txt"
+            result = ftp.cmd_getparams([values])
+            result = ftp.process_ftp_reply("GetParams", timeout=60)
+            print(f"getparams: {result.error_code.name}", flush=True)
+            if result.error_code != FtpError.Success:
+                raise RuntimeError(f"getparams failed: {result.error_code.name}")
+        print("MAVFTP HARDWARE TEST PASSED", flush=True)
+    finally:
+        if ftp is not None:
+            for path in (remote, renamed):
+                try:
+                    ftp.cmd_rm([path])
+                except Exception:  # pylint: disable=broad-exception-caught
+                    # best-effort cleanup only
+                    pass
+        master.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("device", nargs="?", default="/dev/ttyACM0")
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--component", type=int, default=1)
+    args = parser.parse_args()
+    try:
+        run(args.device, args.baud, args.component)
+    except Exception as error:  # pylint: disable=broad-exception-caught
+        print(f"MAVFTP HARDWARE TEST FAILED: {error}", file=sys.stderr, flush=True)
+        sys.exit(1)


### PR DESCRIPTION
I would like at some point to get rid of my mavftp.py fork in AMC.

So here are some fixes from that downstream port:

Improve MAVFTP reliability, validation, error handling, and regression coverage.

## Changes

- Harden FTP session and transfer lifecycle handling:
  - Adopt server-allocated sessions for downloads and uploads.
  - Correlate replies by sequence, session, and request type.
  - Reject stale, duplicate, out-of-order, and wrong-session replies.
  - Retry open, read, burst-read, and write requests using the correct sequence.
  - Resume stalled burst transfers from the current read position.
  - Handle partial bursts, unknown file sizes, EOF detection, and sequence rollover.
  - Terminate active sessions reliably after timeouts or callback failures.

- Improve input and packet validation:
  - Validate transfer settings and timeout relationships.
  - Reject invalid ranges, unsupported/non-ASCII paths, oversized payloads, malformed directory entries, and malformed parameter records.
  - Bound synchronous read buffers and burst gap allocation.
  - Preserve server-provided NACK and filesystem errors.

- Correct command and callback behavior:
  - Complete simple commands promptly.
  - Preserve requested ranges for synchronous reads.
  - Clean up upload/download handles and callbacks on success and failure.
  - Correct rename arguments and parameter output handling.
  - Support string parameter datatype identifiers and datatype comments.
  - Add ProfiCNC and Matek serial-port detection.

- Add extensive regression coverage for transfer retries, session allocation, stale replies, malformed packets, callbacks, cleanup, parameter decoding, range reads, and empty uploads.

- Add an opt-in end-to-end hardware MAVFTP utility covering upload, download, CRC, listing, rename, deletion, range reads, and parameter export.
