### PR TITLE
mavlogdump: keep one-off and burst messages when using --reduce-rate

### DIFF
--- a/tests/test_mavlogdump.py
+++ b/tests/test_mavlogdump.py
@@ -11,7 +11,10 @@ try:
 except ImportError:
     # importlib.resources.files() requires Python 3.9+; use backport for older versions
     from importlib_resources import files as importlib_files
+import struct
 import sys
+
+from pymavlink import mavutil
 
 class MAVLogDumpTest(unittest.TestCase):
 
@@ -44,6 +47,45 @@ class MAVLogDumpTest(unittest.TestCase):
                 success = True
 
         assert True
+
+    def test_reduce_rate_keeps_oneoff_tlog_messages(self):
+        """--reduce-rate must not drop PARAM_VALUE/STATUSTEXT bursts or HEARTBEATs"""
+        in_filename = "tmp_reduce_in.tlog"
+        out_filename = "tmp_reduce_out.tlog"
+        mav = mavutil.mavlink.MAVLink(None, srcSystem=1, srcComponent=1)
+        t0 = 1700000000.0
+        with open(in_filename, 'wb') as f:
+            def emit(t, msg):
+                f.write(struct.pack('>Q', int(t * 1e6)) + msg.pack(mav))
+            # 2 seconds of ATTITUDE at 50Hz
+            for i in range(100):
+                emit(t0 + i * 0.02, mav.attitude_encode(i * 20, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0))
+            # bursts of PARAM_VALUE and STATUSTEXT, 5ms apart
+            for i in range(10):
+                emit(t0 + 1.0 + i * 0.005, mav.param_value_encode(("P%d" % i).encode(), float(i), 9, 10, i))
+            for i in range(5):
+                emit(t0 + 1.5 + i * 0.005, mav.statustext_encode(6, ("msg %d" % i).encode()))
+            # 1Hz heartbeats from an autopilot and a gimbal, 50ms apart
+            for i in range(2):
+                emit(t0 + i, mav.heartbeat_encode(2, 3, 0, 0, 4))
+                emit(t0 + i + 0.05, mav.heartbeat_encode(26, 8, 0, 0, 4))
+
+        os.system("mavlogdump.py --reduce-rate 10 --quiet --parms --output %s %s" % (out_filename, in_filename))
+
+        counts = {}
+        mlog = mavutil.mavlink_connection(out_filename)
+        while True:
+            m = mlog.recv_match()
+            if m is None:
+                break
+            counts[m.get_type()] = counts.get(m.get_type(), 0) + 1
+        os.remove(in_filename)
+        os.remove(out_filename)
+
+        assert counts.get('PARAM_VALUE', 0) == 10, counts
+        assert counts.get('STATUSTEXT', 0) == 5, counts
+        assert counts.get('HEARTBEAT', 0) == 4, counts
+        assert counts.get('ATTITUDE', 0) < 100, counts
 
 if __name__ == '__main__':
     unittest.main()

--- a/tools/mavlogdump.py
+++ b/tools/mavlogdump.py
@@ -131,7 +131,12 @@ last_msg_rate_t = {}
 def reduce_rate_msg(m, reduction_rate):
     '''return True if this msg should be discarded by reduction'''
     mtype = m.get_type()
-    if mtype in ['PARM','MSG','FMT','FMTU','MULT','MODE','EVT','UNIT', 'VER']:
+    # never drop messages that are sent once or in short bursts (e.g.
+    # parameters, missions, events) rather than at a steady rate, as
+    # rate reduction would discard most of a burst. HEARTBEAT is kept so
+    # that every source system/component remains visible in the output.
+    if mtype in ['PARM','MSG','FMT','FMTU','MULT','MODE','EV','ERR','CMD','UNIT','VER',
+                 'PARAM_VALUE','STATUSTEXT','HEARTBEAT','MISSION_ITEM_INT']:
         return False
     t = getattr(m,'_timestamp',None)
     if t is None:


### PR DESCRIPTION
## What was wrong

`mavlogdump.py --reduce-rate N` drops the parameter download from a tlog, even with `--parms` (issue #1033). On a synthetic tlog containing 100 ATTITUDE at 50 Hz, a burst of 10 PARAM_VALUE 5 ms apart, 5 STATUSTEXT 5 ms apart, and 1 Hz HEARTBEATs from two components 50 ms apart:

```
$ mavlogdump.py --reduce-rate 10 in.tlog --output out.tlog --quiet --parms
# message counts in out.tlog, master:
{'ATTITUDE': 17, 'HEARTBEAT': 1}
```

All 10 PARAM_VALUE and all 5 STATUSTEXT are gone, and one of the two heartbeat sources disappears entirely.

## Root cause

`reduce_rate_msg()` exempts a fixed list of message types from rate reduction, but the list only contains DataFlash names (`PARM`, `MSG`, `FMT`, ...). Their tlog equivalents (`PARAM_VALUE`, `STATUSTEXT`) are rate-limited like any streaming message, so a burst is reduced to at most its first element. The `--parms` handling further down the loop is never reached because the message has already been discarded. The list also has `EVT`, which is not a DataFlash message; the event message is `EV` (as the `--meta` list in the same file already uses).

## The fix

Extend the exempt list, following the discussion on the issue:

- `PARAM_VALUE`, `STATUSTEXT`: tlog equivalents of `PARM`, `MSG`; sent in bursts, not at a steady rate.
- `MISSION_ITEM_INT`, `CMD`: mission download, same reasoning.
- `HEARTBEAT`: sent at 1 Hz by every component; with two sources a few ms apart, rate limiting drops one source completely.
- `EVT` -> `EV`, plus `ERR` (one-off DataFlash messages, matching MAVExplorer's `cmd_messages`).

`AUTOPILOT_VERSION` was left out as agreed on the issue (sent once, so unaffected by rate limiting in practice).

After the change, on the same input:

```
{'ATTITUDE': 17, 'PARAM_VALUE': 10, 'STATUSTEXT': 5, 'HEARTBEAT': 4}
```

## Verification

Added `test_reduce_rate_keeps_oneoff_tlog_messages` in `tests/test_mavlogdump.py`. It writes the synthetic tlog described above, runs `mavlogdump.py --reduce-rate 10 --quiet --parms --output`, reads the output back with `mavutil.mavlink_connection`, and asserts all PARAM_VALUE, STATUSTEXT and HEARTBEAT messages survive while ATTITUDE is reduced. It fails on master (`assert 0 == 10` for PARAM_VALUE) and passes with this change.

```
python3 -m pip install .
python3 -m pytest tests/test_mavlogdump.py -q   # 2 passed
flake8 tools/mavlogdump.py tests/test_mavlogdump.py --count --select=E9,F63,F7,F82   # 0
```

Tested with Python 3.12 on macOS.

Fixes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)
