### PR TITLE
generator: parse isDestination and require hasLocation with it

### DIFF
--- a/generator/mavparse.py
+++ b/generator/mavparse.py
@@ -170,7 +170,7 @@ class MAVEnumParam(object):
             self.description = description
 
 class MAVEnumEntry(object):
-    def __init__(self, name, value, description='', wip=False, end_marker=False, autovalue=False, origin_file='', origin_line=0, has_location=False):
+    def __init__(self, name, value, description='', wip=False, end_marker=False, autovalue=False, origin_file='', origin_line=0, has_location=False, is_destination=False):
         self.name = name
         self.value = value
         self.deprecated = None
@@ -182,6 +182,7 @@ class MAVEnumEntry(object):
         self.origin_file = origin_file
         self.origin_line = origin_line
         self.has_location = has_location
+        self.is_destination = is_destination
 
 class MAVEnum(object):
     def __init__(self, name, linenumber, description='', bitmask=False):
@@ -243,6 +244,18 @@ class MAVXML(object):
                     raise MAVParseError('expected missing %s "%s" attribute at %s:%u' % (
                         where, c, filename, p.CurrentLineNumber))
 
+        def bool_attr(attrs, name):
+            '''return an optional boolean attribute; absent means False'''
+            value = attrs.get(name, False)
+            if value == 'true':
+                value = True
+            elif value == 'false':
+                value = False
+            if type(value) != bool:
+                raise MAVParseError('invalid %s value "%s" at %s:%u' % (
+                    name, value, filename, p.CurrentLineNumber))
+            return value
+
         def start_element(name, attrs):
             in_element_list.append(name)
             in_element = '.'.join(in_element_list)
@@ -293,13 +306,13 @@ class MAVXML(object):
                 # check highest value
                 if (value > self.enum[-1].highest_value):
                     self.enum[-1].highest_value = value
-                has_location = attrs.get('hasLocation', False)
-                if has_location == 'true':
-                    has_location = True
-                elif has_location == 'false':
-                    has_location = False
-                if type(has_location) != bool:
-                    raise MAVParseError("invalid has_location value %s" % has_location)
+                has_location = bool_attr(attrs, 'hasLocation')
+                is_destination = bool_attr(attrs, 'isDestination')
+                if is_destination and not has_location:
+                    # a destination is somewhere the vehicle goes to, so
+                    # it must have a location
+                    raise MAVParseError('%s is isDestination but not hasLocation at %s:%u' % (
+                        attrs['name'], filename, p.CurrentLineNumber))
 
                 # check bitmask value
                 if self.enum[-1].bitmask:
@@ -309,7 +322,7 @@ class MAVXML(object):
                         print(f"{attrs['name']} has invalid values (bitmask must have powers of 2)")
 
                 # append the new entry
-                self.enum[-1].entry.append(MAVEnumEntry(attrs['name'], value, '', False, False, autovalue, self.filename, p.CurrentLineNumber, has_location=has_location))
+                self.enum[-1].entry.append(MAVEnumEntry(attrs['name'], value, '', False, False, autovalue, self.filename, p.CurrentLineNumber, has_location=has_location, is_destination=is_destination))
             elif in_element == "mavlink.enums.enum.entry.wip":
                 self.enum[-1].entry[-1].wip = True
             elif in_element == "mavlink.enums.enum.entry.param":

--- a/tests/isdestination-without-haslocation.xml
+++ b/tests/isdestination-without-haslocation.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<mavlink>
+  <enums>
+    <enum name="MAV_CMD">
+      <description>An isDestination entry which is not hasLocation should raise an exception.</description>
+      <entry value="1" name="MAV_CMD_TEST" hasLocation="false" isDestination="true">
+        <description>Test command.</description>
+        <param index="1">Param 1.</param>
+        <param index="2">Param 2.</param>
+        <param index="3">Param 3.</param>
+        <param index="4">Param 4.</param>
+        <param index="5">Param 5.</param>
+        <param index="6">Param 6.</param>
+        <param index="7">Param 7.</param>
+      </entry>
+    </enum>
+  </enums>
+</mavlink>

--- a/tests/snapshottests/resources/common.xml
+++ b/tests/snapshottests/resources/common.xml
@@ -1181,7 +1181,7 @@
         <param index="6" label="Longitude">Longitude</param>
         <param index="7" label="Altitude" units="m">Altitude</param>
       </entry>
-      <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT" hasLocation="false" isDestination="true">
+      <entry value="30" name="MAV_CMD_NAV_CONTINUE_AND_CHANGE_ALT" hasAltitudeOnly="true">
         <description>Continue on the current course and climb/descend to specified altitude.  When the altitude is reached continue to the next command (i.e., don't proceed to the next command until the desired altitude is reached.</description>
         <param index="1" label="Action" minValue="0" maxValue="2" increment="1">Climb or Descend (0 = Neutral, command completes when within 5m of this command's altitude, 1 = Climbing, command completes when at or above this command's altitude, 2 = Descending, command completes when at or below this command's altitude.</param>
         <param index="2">Empty</param>
@@ -1336,7 +1336,7 @@
         <param index="6">Empty</param>
         <param index="7">Empty</param>
       </entry>
-      <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT" hasLocation="false" isDestination="true">
+      <entry value="113" name="MAV_CMD_CONDITION_CHANGE_ALT" hasAltitudeOnly="true">
         <description>Ascend/descend to target altitude at specified rate. Delay mission state machine until desired altitude reached.</description>
         <param index="1" label="Rate" units="m/s">Descent / Ascend rate.</param>
         <param index="2">Empty</param>

--- a/tests/test_mavxml.py
+++ b/tests/test_mavxml.py
@@ -32,6 +32,13 @@ class MAVXMLTest(unittest.TestCase):
             _ = MAVXML(test_filepath)
 
 
+    def test_isdestination_requires_haslocation(self):
+        """Test that an enum entry which is isDestination must also be hasLocation"""
+        test_filename = "isdestination-without-haslocation.xml"
+        test_filepath = importlib_files(__spec__.parent).joinpath(test_filename)
+        with self.assertRaises(MAVParseError):
+            _ = MAVXML(test_filepath)
+
     def test_wire_protocol_version(self):
         """Test that an unknown MAVLink wire protocol version raises an exception"""
         with self.assertRaises(MAVParseError):


### PR DESCRIPTION
A destination is somewhere the vehicle goes to, so any enum entry marked isDestination="true" must also be hasLocation="true". mavlink/mavlink#2582 solidifies this in common.xml.

Parse isDestination alongside hasLocation, store it on MAVEnumEntry and raise MAVParseError when the invariant does not hold.  The snapshot test copy of common.xml had two entries which violated it; update them to match upstream, which now marks them hasAltitudeOnly="true".