### PR TITLE
mavparm: honour use_tabs for params present in only one file

### DIFF
--- a/mavparm.py
+++ b/mavparm.py
@@ -193,11 +193,19 @@ class MAVParmDict(dict):
             if not k in other:
                 value = float(self[k])
                 if show_only2:
-                    print("%-16.16s              %12.4f%s" % (k, value, comment(info(k, "FILE2", value))))
+                    c = comment(info(k, "FILE2", value))
+                    if use_tabs:
+                        print("%s\t\t%.4f%s" % (k, value, c))
+                    else:
+                        print("%-16.16s              %12.4f%s" % (k, value, c))
             elif not k in self:
                 if show_only1:
                     value = float(other[k])
-                    print("%-16.16s %12.4f%s" % (k, value, comment(info(k, "FILE1", value))))
+                    c = comment(info(k, "FILE1", value))
+                    if use_tabs:
+                        print("%s\t%.4f%s" % (k, value, c))
+                    else:
+                        print("%-16.16s %12.4f%s" % (k, value, c))
             elif abs(self[k] - other[k]) > self.mindelta:
                 value = float(self[k])
                 c = comment(info(k, "FILE1", float(other[k])), info(k, "FILE2", value))

--- a/tests/test_mavparm.py
+++ b/tests/test_mavparm.py
@@ -5,6 +5,8 @@
 Unit tests for the mavparm library
 """
 
+import contextlib
+import io
 import unittest
 import os
 
@@ -54,6 +56,30 @@ class MAVParmDictTest(unittest.TestCase):
         self.parms.show()
         
         self.parms.diff('prms.txt')
-        
+
+    def test_diff_use_tabs(self):
+        """Test that use_tabs also applies to params present in only one file"""
+        other = mavparm.MAVParmDict()
+        other['AFS_ACTION'] = 42
+        other['PARAM1'] = 35.45
+        other['ONLY_IN_FILE1'] = 7
+        other.save('prms.txt')
+
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out):
+            self.parms.diff('prms.txt', use_tabs=True, header=True)
+        os.remove('prms.txt')
+
+        lines = [l for l in out.getvalue().splitlines() if not l.startswith('Loaded ')]
+        assert lines == [
+            "PARAMETER\tFILE1\tFILE2",
+            "ONLY_IN_FILE1\t7.0000",
+            "PARAM1\t35.4500\t34.4500",
+            "PARAM2\t\t0.0000",
+            "PARAM3\t\t-13.4000",
+        ]
+        for line in lines:
+            assert " " not in line
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What was wrong

`mavparmdiff.py -t` is documented as "use tabs delimiter between columns for the output", but only the header row and the rows for parameters that differ between the two files were tab-delimited. Parameters present in only one file were still printed with the fixed-width, space-padded format, so the output could not be imported into a spreadsheet (issue #796).

With two three-line parameter files (`cat -vt` shows tabs as `^I`):

```
$ mavparmdiff.py -t p1.parm p2.parm | cat -vt
PARAMETER^IFILE1^IFILE2
ADSB_ENABLE            0.0000
ADSB_TYPE                           0.0000
AHRS_TRIM_X^I-0.0135^I-0.0512
```

## Root cause

In `MAVParmDict.diff()` the `use_tabs` flag was only checked in the header branch and in the "value differs" branch. The "only in FILE1" and "only in FILE2" branches always used the `%-16.16s %12.4f` formats.

## The fix

When `use_tabs` is set, print `NAME\tVALUE` for params only in FILE1 and `NAME\t\tVALUE` for params only in FILE2, so the columns line up with the header and the differing-value rows. The space-padded output is unchanged.

```
$ mavparmdiff.py -t p1.parm p2.parm | cat -vt
PARAMETER^IFILE1^IFILE2
ADSB_ENABLE^I0.0000
ADSB_TYPE^I^I0.0000
AHRS_TRIM_X^I-0.0135^I-0.0512
```

## Verification

Added `test_diff_use_tabs` in `tests/test_mavparm.py`, which captures `diff(..., use_tabs=True, header=True)` output and checks every row is purely tab-delimited. It fails on master (`AssertionError` on the space-padded rows) and passes with this change.

```
python3 -m pytest tests/test_mavparm.py -q   # 4 passed
flake8 mavparm.py tests/test_mavparm.py --count --select=E9,F63,F7,F82   # 0
```

Tested with Python 3.12 on macOS.

Fixes #796

🤖 Generated with [Claude Code](https://claude.com/claude-code)
