### PR TITLE
XSD: Attributes indicate allowed in mission, fence, rally, command

### DIFF
--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -200,6 +200,7 @@
 <xs:attribute name="hasLocation" type="xs:boolean" default="false"/>      <!-- lat/lon/alt location in params 5, 6, 7 (entry contains location information). -->
 <xs:attribute name="isDestination" type="xs:boolean" default="false"/>    <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
 <xs:attribute name="hasAltitudeOnly" type="xs:boolean" default="false"/>  <!-- alt in param7 and lat/lon not in param 5/6 -->
+<xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- planned for removal -->
 <xs:attribute name="mission" type="xs:boolean" default="false"/>          <!-- entry can be used in mission plan -->
 <xs:attribute name="fence" type="xs:boolean" default="false"/>            <!-- entry can be used in fence plan -->
 <xs:attribute name="rally" type="xs:boolean" default="false"/>            <!-- entry can be used in rally plan -->
@@ -294,6 +295,7 @@
         <xs:attribute ref="hasLocation"/>
         <xs:attribute ref="hasAltitudeOnly"/>
         <xs:attribute ref="isDestination"/> <!-- requires hasLocation -->
+        <xs:attribute ref="missionOnly"/>  <!-- planned for removal -->
         <xs:attribute ref="mission"/>
         <xs:attribute ref="fence"/>
         <xs:attribute ref="rally"/>

--- a/generator/mavschema.xsd
+++ b/generator/mavschema.xsd
@@ -197,10 +197,13 @@
 <xs:attribute name="reserved" type="xs:boolean" default="false"/>      <!-- parameter is reserved -->
 
 <!-- definition entry elements attributes (like the ones used on MAV_CMD for example) -->
-<xs:attribute name="hasLocation" type="xs:boolean" default="false"/> <!-- lat/lon/alt location in params 5, 6, 7 (entry contains location information). -->
-<xs:attribute name="isDestination" type="xs:boolean" default="false"/>  <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
+<xs:attribute name="hasLocation" type="xs:boolean" default="false"/>      <!-- lat/lon/alt location in params 5, 6, 7 (entry contains location information). -->
+<xs:attribute name="isDestination" type="xs:boolean" default="false"/>    <!-- entry is a waypoint/destination (lat/lon/alt in params 5, 6, 7) -->
 <xs:attribute name="hasAltitudeOnly" type="xs:boolean" default="false"/>  <!-- alt in param7 and lat/lon not in param 5/6 -->
-<xs:attribute name="missionOnly" type="xs:boolean" default="false"/>  <!-- entry only makes sense in missions, not commands -->
+<xs:attribute name="mission" type="xs:boolean" default="false"/>          <!-- entry can be used in mission plan -->
+<xs:attribute name="fence" type="xs:boolean" default="false"/>            <!-- entry can be used in fence plan -->
+<xs:attribute name="rally" type="xs:boolean" default="false"/>            <!-- entry can be used in rally plan -->
+<xs:attribute name="command" type="xs:boolean" default="false"/>          <!-- entry can be used in command protocol -->
 
 <!-- definition of complex elements -->
 <xs:element name="param">
@@ -288,10 +291,13 @@
         </xs:sequence>
         <xs:attribute ref="value" />
         <xs:attribute ref="name" use="required"/>
-        <xs:attribute ref="hasLocation"/> <!-- Mutually exclusive with hasAltitudeOnly (can't enforce in XSD1.0) -->
+        <xs:attribute ref="hasLocation"/>
         <xs:attribute ref="hasAltitudeOnly"/>
-        <xs:attribute ref="isDestination"/>
-        <xs:attribute ref="missionOnly"/>
+        <xs:attribute ref="isDestination"/> <!-- requires hasLocation -->
+        <xs:attribute ref="mission"/>
+        <xs:attribute ref="fence"/>
+        <xs:attribute ref="rally"/>
+        <xs:attribute ref="command"/>
     </xs:complexType>
 </xs:element>
 


### PR DESCRIPTION
More flexibly describe where MAV_CMD can be used - mission, fence, rally, commands.

Falls out of discussions https://github.com/mavlink/mavlink/pull/2005#issuecomment-5521509017