### PR TITLE
pymavlink: Add AUTO and HOLD to blimp modes

### DIFF
--- a/mavutil.py
+++ b/mavutil.py
@@ -2396,6 +2396,8 @@ mode_mapping_blimp = {
     2 : 'VELOCITY',
     3 : 'LOITER',
     4 : 'RTL',
+    5 : 'AUTO',
+    6 : 'HOLD',
 }
 
 AP_MAV_TYPE_MODE_MAP_DEFAULT = {


### PR DESCRIPTION
Add AUTO and HOLD to blimp mode mapping.