### PR TITLE
mavgen_cpp11: fix IndexError when an enum entry is a prefix of the enum name

### DIFF
--- a/generator/mavgen_cpp11.py
+++ b/generator/mavgen_cpp11.py
@@ -301,7 +301,10 @@ def enum_remove_prefix(prefix, s):
     sl = s.split('_')
 
     for i in range(len(pl)):
-        if pl[i] == sl[0]:
+        # keep at least one component, so that an entry whose name is a
+        # prefix of the enum name (e.g. SOME_ENUM in SOME_ENUM_NAME) does
+        # not end up with an empty name
+        if len(sl) > 1 and pl[i] == sl[0]:
             sl = sl[1:]
         else:
             break

--- a/tests/test_mavgen_cpp11.py
+++ b/tests/test_mavgen_cpp11.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""
+Tests for the C++11 generator.
+"""
+
+from pathlib import Path
+import shutil
+import sys
+
+try:
+    from pymavlink.generator import mavgen
+    from pymavlink.generator import mavgen_cpp11
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from generator import mavgen
+    from generator import mavgen_cpp11
+
+
+def test_enum_remove_prefix():
+    assert mavgen_cpp11.enum_remove_prefix("MAV_CMD", "MAV_CMD_NAV_WAYPOINT") == "NAV_WAYPOINT"
+    assert mavgen_cpp11.enum_remove_prefix("MAV_FRAME", "MAV_FRAME_GLOBAL") == "GLOBAL"
+    # a remainder starting with a digit gets the last prefix component back
+    assert mavgen_cpp11.enum_remove_prefix("MAV_SYS_STATUS_SENSOR", "MAV_SYS_STATUS_SENSOR_3D_GYRO") == "SENSOR_3D_GYRO"
+    # an entry whose name is a prefix of the enum name must keep its last component
+    assert mavgen_cpp11.enum_remove_prefix("SOME_ENUM_NAME", "SOME_ENUM") == "ENUM"
+    assert mavgen_cpp11.enum_remove_prefix("SOME_ENUM_NAME", "SOME_ENUM_NAME") == "NAME"
+    assert mavgen_cpp11.enum_remove_prefix("SOME_ENUM_NAME", "SOME") == "SOME"
+
+
+def test_cpp11_generator_enum_entry_is_prefix_of_enum_name(tmp_path):
+    xml_filepath = tmp_path / "test.xml"
+    xml_filepath.write_text("""<?xml version="1.0"?>
+<mavlink>
+  <version>3</version>
+  <enums>
+    <enum name="SOME_ENUM_NAME">
+      <entry value="0" name="SOME_ENUM"/>
+      <entry value="1" name="SOME_ENUM_NAME_VALUE"/>
+    </enum>
+  </enums>
+  <messages>
+  </messages>
+</mavlink>
+""")
+    output_dir = Path(__file__).resolve().parents[1] / ".tmp" / "cpp11-generator"
+    shutil.rmtree(output_dir, ignore_errors=True)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    ok = mavgen.mavgen(
+        mavgen.Opts(
+            output=str(output_dir),
+            language="C++11",
+            wire_protocol="2.0",
+            validate=False,
+        ),
+        [str(xml_filepath)],
+    )
+
+    assert ok is True
+
+    header = (output_dir / "test" / "test.hpp").read_text(encoding="utf-8")
+    assert "enum class SOME_ENUM_NAME" in header
+    assert "    ENUM=0," in header
+    assert "    VALUE=1," in header


### PR DESCRIPTION
## What was wrong

`mavgen.py --lang=C++11` crashes when an enum contains an entry whose name is a prefix of the enum name (issue #887):

```xml
<enum name="SOME_ENUM_NAME">
  <entry value="0" name="SOME_ENUM"/>
</enum>
```

```
$ mavgen.py --lang=C++11 --wire-protocol=2.0 -o out test.xml
...
  File ".../pymavlink/generator/mavgen_cpp11.py", line 304, in enum_remove_prefix
    if pl[i] == sl[0]:
IndexError: list index out of range
```

The C generator handles the same file fine; only the C++11 output is affected.

## Root cause

`enum_remove_prefix()` builds the scoped `enum class` entry names by popping one leading component of the entry name for each matching component of the enum name. It never checks that at least one component is left, so for `SOME_ENUM` in `SOME_ENUM_NAME` the list runs empty after two pops and the third comparison indexes into an empty list. (Even if the loop ended there, the following `sl[0][0].isdigit()` would fail the same way.)

## The fix

Stop stripping once a single component remains, so the entry keeps its last component: `SOME_ENUM` becomes `SOME_ENUM_NAME::ENUM`. This is the guard @shancock884 suggested on the issue.

It only changes behaviour for inputs that previously crashed: an entry that used to strip down to exactly one component takes the same path as before. To confirm, I regenerated C++11 headers for `message_definitions/v1.0/all.xml` before and after the change; all 389 `.hpp` files are byte-identical (`diff -r`).

## Verification

New `tests/test_mavgen_cpp11.py`:

- `test_enum_remove_prefix`: existing cases (`MAV_CMD_NAV_WAYPOINT` -> `NAV_WAYPOINT`, the digit case `MAV_SYS_STATUS_SENSOR_3D_GYRO` -> `SENSOR_3D_GYRO`) plus the prefix cases from the issue.
- `test_cpp11_generator_enum_entry_is_prefix_of_enum_name`: runs `mavgen.mavgen(..., language="C++11")` on a temp XML with the enum above and checks the generated `test.hpp` contains `enum class SOME_ENUM_NAME` with `ENUM=0` and `VALUE=1`.

Both fail on master with the `IndexError` above and pass with this change.

```
python3 -m pytest tests/test_mavgen_cpp11.py tests/test_mavgen_typescript.py -q   # 3 passed
flake8 generator/mavgen_cpp11.py tests/test_mavgen_cpp11.py --count --select=E9,F63,F7,F82   # 0
```

Tested with Python 3.12 on macOS.

Fixes #887

🤖 Generated with [Claude Code](https://claude.com/claude-code)
